### PR TITLE
Introduces base class for plugins to simplify export

### DIFF
--- a/force_bdss/base_extension_plugin.py
+++ b/force_bdss/base_extension_plugin.py
@@ -1,0 +1,25 @@
+from envisage.plugin import Plugin
+from traits.trait_types import List
+
+from force_bdss.data_sources.i_data_source_bundle import IDataSourceBundle
+from force_bdss.kpi.i_kpi_calculator_bundle import IKPICalculatorBundle
+from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
+    IMultiCriteriaOptimizerBundle
+
+
+class BaseExtensionPlugin(Plugin):
+    mco_bundles = List(
+        IMultiCriteriaOptimizerBundle,
+        contributes_to='force.bdss.mco.bundles'
+    )
+
+    #: A list of the available Data Sources.
+    #: It will be populated by plugins.
+    data_source_bundles = List(
+        IDataSourceBundle,
+        contributes_to='force.bdss.data_sources.bundles')
+
+    kpi_calculator_bundles = List(
+        IKPICalculatorBundle,
+        contributes_to='force.bdss.kpi_calculators.bundles'
+    )

--- a/force_bdss/base_extension_plugin.py
+++ b/force_bdss/base_extension_plugin.py
@@ -8,17 +8,33 @@ from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
 
 
 class BaseExtensionPlugin(Plugin):
+    """Base class for extension plugins, that is, plugins that are
+    provided by external contributors.
+
+    It provides a set of slots to be populated that end up contributing
+    to the application extension points. To use the class, simply inherit it
+    in your plugin, and then define the trait default initializer for the
+    specific trait you want to populate. For example::
+
+        class MyPlugin(BaseExtensionPlugin):
+            def _data_source_bundles(self):
+                return [MyDataSourceBundle1(),
+                        MyDataSourceBundle2()]
+    """
+
+    #: A list of available Multi Criteria Optimizers this plugin exports.
     mco_bundles = List(
         IMultiCriteriaOptimizerBundle,
         contributes_to='force.bdss.mco.bundles'
     )
 
-    #: A list of the available Data Sources.
-    #: It will be populated by plugins.
+    #: A list of the available Data Sources this plugin exports.
     data_source_bundles = List(
         IDataSourceBundle,
-        contributes_to='force.bdss.data_sources.bundles')
+        contributes_to='force.bdss.data_sources.bundles'
+    )
 
+    #: A list of the available KPI calculators this plugin exports.
     kpi_calculator_bundles = List(
         IKPICalculatorBundle,
         contributes_to='force.bdss.kpi_calculators.bundles'

--- a/force_bdss/core_plugins/csv_extractor/csv_extractor_plugin.py
+++ b/force_bdss/core_plugins/csv_extractor/csv_extractor_plugin.py
@@ -1,16 +1,8 @@
-from envisage.plugin import Plugin
-from traits.api import List
-
-from force_bdss.data_sources.i_data_source_bundle import IDataSourceBundle
+from force_bdss.base_extension_plugin import BaseExtensionPlugin
 
 from .csv_extractor.csv_extractor_bundle import CSVExtractorBundle
 
 
-class CSVExtractorPlugin(Plugin):
-    data_sources = List(
-        IDataSourceBundle,
-        contributes_to='force.bdss.data_sources.bundles'
-    )
-
-    def _data_sources_default(self):
+class CSVExtractorPlugin(BaseExtensionPlugin):
+    def _data_source_bundles_default(self):
         return [CSVExtractorBundle()]

--- a/force_bdss/core_plugins/test_kpi/test_kpi_calculator_plugin.py
+++ b/force_bdss/core_plugins/test_kpi/test_kpi_calculator_plugin.py
@@ -1,17 +1,8 @@
-from envisage.plugin import Plugin
-from traits.api import List
-
-from force_bdss.kpi.i_kpi_calculator_bundle import (
-    IKPICalculatorBundle)
+from force_bdss.base_extension_plugin import BaseExtensionPlugin
 
 from .kpi_adder.kpi_adder_bundle import KPIAdderBundle
 
 
-class TestKPICalculatorPlugin(Plugin):
-    kpi_calculators = List(
-        IKPICalculatorBundle,
-        contributes_to='force.bdss.kpi_calculators.bundles'
-    )
-
-    def _kpi_calculators_default(self):
+class TestKPICalculatorPlugin(BaseExtensionPlugin):
+    def _kpi_calculator_bundles_default(self):
         return [KPIAdderBundle()]

--- a/force_bdss/core_plugins/test_mco/multi_criteria_optimizers_plugin.py
+++ b/force_bdss/core_plugins/test_mco/multi_criteria_optimizers_plugin.py
@@ -1,17 +1,8 @@
-from envisage.plugin import Plugin
-from traits.api import List
-
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import (
-    IMultiCriteriaOptimizerBundle)
+from force_bdss.base_extension_plugin import BaseExtensionPlugin
 
 from .dakota.dakota_bundle import DakotaBundle
 
 
-class MultiCriteriaOptimizersPlugin(Plugin):
-    multi_criteria_optimizers = List(
-        IMultiCriteriaOptimizerBundle,
-        contributes_to='force.bdss.mco.bundles'
-    )
-
-    def _multi_criteria_optimizers_default(self):
+class MultiCriteriaOptimizersPlugin(BaseExtensionPlugin):
+    def _mco_bundles_default(self):
         return [DakotaBundle()]

--- a/force_bdss/tests/test_bundle_registry_plugin.py
+++ b/force_bdss/tests/test_bundle_registry_plugin.py
@@ -1,5 +1,7 @@
 import unittest
 
+from force_bdss.base_extension_plugin import (
+    BaseExtensionPlugin)
 from force_bdss.id_generators import bundle_id
 
 try:
@@ -7,9 +9,7 @@ try:
 except ImportError:
     from unittest import mock
 
-from traits.api import List
 from envisage.application import Application
-from envisage.plugin import Plugin
 
 from force_bdss.bundle_registry_plugin import BundleRegistryPlugin
 from force_bdss.data_sources.i_data_source_bundle import IDataSourceBundle
@@ -31,25 +31,7 @@ class TestBundleRegistry(unittest.TestCase):
         self.assertEqual(self.plugin.kpi_calculator_bundles, [])
 
 
-class BaseBDSSPlugin(Plugin):
-    mco_bundles = List(
-        IMultiCriteriaOptimizerBundle,
-        contributes_to='force.bdss.mco.bundles'
-    )
-
-    #: A list of the available Data Sources.
-    #: It will be populated by plugins.
-    data_source_bundles = List(
-        IDataSourceBundle,
-        contributes_to='force.bdss.data_sources.bundles')
-
-    kpi_calculator_bundles = List(
-        IKPICalculatorBundle,
-        contributes_to='force.bdss.kpi_calculators.bundles'
-    )
-
-
-class MySuperPlugin(BaseBDSSPlugin):
+class MySuperPlugin(BaseExtensionPlugin):
     def _mco_bundles_default(self):
         return [mock.Mock(spec=IMultiCriteriaOptimizerBundle,
                           id=bundle_id("enthought", "mco1"))]


### PR DESCRIPTION
Introduced a base class BaseExtensionPlugin. This class provides the base class for all plugins that are externally provided, and allows the user to just define the default methods to return their own bundles, instead of having to deal with the extension point ids.
