### PR TITLE
Renamed MCO classes to consistency

### DIFF
--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -16,6 +16,6 @@ from .kpi.i_kpi_calculator_bundle import IKPICalculatorBundle  # noqa
 
 from .mco.base_mco_model import BaseMCOModel  # noqa
 from .mco.base_mco_communicator import BaseMCOCommunicator  # noqa
-from .mco.base_multi_criteria_optimizer import BaseMultiCriteriaOptimizer  # noqa
-from .mco.base_multi_criteria_optimizer_bundle import BaseMultiCriteriaOptimizerBundle  # noqa
-from .mco.i_multi_criteria_optimizer_bundle import IMultiCriteriaOptimizerBundle  # noqa
+from .mco.base_mco import BaseMCO  # noqa
+from .mco.base_mco_bundle import BaseMCOBundle  # noqa
+from .mco.i_mco_bundle import IMCOBundle  # noqa

--- a/force_bdss/base_extension_plugin.py
+++ b/force_bdss/base_extension_plugin.py
@@ -4,8 +4,7 @@ from traits.trait_types import List
 from .ids import ExtensionPointID
 from .data_sources.i_data_source_bundle import IDataSourceBundle
 from .kpi.i_kpi_calculator_bundle import IKPICalculatorBundle
-from .mco.i_multi_criteria_optimizer_bundle import \
-    IMultiCriteriaOptimizerBundle
+from .mco.i_mco_bundle import IMCOBundle
 
 
 class BaseExtensionPlugin(Plugin):
@@ -25,7 +24,7 @@ class BaseExtensionPlugin(Plugin):
 
     #: A list of available Multi Criteria Optimizers this plugin exports.
     mco_bundles = List(
-        IMultiCriteriaOptimizerBundle,
+        IMCOBundle,
         contributes_to=ExtensionPointID.MCO_BUNDLES
     )
 

--- a/force_bdss/bundle_registry_plugin.py
+++ b/force_bdss/bundle_registry_plugin.py
@@ -6,8 +6,8 @@ from force_bdss.ids import ExtensionPointID
 from .data_sources.i_data_source_bundle import (
     IDataSourceBundle)
 from .kpi.i_kpi_calculator_bundle import IKPICalculatorBundle
