### PR TITLE
Removed name property from base evaluator classes

### DIFF
--- a/force_bdss/data_sources/base_data_source.py
+++ b/force_bdss/data_sources/base_data_source.py
@@ -25,12 +25,6 @@ class BaseDataSource(ABCHasStrictTraits):
         self.model = model
         super(BaseDataSource, self).__init__(*args, **kwargs)
 
-    @property
-    def name(self):
-        """Utility property to retrieve the bundle name from the data source
-        object."""
-        return self.bundle.name
-
     @abc.abstractmethod
     def run(self, parameters):
         """Executes the data source evaluation/fetching and returns

--- a/force_bdss/kpi/base_kpi_calculator.py
+++ b/force_bdss/kpi/base_kpi_calculator.py
@@ -25,11 +25,6 @@ class BaseKPICalculator(ABCHasStrictTraits):
         self.model = model
         super(BaseKPICalculator, self).__init__(*args, **kwargs)
 
-    @property
-    def name(self):
-        """Convenience property. Returns the name of the originating bundle."""
-        return self.bundle.name
-
     @abc.abstractmethod
     def run(self, data_source_results):
         """

--- a/force_bdss/mco/base_multi_criteria_optimizer.py
+++ b/force_bdss/mco/base_multi_criteria_optimizer.py
@@ -25,12 +25,6 @@ class BaseMultiCriteriaOptimizer(ABCHasStrictTraits):
         self.model = model
         super(BaseMultiCriteriaOptimizer, self).__init__(*args, **kwargs)
 
-    @property
-    def name(self):
-        """Convenience property to return the name of the bundle from the
-        MCO itself"""
-        return self.bundle.name
-
     @abc.abstractmethod
     def run(self):
         """Reimplement this method to perform the MCO operations."""


### PR DESCRIPTION
Removes the name() property as it is a residue of simpler times.
