### PR TITLE
Silenced warnings for IDs not specified by specifying them

### DIFF
--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
@@ -1,0 +1,38 @@
+force_bdss.core_plugins.dummy.dummy_data_source package
+=======================================================
+
+Submodules
+----------
+
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source module
+------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_bundle module
+-------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model module
+------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.rst
@@ -8,6 +8,7 @@ Subpackages
 
     force_bdss.core_plugins.dummy.csv_extractor
     force_bdss.core_plugins.dummy.dummy_dakota
+    force_bdss.core_plugins.dummy.dummy_data_source
     force_bdss.core_plugins.dummy.dummy_kpi_calculator
     force_bdss.core_plugins.dummy.kpi_adder
 

--- a/doc/source/api/force_bdss.mco.rst
+++ b/doc/source/api/force_bdss.mco.rst
@@ -12,6 +12,22 @@ Subpackages
 Submodules
 ----------
 
+force_bdss.mco.base_mco module
+------------------------------
+
+.. automodule:: force_bdss.mco.base_mco
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.mco.base_mco_bundle module
+-------------------------------------
+
+.. automodule:: force_bdss.mco.base_mco_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 force_bdss.mco.base_mco_communicator module
 -------------------------------------------
 
@@ -28,26 +44,10 @@ force_bdss.mco.base_mco_model module
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.base_multi_criteria_optimizer module
----------------------------------------------------
+force_bdss.mco.i_mco_bundle module
+----------------------------------
 
-.. automodule:: force_bdss.mco.base_multi_criteria_optimizer
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.base_multi_criteria_optimizer_bundle module
-----------------------------------------------------------
-
-.. automodule:: force_bdss.mco.base_multi_criteria_optimizer_bundle
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.i_multi_criteria_optimizer_bundle module
--------------------------------------------------------
-
-.. automodule:: force_bdss.mco.i_multi_criteria_optimizer_bundle
+.. automodule:: force_bdss.mco.i_mco_bundle
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.mco.tests.rst
+++ b/doc/source/api/force_bdss.mco.tests.rst
@@ -4,26 +4,26 @@ force_bdss.mco.tests package
 Submodules
 ----------
 
+force_bdss.mco.tests.test_base_mco module
+-----------------------------------------
+
+.. automodule:: force_bdss.mco.tests.test_base_mco
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.mco.tests.test_base_mco_bundle module
+------------------------------------------------
+
+.. automodule:: force_bdss.mco.tests.test_base_mco_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 force_bdss.mco.tests.test_base_mco_communicator module
 ------------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_communicator
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.tests.test_base_multi_criteria_optimizer module
---------------------------------------------------------------
-
-.. automodule:: force_bdss.mco.tests.test_base_multi_criteria_optimizer
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.tests.test_base_multi_criteria_optimizer_bundle module
----------------------------------------------------------------------
-
-.. automodule:: force_bdss.mco.tests.test_base_multi_criteria_optimizer_bundle
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.tests.rst
+++ b/doc/source/api/force_bdss.tests.rst
@@ -27,10 +27,10 @@ force_bdss.tests.test_bundle_registry_plugin module
     :undoc-members:
     :show-inheritance:
 
-force_bdss.tests.test_id_generators module
-------------------------------------------
+force_bdss.tests.test_ids module
+--------------------------------
 
-.. automodule:: force_bdss.tests.test_id_generators
+.. automodule:: force_bdss.tests.test_ids
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.tests.rst
+++ b/doc/source/api/force_bdss.tests.rst
@@ -11,6 +11,14 @@ Subpackages
 Submodules
 ----------
 
+force_bdss.tests.test_bdss_application module
+---------------------------------------------
+
+.. automodule:: force_bdss.tests.test_bdss_application
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 force_bdss.tests.test_bundle_registry_plugin module
 ---------------------------------------------------
 

--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -1,5 +1,5 @@
 from .base_extension_plugin import BaseExtensionPlugin  # noqa
-from .ids import bundle_id  # noqa
+from .ids import bundle_id, plugin_id  # noqa
 
 from .data_sources.base_data_source_model import BaseDataSourceModel  # noqa
 from .data_sources.data_source_result import DataSourceResult  # noqa

--- a/force_bdss/core_evaluation_driver.py
+++ b/force_bdss/core_evaluation_driver.py
@@ -3,17 +3,21 @@ from __future__ import print_function
 import sys
 from traits.api import on_trait_change
 
+from .ids import plugin_id
 from .base_core_driver import BaseCoreDriver
 from .io.workflow_reader import (
     InvalidVersionException,
     InvalidFileException
 )
 