-from .mco.i_multi_criteria_optimizer_bundle import (
-    IMultiCriteriaOptimizerBundle
+from .mco.i_mco_bundle import (
+    IMCOBundle
 )
 
 
@@ -28,7 +28,7 @@ class BundleRegistryPlugin(Plugin):
     #: A List of the available Multi Criteria Optimizers.
     #: This will be populated by MCO plugins.
     mco_bundles = ExtensionPoint(
-        List(IMultiCriteriaOptimizerBundle),
+        List(IMCOBundle),
         id=ExtensionPointID.MCO_BUNDLES)
 
     #: A list of the available Data Sources.

--- a/force_bdss/core_evaluation_driver.py
+++ b/force_bdss/core_evaluation_driver.py
@@ -23,7 +23,7 @@ class CoreEvaluationDriver(BaseCoreDriver):
             print(str(e), file=sys.stderr)
             sys.exit(1)
 
-        mco_model = workflow.multi_criteria_optimizer
+        mco_model = workflow.mco
         mco_bundle = mco_model.bundle
         mco_communicator = mco_bundle.create_communicator(
             self.application,

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -24,7 +24,7 @@ class CoreMCODriver(BaseCoreDriver):
             print(str(e), file=sys.stderr)
             sys.exit(1)
 
-        mco_model = workflow.multi_criteria_optimizer
+        mco_model = workflow.mco
         mco_bundle = mco_model.bundle
         mco = mco_bundle.create_optimizer(self.application, mco_model)
         mco.run()

--- a/force_bdss/core_plugins/dummy/dummy_dakota/dakota_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/dakota_bundle.py
@@ -1,12 +1,12 @@
 from traits.api import String
-from force_bdss.api import bundle_id, BaseMultiCriteriaOptimizerBundle
+from force_bdss.api import bundle_id, BaseMCOBundle
 
 from .dakota_communicator import DummyDakotaCommunicator
 from .dakota_model import DummyDakotaModel
 from .dakota_optimizer import DummyDakotaOptimizer
 
 
-class DummyDakotaBundle(BaseMultiCriteriaOptimizerBundle):
+class DummyDakotaBundle(BaseMCOBundle):
     id = String(bundle_id("enthought", "dummy_dakota"))
 
     name = "Dummy Dakota"

--- a/force_bdss/core_plugins/dummy/dummy_dakota/dakota_optimizer.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/dakota_optimizer.py
@@ -3,7 +3,7 @@ import sys
 import itertools
 import collections
 
-from force_bdss.api import BaseMultiCriteriaOptimizer
+from force_bdss.api import BaseMCO
 
 
 def rotated_range(start, stop, starting_value):
@@ -14,7 +14,7 @@ def rotated_range(start, stop, starting_value):
     return list(d)
 
 
-class DummyDakotaOptimizer(BaseMultiCriteriaOptimizer):
+class DummyDakotaOptimizer(BaseMCO):
     def run(self):
         parameters = self.model.parameters
 

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -18,15 +18,15 @@ except ImportError:
 from force_bdss.ids import bundle_id, mco_parameter_id
 from force_bdss.io.workflow_writer import WorkflowWriter
 from force_bdss.mco.base_mco_model import BaseMCOModel
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
-    IMultiCriteriaOptimizerBundle
+from force_bdss.mco.i_mco_bundle import \
+    IMCOBundle
 from force_bdss.workspecs.workflow import Workflow
 
 
 class TestWorkflowWriter(unittest.TestCase):
     def setUp(self):
         self.mock_registry = mock.Mock(spec=BundleRegistryPlugin)
-        mock_mco_bundle = mock.Mock(spec=IMultiCriteriaOptimizerBundle,
+        mock_mco_bundle = mock.Mock(spec=IMCOBundle,
                                     id=bundle_id("enthought", "mock"))
         mock_mco_model = mock.Mock(
             spec=BaseMCOModel,
@@ -69,7 +69,7 @@ class TestWorkflowWriter(unittest.TestCase):
         wf = Workflow()
         wf.multi_criteria_optimizer = BaseMCOModel(
             mock.Mock(
-                spec=IMultiCriteriaOptimizerBundle,
+                spec=IMCOBundle,
                 id=bundle_id("enthought", "mock")))
         wf.multi_criteria_optimizer.parameters = [
             BaseMCOParameter(

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -18,8 +18,7 @@ except ImportError:
 from force_bdss.ids import bundle_id, mco_parameter_id
 from force_bdss.io.workflow_writer import WorkflowWriter
 from force_bdss.mco.base_mco_model import BaseMCOModel
-from force_bdss.mco.i_mco_bundle import \
-    IMCOBundle
+from force_bdss.mco.i_mco_bundle import IMCOBundle
 from force_bdss.workspecs.workflow import Workflow
 
 
@@ -49,7 +48,7 @@ class TestWorkflowWriter(unittest.TestCase):
         result = json.loads(fp.getvalue())
         self.assertIn("version", result)
         self.assertIn("workflow", result)
-        self.assertIn("multi_criteria_optimizer", result["workflow"])
+        self.assertIn("mco", result["workflow"])
         self.assertIn("data_sources", result["workflow"])
         self.assertIn("kpi_calculators", result["workflow"])
 
@@ -62,16 +61,16 @@ class TestWorkflowWriter(unittest.TestCase):
         wfreader = WorkflowReader(self.mock_registry,
                                   self.mock_mco_parameter_registry)
         wf_result = wfreader.read(fp)
-        self.assertEqual(wf_result.multi_criteria_optimizer.bundle.id,
-                         wf.multi_criteria_optimizer.bundle.id)
+        self.assertEqual(wf_result.mco.bundle.id,
+                         wf.mco.bundle.id)
 
     def _create_mock_workflow(self):
         wf = Workflow()
-        wf.multi_criteria_optimizer = BaseMCOModel(
+        wf.mco = BaseMCOModel(
             mock.Mock(
                 spec=IMCOBundle,
                 id=bundle_id("enthought", "mock")))
-        wf.multi_criteria_optimizer.parameters = [
+        wf.mco.parameters = [
             BaseMCOParameter(
                 factory=mock.Mock(
                     spec=BaseMCOParameterFactory,

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -93,7 +93,7 @@ class WorkflowReader(HasStrictTraits):
 
         try:
             wf_data = json_data["workflow"]
-            wf.multi_criteria_optimizer = self._extract_mco(wf_data)
+            wf.mco = self._extract_mco(wf_data)
             wf.data_sources[:] = self._extract_data_sources(wf_data)
             wf.kpi_calculators[:] = self._extract_kpi_calculators(wf_data)
         except KeyError as e:
@@ -118,7 +118,7 @@ class WorkflowReader(HasStrictTraits):
         """
         registry = self.bundle_registry
 
-        mco_data = wf_data.get("multi_criteria_optimizer")
+        mco_data = wf_data.get("mco")
         if mco_data is None:
             # The file was saved without setting an MCO.
             # The file is valid, we simply can't run any optimization yet.
@@ -126,11 +126,11 @@ class WorkflowReader(HasStrictTraits):
 
         mco_id = mco_data["id"]
         mco_bundle = registry.mco_bundle_by_id(mco_id)
-        model_data = wf_data["multi_criteria_optimizer"]["model_data"]
+        model_data = wf_data["mco"]["model_data"]
         model_data["parameters"] = self._extract_mco_parameters(
             model_data["parameters"])
         model = mco_bundle.create_model(
-            wf_data["multi_criteria_optimizer"]["model_data"])
+            wf_data["mco"]["model_data"])
         return model
 
     def _extract_data_sources(self, wf_data):

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -23,13 +23,13 @@ class WorkflowWriter(HasStrictTraits):
         }
 
         wf_data = data["workflow"]
-        wf_data["multi_criteria_optimizer"] = {
-            "id": workflow.multi_criteria_optimizer.bundle.id,
-            "model_data": workflow.multi_criteria_optimizer.__getstate__()
+        wf_data["mco"] = {
+            "id": workflow.mco.bundle.id,
+            "model_data": workflow.mco.__getstate__()
         }
 
         parameters_data = []
-        for param in wf_data["multi_criteria_optimizer"]["model_data"]["parameters"]:  # noqa
+        for param in wf_data["mco"]["model_data"]["parameters"]:  # noqa
             parameters_data.append(
                 {
                     "id": param.factory.id,
@@ -37,7 +37,7 @@ class WorkflowWriter(HasStrictTraits):
                 }
             )
 
-        wf_data["multi_criteria_optimizer"]["model_data"]["parameters"] = parameters_data  # noqa
+        wf_data["mco"]["model_data"]["parameters"] = parameters_data  # noqa
 
         kpic_data = []
         for kpic in workflow.kpi_calculators:

--- a/force_bdss/mco/base_mco.py
+++ b/force_bdss/mco/base_mco.py
@@ -4,16 +4,16 @@ from traits.api import ABCHasStrictTraits, Instance
 
 from ..bdss_application import BDSSApplication
 from .base_mco_model import BaseMCOModel
-from .i_multi_criteria_optimizer_bundle import IMultiCriteriaOptimizerBundle
+from .i_mco_bundle import IMCOBundle
 
 
-class BaseMultiCriteriaOptimizer(ABCHasStrictTraits):
+class BaseMCO(ABCHasStrictTraits):
     """Base class for the Multi Criteria Optimizer.
 
     Inherit this class for your MCO implementation
     """
     #: A reference to the bundle
-    bundle = Instance(IMultiCriteriaOptimizerBundle)
+    bundle = Instance(IMCOBundle)
     #: A reference to the application
     application = Instance(BDSSApplication)
     #: A reference to the model class
@@ -23,7 +23,7 @@ class BaseMultiCriteriaOptimizer(ABCHasStrictTraits):
         self.bundle = bundle
         self.application = application
         self.model = model
-        super(BaseMultiCriteriaOptimizer, self).__init__(*args, **kwargs)
+        super(BaseMCO, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
     def run(self):

--- a/force_bdss/mco/base_mco_bundle.py
+++ b/force_bdss/mco/base_mco_bundle.py
@@ -3,13 +3,11 @@ import abc
 from traits.api import ABCHasStrictTraits, String
 from traits.has_traits import provides
 
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import (
-    IMultiCriteriaOptimizerBundle
-)
+from force_bdss.mco.i_mco_bundle import IMCOBundle
 
 
-@provides(IMultiCriteriaOptimizerBundle)
-class BaseMultiCriteriaOptimizerBundle(ABCHasStrictTraits):
+@provides(IMCOBundle)
+class BaseMCOBundle(ABCHasStrictTraits):
     """Base class for the MultiCriteria Optimizer bundle.
     """
     # NOTE: any changes to the interface of this class must be replicated

--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -4,7 +4,7 @@ from traits.api import ABCHasStrictTraits, Instance
 
 from .base_mco_model import BaseMCOModel
 from ..bdss_application import BDSSApplication
-from .i_multi_criteria_optimizer_bundle import IMultiCriteriaOptimizerBundle
+from .i_mco_bundle import IMCOBundle
 
 
 class BaseMCOCommunicator(ABCHasStrictTraits):
@@ -19,7 +19,7 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
     again specified by the MCO.
     """
     #: A reference to the bundle
-    bundle = Instance(IMultiCriteriaOptimizerBundle)
+    bundle = Instance(IMCOBundle)
     #: A reference to the application
     application = Instance(BDSSApplication)
     #: A reference to the model class

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -1,7 +1,7 @@
 from traits.api import ABCHasStrictTraits, Instance, List
 
 from .parameters.base_mco_parameter import BaseMCOParameter
-from .i_multi_criteria_optimizer_bundle import IMultiCriteriaOptimizerBundle
+from .i_mco_bundle import IMCOBundle
 
 
 class BaseMCOModel(ABCHasStrictTraits):
@@ -14,7 +14,7 @@ class BaseMCOModel(ABCHasStrictTraits):
     """
     #: A reference to the creating bundle, so that we can
     #: retrieve it as the originating factory.
-    bundle = Instance(IMultiCriteriaOptimizerBundle,
+    bundle = Instance(IMCOBundle,
                       visible=False,
                       transient=True)
 

--- a/force_bdss/mco/i_mco_bundle.py
+++ b/force_bdss/mco/i_mco_bundle.py
@@ -1,7 +1,7 @@
 from traits.api import Interface, String
 
 
-class IMultiCriteriaOptimizerBundle(Interface):
+class IMCOBundle(Interface):
     """Interface for the MultiCriteria Optimizer bundle.
     You should not need it, as its main use is for envisage support.
     """

--- a/force_bdss/mco/tests/test_base_mco.py
+++ b/force_bdss/mco/tests/test_base_mco.py
@@ -1,10 +1,8 @@
 import unittest
 
 from force_bdss.mco.base_mco_model import BaseMCOModel
-from force_bdss.mco.base_multi_criteria_optimizer import \
-    BaseMultiCriteriaOptimizer
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
-    IMultiCriteriaOptimizerBundle
+from force_bdss.mco.base_mco import BaseMCO
+from force_bdss.mco.i_mco_bundle import IMCOBundle
 
 try:
     import mock
@@ -14,14 +12,14 @@ except ImportError:
 from force_bdss.bdss_application import BDSSApplication
 
 
-class DummyMCO(BaseMultiCriteriaOptimizer):
+class DummyMCO(BaseMCO):
     def run(self, *args, **kwargs):
         pass
 
 
 class TestBaseMultiCriteriaOptimizer(unittest.TestCase):
     def test_initialization(self):
-        bundle = mock.Mock(spec=IMultiCriteriaOptimizerBundle)
+        bundle = mock.Mock(spec=IMCOBundle)
         application = mock.Mock(spec=BDSSApplication)
         model = mock.Mock(spec=BaseMCOModel)
         mco = DummyMCO(bundle, application, model)

--- a/force_bdss/mco/tests/test_base_mco_bundle.py
+++ b/force_bdss/mco/tests/test_base_mco_bundle.py
@@ -1,11 +1,9 @@
 import unittest
 
-from force_bdss.mco.base_multi_criteria_optimizer_bundle import (
-    BaseMultiCriteriaOptimizerBundle
-)
+from force_bdss.mco.base_mco_bundle import BaseMCOBundle
 
 
-class DummyMCOBundle(BaseMultiCriteriaOptimizerBundle):
+class DummyMCOBundle(BaseMCOBundle):
     id = "foo"
 
     name = "bar"

--- a/force_bdss/mco/tests/test_base_mco_communicator.py
+++ b/force_bdss/mco/tests/test_base_mco_communicator.py
@@ -2,8 +2,7 @@ import unittest
 
 from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
 from force_bdss.mco.base_mco_model import BaseMCOModel
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
-    IMultiCriteriaOptimizerBundle
+from force_bdss.mco.i_mco_bundle import IMCOBundle
 
 try:
     import mock
@@ -23,7 +22,7 @@ class DummyMCOCommunicator(BaseMCOCommunicator):
 
 class TestBaseMCOCommunicator(unittest.TestCase):
     def test_initialization(self):
-        bundle = mock.Mock(spec=IMultiCriteriaOptimizerBundle)
+        bundle = mock.Mock(spec=IMCOBundle)
         application = mock.Mock(spec=BDSSApplication)
         model = mock.Mock(spec=BaseMCOModel)
         mcocomm = DummyMCOCommunicator(bundle, application, model)

--- a/force_bdss/tests/fixtures/test_csv.json
+++ b/force_bdss/tests/fixtures/test_csv.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
   "workflow": {
-    "multi_criteria_optimizer": {
+    "mco": {
       "id": "force.bdss.bundle.enthought.dummy_dakota",
       "model_data": {
         "parameters" : [

--- a/force_bdss/tests/test_bundle_registry_plugin.py
+++ b/force_bdss/tests/test_bundle_registry_plugin.py
@@ -14,8 +14,8 @@ from envisage.application import Application
 from force_bdss.bundle_registry_plugin import BundleRegistryPlugin
 from force_bdss.data_sources.i_data_source_bundle import IDataSourceBundle
 from force_bdss.kpi.i_kpi_calculator_bundle import IKPICalculatorBundle
-from force_bdss.mco.i_multi_criteria_optimizer_bundle import \
-    IMultiCriteriaOptimizerBundle
+from force_bdss.mco.i_mco_bundle import \
+    IMCOBundle
 
 
 class TestBundleRegistry(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestBundleRegistry(unittest.TestCase):
 
 class MySuperPlugin(BaseExtensionPlugin):
     def _mco_bundles_default(self):
-        return [mock.Mock(spec=IMultiCriteriaOptimizerBundle,
+        return [mock.Mock(spec=IMCOBundle,
                           id=bundle_id("enthought", "mco1"))]
 
     def _data_source_bundles_default(self):

--- a/force_bdss/workspecs/workflow.py
+++ b/force_bdss/workspecs/workflow.py
@@ -9,7 +9,7 @@ class Workflow(HasStrictTraits):
     """Model object that represents the Workflow as a whole"""
     #: Contains the bundle-specific MCO Model object.
     #: Can be None if no MCO has been specified yet.
-    multi_criteria_optimizer = Instance(BaseMCOModel, allow_none=True)
+    mco = Instance(BaseMCOModel, allow_none=True)
 
     #: Contains the bundle-specific DataSource Model objects.
     #: The list can be empty


### PR DESCRIPTION
Changed the names from long to abbreviation to keep consistency of otherwise excessively long names.

Fixes #48 