### PR TITLE
Introduced logging in case of plugin load error

### DIFF
--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -37,8 +37,6 @@ class BDSSApplication(Application):
         else:
             plugins.append(CoreMCODriver())
 
-
-
         mgr = ExtensionManager(
             namespace='force.bdss.extensions',
             invoke_on_load=True,

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -40,7 +40,8 @@ class BDSSApplication(Application):
         mgr = ExtensionManager(
             namespace='force.bdss.extensions',
             invoke_on_load=True,
-            on_load_failure_callback=functools.partial(_load_failure_callback)
+            on_load_failure_callback=functools.partial(_load_failure_callback,
+                                                       plugins)
         )
 
         try:

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -52,12 +52,17 @@ class BDSSApplication(Application):
 
 
 def _import_extensions(plugins, ext):
+    """Service routine extracted for testing.
+    Imports the extension in the plugins argument.
+    """
     logging.info("Found extension {}".format(ext.obj))
     plugins.append(ext.obj)
 
 
 def _load_failure_callback(plugins, manager, entry_point, exception):
-    """Reports failure to load a module through stevedore.
+    """Service routine extracted for testing.
+    Reports failure to load a module through stevedore, using the
+    on_load_failure_callback option.
     """
     logging.error(
         "Unable to load plugin {}. Exception: {}. Message: {}".format(

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -1,4 +1,7 @@
-from stevedore import extension
+import functools
+import logging
+
+from stevedore.extension import ExtensionManager
 from stevedore.exception import NoMatches
 
 from envisage.api import Application
@@ -34,18 +37,31 @@ class BDSSApplication(Application):
         else:
             plugins.append(CoreMCODriver())
 
-        mgr = extension.ExtensionManager(
+
+
+        mgr = ExtensionManager(
             namespace='force.bdss.extensions',
-            invoke_on_load=True
+            invoke_on_load=True,
+            on_load_failure_callback=functools.partial(_load_failure_callback)
         )
 
-        def import_extensions(ext):
-            print("Found extension {}".format(ext.name))
-            plugins.append(ext.obj)
-
         try:
-            mgr.map(import_extensions)
+            mgr.map(functools.partial(_import_extensions, plugins))
         except NoMatches:
-            print("No extensions found")
+            logging.info("No extensions found")
 
         super(BDSSApplication, self).__init__(plugins=plugins)
+
+
+def _import_extensions(plugins, ext):
+    logging.info("Found extension {}".format(ext.obj))
+    plugins.append(ext.obj)
+
+
+def _load_failure_callback(plugins, manager, entry_point, exception):
+    """Reports failure to load a module through stevedore.
+    """
+    logging.error(
+        "Unable to load plugin {}. Exception: {}. Message: {}".format(
+            entry_point, exception.__class__.__name__, exception)
+    )

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -41,4 +41,3 @@ class TestBDSSApplication(unittest.TestCase):
         _import_extensions(plugins, ext)
 
         self.assertEqual(plugins[0], plugin)
-

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -1,0 +1,34 @@
+import unittest
+import testfixtures
+
+from force_bdss.bdss_application import (
+    BDSSApplication,
+    _load_failure_callback,
+    _import_extensions
+)
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestBDSSApplication(unittest.TestCase):
+    def test_initialization(self):
+        app = BDSSApplication(False, "foo/bar")
+        self.assertFalse(app.evaluate)
+        self.assertEqual(app.workflow_filepath, "foo/bar")
+
+    def test_extension_load_failure(self):
+        plugins = []
+        with testfixtures.LogCapture() as log:
+            _load_failure_callback(plugins,
+                                   mock.Mock(),
+                                   "foo",
+                                   Exception("hello"))
+
+        log.check(
+            ('root', 'ERROR', "Unable to load plugin foo. Exception: "
+                              "Exception. Message: hello")
+        )
+        self.assertEqual(plugins, [])

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -32,3 +32,13 @@ class TestBDSSApplication(unittest.TestCase):
                               "Exception. Message: hello")
         )
         self.assertEqual(plugins, [])
+
+    def test_import_extension(self):
+        plugins = []
+        plugin = mock.Mock()
+        ext = mock.Mock()
+        ext.obj = plugin
+        _import_extensions(plugins, ext)
+
+        self.assertEqual(plugins[0], plugin)
+

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -1,3 +1,4 @@
 flake8
 coverage
 mock
+testfixtures


### PR DESCRIPTION
Small PR that introduces basic logging in case of error at loading. Unfortunately it's not possible to retrieve the traceback, but the exception message and the exception should be a good hint.