+CORE_EVALUATION_DRIVER_ID = plugin_id("core", "CoreEvaluationDriver")
+
 
 class CoreEvaluationDriver(BaseCoreDriver):
     """Main plugin that handles the execution of the MCO
     or the evaluation.
     """
+    id = CORE_EVALUATION_DRIVER_ID
 
     @on_trait_change("application:started")
     def application_started(self):

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -4,17 +4,21 @@ import sys
 
 from traits.api import on_trait_change
 
+from .ids import plugin_id
 from .base_core_driver import BaseCoreDriver
 from .io.workflow_reader import (
     InvalidVersionException,
     InvalidFileException
 )
 
+CORE_MCO_DRIVER_ID = plugin_id("core", "CoreMCODriver")
+
 
 class CoreMCODriver(BaseCoreDriver):
     """Main plugin that handles the execution of the MCO
     or the evaluation.
     """
+    id = CORE_MCO_DRIVER_ID
 
     @on_trait_change("application:started")
     def application_started(self):

--- a/force_bdss/core_plugins/dummy/dummy_plugin.py
+++ b/force_bdss/core_plugins/dummy/dummy_plugin.py
@@ -1,4 +1,4 @@
-from force_bdss.api import BaseExtensionPlugin
+from force_bdss.api import BaseExtensionPlugin, plugin_id
 from .csv_extractor.csv_extractor_bundle import CSVExtractorBundle
 from .kpi_adder.kpi_adder_bundle import KPIAdderBundle
 from .dummy_dakota.dakota_bundle import DummyDakotaBundle
@@ -9,6 +9,8 @@ from .dummy_kpi_calculator.dummy_kpi_calculator_bundle import (
 
 
 class DummyPlugin(BaseExtensionPlugin):
+    id = plugin_id("enthought", "DummyPlugin")
+
     def _data_source_bundles_default(self):
         return [DummyDataSourceBundle(),
                 CSVExtractorBundle()]

--- a/force_bdss/ids.py
+++ b/force_bdss/ids.py
@@ -33,11 +33,13 @@ def bundle_id(producer, identifier):
 
 
 def mco_parameter_id(producer, identifier):
+    """Creates an ID for an MCO parameter, so that it can be identified
+    uniquely."""
     return _string_id("mco_parameter", producer, identifier)
 
 
 def plugin_id(producer, identifier):
-    """Creates an ID for the plugins. These must be defined, otherwise 
+    """Creates an ID for the plugins. These must be defined, otherwise
     the envisage system will complain (but not break)
     """
     return _string_id("plugin", producer, identifier)

--- a/force_bdss/ids.py
+++ b/force_bdss/ids.py
@@ -36,6 +36,10 @@ def mco_parameter_id(producer, identifier):
     return _string_id("mco_parameter", producer, identifier)
 
 
+def plugin_id(producer, identifier):
+    return _string_id("plugin", producer, identifier)
+
+
 def _string_id(entity_namespace, producer, identifier):
     """Creates an id for a generic entity.
 

--- a/force_bdss/ids.py
+++ b/force_bdss/ids.py
@@ -37,6 +37,9 @@ def mco_parameter_id(producer, identifier):
 
 
 def plugin_id(producer, identifier):
+    """Creates an ID for the plugins. These must be defined, otherwise 
+    the envisage system will complain (but not break)
+    """
     return _string_id("plugin", producer, identifier)
 
 

--- a/force_bdss/tests/test_ids.py
+++ b/force_bdss/tests/test_ids.py
@@ -1,6 +1,6 @@
 import unittest
 
-from force_bdss.ids import bundle_id
+from force_bdss.ids import bundle_id, plugin_id
 
 
 class TestIdGenerators(unittest.TestCase):
@@ -13,3 +13,12 @@ class TestIdGenerators(unittest.TestCase):
                 bundle_id(bad_entry, "bar")
             with self.assertRaises(ValueError):
                 bundle_id("foo", bad_entry)
+
+    def test_plugin_id(self):
+        self.assertEqual(plugin_id("foo", "bar"), "force.bdss.plugin.foo.bar")
+
+        for bad_entry in ["", None, "   ", "foo bar"]:
+            with self.assertRaises(ValueError):
+                plugin_id(bad_entry, "bar")
+            with self.assertRaises(ValueError):
+                plugin_id("foo", bad_entry)


### PR DESCRIPTION
Specifies the ids for the plugins. Envisage requires them to be defined, or it will issue a warning that it is using a generated id. It is good practice that we do define them, so a new function has been introduced to create them.
