### PR TITLE
Remove application and model from bundles. Added plugin reference.

### DIFF
--- a/doc/source/api/force_bdss.cli.rst
+++ b/doc/source/api/force_bdss.cli.rst
@@ -1,5 +1,5 @@
-force_bdss.cli package
-======================
+force\_bdss\.cli package
+========================
 
 Subpackages
 -----------
@@ -11,8 +11,8 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.cli.force_bdss module
---------------------------------
+force\_bdss\.cli\.force\_bdss module
+------------------------------------
 
 .. automodule:: force_bdss.cli.force_bdss
     :members:

--- a/doc/source/api/force_bdss.cli.tests.rst
+++ b/doc/source/api/force_bdss.cli.tests.rst
@@ -1,11 +1,11 @@
-force_bdss.cli.tests package
-============================
+force\_bdss\.cli\.tests package
+===============================
 
 Submodules
 ----------
 
-force_bdss.cli.tests.test_execution module
-------------------------------------------
+force\_bdss\.cli\.tests\.test\_execution module
+-----------------------------------------------
 
 .. automodule:: force_bdss.cli.tests.test_execution
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.rst
@@ -1,27 +1,34 @@
-force_bdss.core_plugins.dummy.csv_extractor package
-===================================================
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor package
+=========================================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    force_bdss.core_plugins.dummy.csv_extractor.tests
 
 Submodules
 ----------
 
-force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_bundle module
------------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_bundle module
+--------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source module
-----------------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_data\_source module
+--------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model module
-----------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_model module
+-------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.tests.rst
@@ -1,0 +1,30 @@
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests package
+================================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests\.test\_csv\_extractor\_bundle module
+---------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests\.test\_csv\_extractor\_data\_source module
+---------------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.csv_extractor.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.rst
@@ -1,35 +1,42 @@
-force_bdss.core_plugins.dummy.dummy_dakota package
-==================================================
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota package
+========================================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    force_bdss.core_plugins.dummy.dummy_dakota.tests
 
 Submodules
 ----------
 
-force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle module
----------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_bundle module
+-----------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.dummy_dakota.dakota_communicator module
----------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_communicator module
+-----------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.dummy_dakota.dakota_model module
---------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_model module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer module
-------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_optimizer module
+--------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.tests.rst
@@ -1,0 +1,30 @@
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests package
+===============================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests\.test\_dakota\_bundle module
+------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests\.test\_dakota\_communicator module
+------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_communicator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
@@ -1,0 +1,45 @@
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source package
+==============================================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    force_bdss.core_plugins.dummy.dummy_data_source.tests
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source module
+----------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source\_bundle module
+------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source\_model module
+-----------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.tests.rst
@@ -1,0 +1,30 @@
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests package
+=====================================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests\.test\_dummy\_data\_source module
+-----------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests\.test\_dummy\_data\_source\_bundle module
+-------------------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.rst
@@ -1,27 +1,34 @@
-force_bdss.core_plugins.dummy.dummy_kpi_calculator package
-==========================================================
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator package
+=================================================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests
 
 Submodules
 ----------
 
-force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator module
-------------------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator module
+----------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_bundle module
--------------------------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator\_bundle module
+------------------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_model module
-------------------------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator\_model module
+-----------------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.rst
@@ -1,0 +1,22 @@
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.tests package
+========================================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.tests\.test\_dummy\_kpi\_calculator\_bundle module
+-------------------------------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.test_dummy_kpi_calculator_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.rst
@@ -1,27 +1,34 @@
-force_bdss.core_plugins.dummy.kpi_adder package
-===============================================
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder package
+=====================================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    force_bdss.core_plugins.dummy.kpi_adder.tests
 
 Submodules
 ----------
 
-force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_bundle module
----------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_bundle module
+------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_calculator module
--------------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_calculator module
+----------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_model module
---------------------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_model module
+-----------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.tests.rst
@@ -1,0 +1,22 @@
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.tests package
+============================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.tests\.test\_kpi\_adder\_bundle module
+-------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.kpi_adder.tests.test_kpi_adder_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.kpi_adder.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.rst
@@ -1,5 +1,5 @@
-force_bdss.core_plugins.dummy package
-=====================================
+force\_bdss\.core\_plugins\.dummy package
+=========================================
 
 Subpackages
 -----------
@@ -8,14 +8,16 @@ Subpackages
 
     force_bdss.core_plugins.dummy.csv_extractor
     force_bdss.core_plugins.dummy.dummy_dakota
+    force_bdss.core_plugins.dummy.dummy_data_source
     force_bdss.core_plugins.dummy.dummy_kpi_calculator
     force_bdss.core_plugins.dummy.kpi_adder
+    force_bdss.core_plugins.dummy.tests
 
 Submodules
 ----------
 
-force_bdss.core_plugins.dummy.dummy_plugin module
--------------------------------------------------
+force\_bdss\.core\_plugins\.dummy\.dummy\_plugin module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_plugin
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.tests.rst
@@ -1,0 +1,30 @@
+force\_bdss\.core\_plugins\.dummy\.tests package
+================================================
+
+Submodules
+----------
+
+force\_bdss\.core\_plugins\.dummy\.tests\.data\_source\_bundle\_test\_mixin module
+----------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.tests.data_source_bundle_test_mixin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\_plugins\.dummy\.tests\.kpi\_calculator\_bundle\_test\_mixin module
+-------------------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.tests.kpi_calculator_bundle_test_mixin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: force_bdss.core_plugins.dummy.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.rst
+++ b/doc/source/api/force_bdss.core_plugins.rst
@@ -1,5 +1,5 @@
-force_bdss.core_plugins package
-===============================
+force\_bdss\.core\_plugins package
+==================================
 
 Subpackages
 -----------

--- a/doc/source/api/force_bdss.data_sources.rst
+++ b/doc/source/api/force_bdss.data_sources.rst
@@ -1,5 +1,5 @@
-force_bdss.data_sources package
-===============================
+force\_bdss\.data\_sources package
+==================================
 
 Subpackages
 -----------
@@ -11,48 +11,48 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.data_sources.base_data_source module
------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.base_data_source_bundle module
-------------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source\_bundle module
+-------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.base_data_source_model module
------------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source\_model module
+------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.data_source_parameters module
------------------------------------------------------
+force\_bdss\.data\_sources\.data\_source\_parameters module
+-----------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.data_source_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.data_source_result module
--------------------------------------------------
+force\_bdss\.data\_sources\.data\_source\_result module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.data_source_result
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.i_data_source_bundle module
----------------------------------------------------
+force\_bdss\.data\_sources\.i\_data\_source\_bundle module
+----------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.i_data_source_bundle
     :members:

--- a/doc/source/api/force_bdss.data_sources.tests.rst
+++ b/doc/source/api/force_bdss.data_sources.tests.rst
@@ -1,19 +1,19 @@
-force_bdss.data_sources.tests package
-=====================================
+force\_bdss\.data\_sources\.tests package
+=========================================
 
 Submodules
 ----------
 
-force_bdss.data_sources.tests.test_base_data_source module
-----------------------------------------------------------
+force\_bdss\.data\_sources\.tests\.test\_base\_data\_source module
+------------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.data_sources.tests.test_base_data_source_bundle module
------------------------------------------------------------------
+force\_bdss\.data\_sources\.tests\.test\_base\_data\_source\_bundle module
+--------------------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source_bundle
     :members:

--- a/doc/source/api/force_bdss.io.rst
+++ b/doc/source/api/force_bdss.io.rst
@@ -1,5 +1,5 @@
-force_bdss.io package
-=====================
+force\_bdss\.io package
+=======================
 
 Subpackages
 -----------
@@ -11,16 +11,16 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.io.workflow_reader module
-------------------------------------
+force\_bdss\.io\.workflow\_reader module
+----------------------------------------
 
 .. automodule:: force_bdss.io.workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.io.workflow_writer module
-------------------------------------
+force\_bdss\.io\.workflow\_writer module
+----------------------------------------
 
 .. automodule:: force_bdss.io.workflow_writer
     :members:

--- a/doc/source/api/force_bdss.io.tests.rst
+++ b/doc/source/api/force_bdss.io.tests.rst
@@ -1,19 +1,19 @@
-force_bdss.io.tests package
-===========================
+force\_bdss\.io\.tests package
+==============================
 
 Submodules
 ----------
 
-force_bdss.io.tests.test_workflow_reader module
------------------------------------------------
+force\_bdss\.io\.tests\.test\_workflow\_reader module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.io.tests.test_workflow_writer module
------------------------------------------------
+force\_bdss\.io\.tests\.test\_workflow\_writer module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_writer
     :members:

--- a/doc/source/api/force_bdss.kpi.rst
+++ b/doc/source/api/force_bdss.kpi.rst
@@ -1,5 +1,5 @@
-force_bdss.kpi package
-======================
+force\_bdss\.kpi package
+========================
 
 Subpackages
 -----------
@@ -11,40 +11,40 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.kpi.base_kpi_calculator module
------------------------------------------
+force\_bdss\.kpi\.base\_kpi\_calculator module
+----------------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.kpi.base_kpi_calculator_bundle module
-------------------------------------------------
+force\_bdss\.kpi\.base\_kpi\_calculator\_bundle module
+------------------------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.kpi.base_kpi_calculator_model module
------------------------------------------------
+force\_bdss\.kpi\.base\_kpi\_calculator\_model module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.kpi.i_kpi_calculator_bundle module
----------------------------------------------
+force\_bdss\.kpi\.i\_kpi\_calculator\_bundle module
+---------------------------------------------------
 
 .. automodule:: force_bdss.kpi.i_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.kpi.kpi_calculator_result module
--------------------------------------------
+force\_bdss\.kpi\.kpi\_calculator\_result module
+------------------------------------------------
 
 .. automodule:: force_bdss.kpi.kpi_calculator_result
     :members:

--- a/doc/source/api/force_bdss.kpi.tests.rst
+++ b/doc/source/api/force_bdss.kpi.tests.rst
@@ -1,19 +1,19 @@
-force_bdss.kpi.tests package
-============================
+force\_bdss\.kpi\.tests package
+===============================
 
 Submodules
 ----------
 
-force_bdss.kpi.tests.test_base_kpi_calculator module
-----------------------------------------------------
+force\_bdss\.kpi\.tests\.test\_base\_kpi\_calculator module
+-----------------------------------------------------------
 
 .. automodule:: force_bdss.kpi.tests.test_base_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.kpi.tests.test_base_kpi_calculator_bundle module
------------------------------------------------------------
+force\_bdss\.kpi\.tests\.test\_base\_kpi\_calculator\_bundle module
+-------------------------------------------------------------------
 
 .. automodule:: force_bdss.kpi.tests.test_base_kpi_calculator_bundle
     :members:

--- a/doc/source/api/force_bdss.mco.parameters.rst
+++ b/doc/source/api/force_bdss.mco.parameters.rst
@@ -1,5 +1,5 @@
-force_bdss.mco.parameters package
-=================================
+force\_bdss\.mco\.parameters package
+====================================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.mco.parameters.base_mco_parameter module
----------------------------------------------------
+force\_bdss\.mco\.parameters\.base\_mco\_parameter module
+---------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.base_mco_parameter_factory module
------------------------------------------------------------
+force\_bdss\.mco\.parameters\.base\_mco\_parameter\_factory module
+------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.core_mco_parameters module
-----------------------------------------------------
+force\_bdss\.mco\.parameters\.core\_mco\_parameters module
+----------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.core_mco_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.mco_parameter_factory_registry module
----------------------------------------------------------------
+force\_bdss\.mco\.parameters\.mco\_parameter\_factory\_registry module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.mco_parameter_factory_registry
     :members:

--- a/doc/source/api/force_bdss.mco.parameters.tests.rst
+++ b/doc/source/api/force_bdss.mco.parameters.tests.rst
@@ -1,35 +1,35 @@
-force_bdss.mco.parameters.tests package
-=======================================
+force\_bdss\.mco\.parameters\.tests package
+===========================================
 
 Submodules
 ----------
 
-force_bdss.mco.parameters.tests.test_base_mco_parameter module
---------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.tests.test_base_mco_parameter_factory module
-----------------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter\_factory module
+-------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.tests.test_core_mco_parameters module
----------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_core\_mco\_parameters module
+-----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_core_mco_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.parameters.tests.test_parameter_factory_registry module
-----------------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_parameter\_factory\_registry module
+------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_parameter_factory_registry
     :members:

--- a/doc/source/api/force_bdss.mco.rst
+++ b/doc/source/api/force_bdss.mco.rst
@@ -1,5 +1,5 @@
-force_bdss.mco package
-======================
+force\_bdss\.mco package
+========================
 
 Subpackages
 -----------
@@ -12,42 +12,42 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.mco.base_mco_communicator module
--------------------------------------------
+force\_bdss\.mco\.base\_mco module
+----------------------------------
+
+.. automodule:: force_bdss.mco.base_mco
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.mco\.base\_mco\_bundle module
+------------------------------------------
+
+.. automodule:: force_bdss.mco.base_mco_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.mco\.base\_mco\_communicator module
+------------------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.base_mco_model module
-------------------------------------
+force\_bdss\.mco\.base\_mco\_model module
+-----------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.mco.base_multi_criteria_optimizer module
----------------------------------------------------
+force\_bdss\.mco\.i\_mco\_bundle module
+---------------------------------------
 
-.. automodule:: force_bdss.mco.base_multi_criteria_optimizer
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.base_multi_criteria_optimizer_bundle module
-----------------------------------------------------------
-
-.. automodule:: force_bdss.mco.base_multi_criteria_optimizer_bundle
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.i_multi_criteria_optimizer_bundle module
--------------------------------------------------------
-
-.. automodule:: force_bdss.mco.i_multi_criteria_optimizer_bundle
+.. automodule:: force_bdss.mco.i_mco_bundle
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.mco.tests.rst
+++ b/doc/source/api/force_bdss.mco.tests.rst
@@ -1,29 +1,29 @@
-force_bdss.mco.tests package
-============================
+force\_bdss\.mco\.tests package
+===============================
 
 Submodules
 ----------
 
-force_bdss.mco.tests.test_base_mco_communicator module
-------------------------------------------------------
+force\_bdss\.mco\.tests\.test\_base\_mco module
+-----------------------------------------------
+
+.. automodule:: force_bdss.mco.tests.test_base_mco
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.mco\.tests\.test\_base\_mco\_bundle module
+-------------------------------------------------------
+
+.. automodule:: force_bdss.mco.tests.test_base_mco_bundle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.mco\.tests\.test\_base\_mco\_communicator module
+-------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_communicator
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.tests.test_base_multi_criteria_optimizer module
---------------------------------------------------------------
-
-.. automodule:: force_bdss.mco.tests.test_base_multi_criteria_optimizer
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-force_bdss.mco.tests.test_base_multi_criteria_optimizer_bundle module
----------------------------------------------------------------------
-
-.. automodule:: force_bdss.mco.tests.test_base_multi_criteria_optimizer_bundle
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.rst
+++ b/doc/source/api/force_bdss.rst
@@ -1,5 +1,5 @@
-force_bdss package
-==================
+force\_bdss package
+===================
 
 Subpackages
 -----------
@@ -18,64 +18,64 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.api module
----------------------
+force\_bdss\.api module
+-----------------------
 
 .. automodule:: force_bdss.api
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.base_core_driver module
-----------------------------------
+force\_bdss\.base\_core\_driver module
+--------------------------------------
 
 .. automodule:: force_bdss.base_core_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.base_extension_plugin module
----------------------------------------
+force\_bdss\.base\_extension\_plugin module
+-------------------------------------------
 
 .. automodule:: force_bdss.base_extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.bdss_application module
-----------------------------------
+force\_bdss\.bdss\_application module
+-------------------------------------
 
 .. automodule:: force_bdss.bdss_application
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.bundle_registry_plugin module
-----------------------------------------
+force\_bdss\.bundle\_registry\_plugin module
+--------------------------------------------
 
 .. automodule:: force_bdss.bundle_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_evaluation_driver module
-----------------------------------------
+force\_bdss\.core\_evaluation\_driver module
+--------------------------------------------
 
 .. automodule:: force_bdss.core_evaluation_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.core_mco_driver module
----------------------------------
+force\_bdss\.core\_mco\_driver module
+-------------------------------------
 
 .. automodule:: force_bdss.core_mco_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.ids module
----------------------
+force\_bdss\.ids module
+-----------------------
 
 .. automodule:: force_bdss.ids
     :members:

--- a/doc/source/api/force_bdss.tests.fixtures.rst
+++ b/doc/source/api/force_bdss.tests.fixtures.rst
@@ -1,5 +1,5 @@
-force_bdss.tests.fixtures package
-=================================
+force\_bdss\.tests\.fixtures package
+====================================
 
 Module contents
 ---------------

--- a/doc/source/api/force_bdss.tests.rst
+++ b/doc/source/api/force_bdss.tests.rst
@@ -1,5 +1,5 @@
-force_bdss.tests package
-========================
+force\_bdss\.tests package
+==========================
 
 Subpackages
 -----------
@@ -11,16 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force_bdss.tests.test_bundle_registry_plugin module
----------------------------------------------------
+force\_bdss\.tests\.test\_bdss\_application module
+--------------------------------------------------
+
+.. automodule:: force_bdss.tests.test_bdss_application
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.tests\.test\_bundle\_registry\_plugin module
+---------------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_bundle_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force_bdss.tests.test_id_generators module
-------------------------------------------
+force\_bdss\.tests\.test\_core\_evaluation\_driver module
+---------------------------------------------------------
+
+.. automodule:: force_bdss.tests.test_core_evaluation_driver
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.tests\.test\_id\_generators module
+-----------------------------------------------
 
 .. automodule:: force_bdss.tests.test_id_generators
     :members:

--- a/doc/source/api/force_bdss.workspecs.rst
+++ b/doc/source/api/force_bdss.workspecs.rst
@@ -1,11 +1,11 @@
-force_bdss.workspecs package
-============================
+force\_bdss\.workspecs package
+==============================
 
 Submodules
 ----------
 
-force_bdss.workspecs.workflow module
-------------------------------------
+force\_bdss\.workspecs\.workflow module
+---------------------------------------
 
 .. automodule:: force_bdss.workspecs.workflow
     :members:

--- a/force_bdss/core_evaluation_driver.py
+++ b/force_bdss/core_evaluation_driver.py
@@ -32,15 +32,13 @@ class CoreEvaluationDriver(BaseCoreDriver):
         ds_results = []
         for ds_model in workflow.data_sources:
             ds_bundle = ds_model.bundle
-            data_source = ds_bundle.create_data_source(self.application,
-                                                       ds_model)
-            ds_results.append(data_source.run(parameters))
+            data_source = ds_bundle.create_data_source()
+            ds_results.append(data_source.run(ds_model, parameters))
 
         kpi_results = []
         for kpic_model in workflow.kpi_calculators:
             kpic_bundle = kpic_model.bundle
-            kpi_calculator = kpic_bundle.create_kpi_calculator(
-                self.application, kpic_model)
-            kpi_results.append(kpi_calculator.run(ds_results))
+            kpi_calculator = kpic_bundle.create_kpi_calculator()
+            kpi_results.append(kpi_calculator.run(kpic_model, ds_results))
 
         mco_communicator.send_to_mco(mco_model, kpi_results)

--- a/force_bdss/core_evaluation_driver.py
+++ b/force_bdss/core_evaluation_driver.py
@@ -25,11 +25,9 @@ class CoreEvaluationDriver(BaseCoreDriver):
 
         mco_model = workflow.mco
         mco_bundle = mco_model.bundle
-        mco_communicator = mco_bundle.create_communicator(
-            self.application,
-            mco_model)
+        mco_communicator = mco_bundle.create_communicator()
 
-        parameters = mco_communicator.receive_from_mco()
+        parameters = mco_communicator.receive_from_mco(mco_model)
 
         ds_results = []
         for ds_model in workflow.data_sources:
@@ -45,4 +43,4 @@ class CoreEvaluationDriver(BaseCoreDriver):
                 self.application, kpic_model)
             kpi_results.append(kpi_calculator.run(ds_results))
 
-        mco_communicator.send_to_mco(kpi_results)
+        mco_communicator.send_to_mco(mco_model, kpi_results)

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -26,5 +26,5 @@ class CoreMCODriver(BaseCoreDriver):
 
         mco_model = workflow.mco
         mco_bundle = mco_model.bundle
-        mco = mco_bundle.create_optimizer(self.application, mco_model)
-        mco.run()
+        mco = mco_bundle.create_optimizer()
+        mco.run(mco_model)

--- a/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_bundle.py
+++ b/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_bundle.py
@@ -17,5 +17,5 @@ class CSVExtractorBundle(BaseDataSourceBundle):
 
         return CSVExtractorModel(self, **model_data)
 
-    def create_data_source(self, application, model):
-        return CSVExtractorDataSource(self, application, model)
+    def create_data_source(self):
+        return CSVExtractorDataSource(self)

--- a/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_data_source.py
+++ b/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_data_source.py
@@ -5,20 +5,20 @@ from force_bdss.api import DataSourceResult
 
 
 class CSVExtractorDataSource(BaseDataSource):
-    def run(self, parameters):
-        with open(self.model.filename) as csvfile:
+    def run(self, model, parameters):
+        with open(model.filename) as csvfile:
             reader = csv.reader(csvfile)
             for rowindex, row in enumerate(reader):
-                if rowindex < self.model.row:
+                if rowindex < model.row:
                     continue
 
-                if rowindex == self.model.row:
+                if rowindex == model.row:
                     return DataSourceResult(
                         originator=self,
-                        value_types=[self.model.cuba_type],
+                        value_types=[model.cuba_type],
                         values=numpy.array(
                             parameters.values[0]+float(
-                                row[self.model.column])).reshape(1, 1)
+                                row[model.column])).reshape(1, 1)
                     )
 
                 return None

--- a/force_bdss/core_plugins/dummy/csv_extractor/tests/test_csv_extractor_bundle.py
+++ b/force_bdss/core_plugins/dummy/csv_extractor/tests/test_csv_extractor_bundle.py
@@ -1,0 +1,24 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.tests.data_source_bundle_test_mixin import \
+    DataSourceBundleTestMixin
+from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_bundle import \
+    CSVExtractorBundle
+from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source \
+    import CSVExtractorDataSource
+from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model import \
+    CSVExtractorModel
+
+
+class TestCSVExtractorBundle(DataSourceBundleTestMixin, unittest.TestCase):
+    @property
+    def bundle_class(self):
+        return CSVExtractorBundle
+
+    @property
+    def model_class(self):
+        return CSVExtractorModel
+
+    @property
+    def data_source_class(self):
+        return CSVExtractorDataSource

--- a/force_bdss/core_plugins/dummy/csv_extractor/tests/test_csv_extractor_data_source.py
+++ b/force_bdss/core_plugins/dummy/csv_extractor/tests/test_csv_extractor_data_source.py
@@ -1,0 +1,33 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source \
+    import CSVExtractorDataSource
+from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model import \
+    CSVExtractorModel
+from force_bdss.data_sources.base_data_source_bundle import \
+    BaseDataSourceBundle
+from force_bdss.data_sources.data_source_result import DataSourceResult
+from force_bdss.tests import fixtures
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestCSVExtractorDataSource(unittest.TestCase):
+    def setUp(self):
+        self.bundle = mock.Mock(spec=BaseDataSourceBundle)
+
+    def test_initialization(self):
+        ds = CSVExtractorDataSource(self.bundle)
+        self.assertEqual(ds.bundle, self.bundle)
+
+    def test_run(self):
+        ds = CSVExtractorDataSource(self.bundle)
+        model = CSVExtractorModel(self.bundle)
+        model.filename = fixtures.get("foo.csv")
+        mock_params = mock.Mock()
+        mock_params.values = [1.0]
+        result = ds.run(model, mock_params)
+        self.assertIsInstance(result, DataSourceResult)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/dakota_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/dakota_bundle.py
@@ -16,8 +16,8 @@ class DummyDakotaBundle(BaseMCOBundle):
             model_data = {}
         return DummyDakotaModel(self, **model_data)
 
-    def create_optimizer(self, application, model):
-        return DummyDakotaOptimizer(self, application, model)
+    def create_optimizer(self):
+        return DummyDakotaOptimizer(self)
 
-    def create_communicator(self, application, model):
-        return DummyDakotaCommunicator(self, application, model)
+    def create_communicator(self):
+        return DummyDakotaCommunicator(self)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/dakota_communicator.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/dakota_communicator.py
@@ -5,11 +5,11 @@ from force_bdss.api import DataSourceParameters, BaseMCOCommunicator
 
 
 class DummyDakotaCommunicator(BaseMCOCommunicator):
-    def receive_from_mco(self):
+    def receive_from_mco(self, model):
         data = sys.stdin.read()
         values = list(map(float, data.split()))
-        value_names = [p.value_name for p in self.model.parameters]
-        value_types = [p.value_type for p in self.model.parameters]
+        value_names = [p.value_name for p in model.parameters]
+        value_types = [p.value_type for p in model.parameters]
 
         return DataSourceParameters(
             value_names=value_names,
@@ -17,7 +17,7 @@ class DummyDakotaCommunicator(BaseMCOCommunicator):
             values=numpy.array(values)
         )
 
-    def send_to_mco(self, kpi_results):
+    def send_to_mco(self, model, kpi_results):
         data = " ".join(
             [" ".join(list(map(str, r.values.tolist()))) for r in kpi_results]
         )

--- a/force_bdss/core_plugins/dummy/dummy_dakota/dakota_optimizer.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/dakota_optimizer.py
@@ -15,8 +15,8 @@ def rotated_range(start, stop, starting_value):
 
 
 class DummyDakotaOptimizer(BaseMCO):
-    def run(self):
-        parameters = self.model.parameters
+    def run(self, model):
+        parameters = model.parameters
 
         values = []
         for p in parameters:
@@ -28,11 +28,13 @@ class DummyDakotaOptimizer(BaseMCO):
 
         value_iterator = itertools.product(*values)
 
+        application = self.bundle.plugin.application
+
         for value in value_iterator:
             ps = subprocess.Popen(
                 [sys.argv[0],
                  "--evaluate",
-                 self.application.workflow_filepath],
+                 application.workflow_filepath],
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE)
 

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_bundle.py
@@ -1,0 +1,43 @@
+import unittest
+
+from envisage.plugin import Plugin
+
+from force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle import \
+    DummyDakotaBundle
+from force_bdss.core_plugins.dummy.dummy_dakota.dakota_model import \
+    DummyDakotaModel
+from force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer import \
+    DummyDakotaOptimizer
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestDakotaBundle(unittest.TestCase):
+    def setUp(self):
+        self.plugin = mock.Mock(spec=Plugin)
+
+    def test_initialization(self):
+        bundle = DummyDakotaBundle(self.plugin)
+        self.assertIn("dummy_dakota", bundle.id)
+        self.assertEqual(bundle.plugin, self.plugin)
+
+    def test_create_model(self):
+        bundle = DummyDakotaBundle(self.plugin)
+        model = bundle.create_model({})
+        self.assertIsInstance(model, DummyDakotaModel)
+
+        model = bundle.create_model()
+        self.assertIsInstance(model, DummyDakotaModel)
+
+    def test_create_mco(self):
+        bundle = DummyDakotaBundle(self.plugin)
+        ds = bundle.create_optimizer()
+        self.assertIsInstance(ds, DummyDakotaOptimizer)
+
+    def test_create_communicator(self):
+        bundle = DummyDakotaBundle(self.plugin)
+        ds = bundle.create_optimizer()
+        self.assertIsInstance(ds, DummyDakotaOptimizer)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_communicator.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_communicator.py
@@ -1,6 +1,11 @@
 import unittest
 
-from force_bdss.bdss_application import BDSSApplication
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from envisage.plugin import Plugin
 
 from force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle import (
     DummyDakotaBundle)
@@ -10,15 +15,10 @@ from force_bdss.mco.parameters.base_mco_parameter_factory import \
     BaseMCOParameterFactory
 from force_bdss.mco.parameters.core_mco_parameters import RangedMCOParameter
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 class TestDakotaCommunicator(unittest.TestCase):
     def test_receive_from_mco(self):
-        bundle = DummyDakotaBundle()
+        bundle = DummyDakotaBundle(mock.Mock(spec=Plugin))
         mock_parameter_factory = mock.Mock(spec=BaseMCOParameterFactory)
         model = bundle.create_model()
         model.parameters = [

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_communicator.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_communicator.py
@@ -19,18 +19,17 @@ except ImportError:
 class TestDakotaCommunicator(unittest.TestCase):
     def test_receive_from_mco(self):
         bundle = DummyDakotaBundle()
-        mock_application = mock.Mock(spec=BDSSApplication)
         mock_parameter_factory = mock.Mock(spec=BaseMCOParameterFactory)
         model = bundle.create_model()
         model.parameters = [
             RangedMCOParameter(mock_parameter_factory)
         ]
-        comm = bundle.create_communicator(mock_application, model)
+        comm = bundle.create_communicator()
 
         with mock.patch("sys.stdin") as stdin:
             stdin.read.return_value = "1"
 
-            data = comm.receive_from_mco()
+            data = comm.receive_from_mco(model)
             self.assertIsInstance(data, DataSourceParameters)
             self.assertEqual(len(data.value_names), 1)
             self.assertEqual(len(data.value_types), 1)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
@@ -30,7 +30,8 @@ class TestDakotaOptimizer(unittest.TestCase):
         opt = DummyDakotaOptimizer(self.bundle)
         model = DummyDakotaModel(self.bundle)
         model.parameters = [
-            RangedMCOParameter(mock.Mock(spec=RangedMCOParameterFactory),
+            RangedMCOParameter(
+                mock.Mock(spec=RangedMCOParameterFactory),
                 lower_bound=1,
                 upper_bound=3,
                 initial_value=2)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
@@ -1,0 +1,46 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.dummy_dakota.dakota_model import \
+    DummyDakotaModel
+from force_bdss.mco.base_mco_bundle import BaseMCOBundle
+from force_bdss.mco.parameters.core_mco_parameters import RangedMCOParameter, \
+    RangedMCOParameterFactory
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer import \
+    DummyDakotaOptimizer
+
+
+class TestDakotaOptimizer(unittest.TestCase):
+    def setUp(self):
+        self.bundle = mock.Mock(spec=BaseMCOBundle)
+        self.bundle.plugin = mock.Mock()
+        self.bundle.plugin.application = mock.Mock()
+        self.bundle.plugin.application.workflow_filepath = "whatever"
+
+    def test_initialization(self):
+        opt = DummyDakotaOptimizer(self.bundle)
+        self.assertEqual(opt.bundle, self.bundle)
+
+    def test_run(self):
+        opt = DummyDakotaOptimizer(self.bundle)
+        model = DummyDakotaModel(self.bundle)
+        model.parameters = [
+            RangedMCOParameter(mock.Mock(spec=RangedMCOParameterFactory),
+                lower_bound=1,
+                upper_bound=3,
+                initial_value=2)
+        ]
+
+        mock_process = mock.Mock()
+        mock_process.communicate = mock.Mock(return_value=("1 2 3", ""))
+
+        with mock.patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = mock_process
+            opt.run(model)
+
+        self.assertEqual(mock_popen.call_count, 2)

--- a/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
+++ b/force_bdss/core_plugins/dummy/dummy_dakota/tests/test_dakota_optimizer.py
@@ -38,7 +38,7 @@ class TestDakotaOptimizer(unittest.TestCase):
         ]
 
         mock_process = mock.Mock()
-        mock_process.communicate = mock.Mock(return_value=("1 2 3", ""))
+        mock_process.communicate = mock.Mock(return_value=(b"1 2 3", b""))
 
         with mock.patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value = mock_process

--- a/force_bdss/core_plugins/dummy/dummy_data_source/dummy_data_source.py
+++ b/force_bdss/core_plugins/dummy/dummy_data_source/dummy_data_source.py
@@ -2,7 +2,7 @@ from force_bdss.api import BaseDataSource, DataSourceResult
 
 
 class DummyDataSource(BaseDataSource):
-    def run(self, parameters):
+    def run(self, model, parameters):
         print(parameters)
         return DataSourceResult(
                 originator=self,

--- a/force_bdss/core_plugins/dummy/dummy_data_source/dummy_data_source_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_data_source/dummy_data_source_bundle.py
@@ -12,5 +12,5 @@ class DummyDataSourceBundle(BaseDataSourceBundle):
 
         return DummyDataSourceModel(self, **model_data)
 
-    def create_data_source(self, application, model):
-        return DummyDataSource(self, application, model)
+    def create_data_source(self):
+        return DummyDataSource(self)

--- a/force_bdss/core_plugins/dummy/dummy_data_source/tests/test_dummy_data_source.py
+++ b/force_bdss/core_plugins/dummy/dummy_data_source/tests/test_dummy_data_source.py
@@ -1,0 +1,19 @@
+import unittest
+
+from force_bdss.data_sources.base_data_source_bundle import \
+    BaseDataSourceBundle
+from force_bdss.data_sources.tests.test_base_data_source import DummyDataSource
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestDummyDataSource(unittest.TestCase):
+    def setUp(self):
+        self.bundle = mock.Mock(spec=BaseDataSourceBundle)
+
+    def test_initialization(self):
+        ds = DummyDataSource(self.bundle)
+        self.assertEqual(ds.bundle, self.bundle)

--- a/force_bdss/core_plugins/dummy/dummy_data_source/tests/test_dummy_data_source_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_data_source/tests/test_dummy_data_source_bundle.py
@@ -1,0 +1,24 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source import \
+    DummyDataSource
+from force_bdss.core_plugins.dummy.dummy_data_source\
+    .dummy_data_source_bundle import DummyDataSourceBundle
+from force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model\
+    import DummyDataSourceModel
+from force_bdss.core_plugins.dummy.tests.data_source_bundle_test_mixin import \
+    DataSourceBundleTestMixin
+
+
+class TestDummyDataSourceBundle(DataSourceBundleTestMixin, unittest.TestCase):
+    @property
+    def bundle_class(self):
+        return DummyDataSourceBundle
+
+    @property
+    def model_class(self):
+        return DummyDataSourceModel
+
+    @property
+    def data_source_class(self):
+        return DummyDataSource

--- a/force_bdss/core_plugins/dummy/dummy_kpi_calculator/dummy_kpi_calculator.py
+++ b/force_bdss/core_plugins/dummy/dummy_kpi_calculator/dummy_kpi_calculator.py
@@ -4,7 +4,7 @@ from force_bdss.api import BaseKPICalculator, KPICalculatorResult, bundle_id
 class DummyKPICalculator(BaseKPICalculator):
     id = bundle_id("enthought", "dummy_kpi_calculator")
 
-    def run(self, data_source_results):
+    def run(self, model, data_source_results):
         res = KPICalculatorResult(
             originator=self,
             value_names=data_source_results[0].value_names,

--- a/force_bdss/core_plugins/dummy/dummy_kpi_calculator/dummy_kpi_calculator_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_kpi_calculator/dummy_kpi_calculator_bundle.py
@@ -15,5 +15,5 @@ class DummyKPICalculatorBundle(BaseKPICalculatorBundle):
 
         return DummyKPICalculatorModel(self, **model_data)
 
-    def create_kpi_calculator(self, application, model):
-        return DummyKPICalculator(self, application, model)
+    def create_kpi_calculator(self):
+        return DummyKPICalculator(self)

--- a/force_bdss/core_plugins/dummy/dummy_kpi_calculator/tests/test_dummy_kpi_calculator_bundle.py
+++ b/force_bdss/core_plugins/dummy/dummy_kpi_calculator/tests/test_dummy_kpi_calculator_bundle.py
@@ -1,0 +1,30 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator\
+    import \
+    DummyKPICalculator
+from force_bdss.core_plugins.dummy.dummy_kpi_calculator\
+    .dummy_kpi_calculator_bundle import \
+    DummyKPICalculatorBundle
+from force_bdss.core_plugins.dummy.dummy_kpi_calculator\
+    .dummy_kpi_calculator_model import \
+    DummyKPICalculatorModel
+from force_bdss.core_plugins.dummy.tests.kpi_calculator_bundle_test_mixin \
+    import \
+    KPICalculatorBundleTestMixin
+
+
+class TestDummyKPICalculatorBundle(
+        KPICalculatorBundleTestMixin, unittest.TestCase):
+
+    @property
+    def bundle_class(self):
+        return DummyKPICalculatorBundle
+
+    @property
+    def kpi_calculator_class(self):
+        return DummyKPICalculator
+
+    @property
+    def model_class(self):
+        return DummyKPICalculatorModel

--- a/force_bdss/core_plugins/dummy/dummy_plugin.py
+++ b/force_bdss/core_plugins/dummy/dummy_plugin.py
@@ -10,12 +10,12 @@ from .dummy_kpi_calculator.dummy_kpi_calculator_bundle import (
 
 class DummyPlugin(BaseExtensionPlugin):
     def _data_source_bundles_default(self):
-        return [DummyDataSourceBundle(),
-                CSVExtractorBundle()]
+        return [DummyDataSourceBundle(self),
+                CSVExtractorBundle(self)]
 
     def _mco_bundles_default(self):
-        return [DummyDakotaBundle()]
+        return [DummyDakotaBundle(self)]
 
     def _kpi_calculator_bundles_default(self):
-        return [DummyKPICalculatorBundle(),
-                KPIAdderBundle()]
+        return [DummyKPICalculatorBundle(self),
+                KPIAdderBundle(self)]

--- a/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_bundle.py
+++ b/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_bundle.py
@@ -17,5 +17,5 @@ class KPIAdderBundle(BaseKPICalculatorBundle):
 
         return KPIAdderModel(self, **model_data)
 
-    def create_kpi_calculator(self, application, model):
-        return KPIAdderCalculator(self, application, model)
+    def create_kpi_calculator(self):
+        return KPIAdderCalculator(self)

--- a/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_calculator.py
+++ b/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_calculator.py
@@ -5,11 +5,11 @@ from force_bdss.api import KPICalculatorResult
 
 
 class KPIAdderCalculator(BaseKPICalculator):
-    def run(self, data_source_results):
+    def run(self, model, data_source_results):
         sum = 0.0
         for res in data_source_results:
             try:
-                value_idx = res.value_types.index(self.model.cuba_type_in)
+                value_idx = res.value_types.index(model.cuba_type_in)
             except ValueError:
                 continue
 
@@ -17,6 +17,6 @@ class KPIAdderCalculator(BaseKPICalculator):
 
         return KPICalculatorResult(
             originator=self,
-            value_types=[self.model.cuba_type_out],
+            value_types=[model.cuba_type_out],
             values=numpy.array([sum])
         )

--- a/force_bdss/core_plugins/dummy/kpi_adder/tests/test_kpi_adder_bundle.py
+++ b/force_bdss/core_plugins/dummy/kpi_adder/tests/test_kpi_adder_bundle.py
@@ -1,0 +1,27 @@
+import unittest
+
+from force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_bundle import \
+    KPIAdderBundle
+from force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_calculator import \
+    KPIAdderCalculator
+from force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_model import \
+    KPIAdderModel
+from force_bdss.core_plugins.dummy.tests.kpi_calculator_bundle_test_mixin \
+    import \
+    KPICalculatorBundleTestMixin
+
+
+class TestDummyKPICalculatorBundle(
+        KPICalculatorBundleTestMixin, unittest.TestCase):
+
+    @property
+    def bundle_class(self):
+        return KPIAdderBundle
+
+    @property
+    def kpi_calculator_class(self):
+        return KPIAdderCalculator
+
+    @property
+    def model_class(self):
+        return KPIAdderModel

--- a/force_bdss/core_plugins/dummy/tests/data_source_bundle_test_mixin.py
+++ b/force_bdss/core_plugins/dummy/tests/data_source_bundle_test_mixin.py
@@ -1,0 +1,44 @@
+from envisage.plugin import Plugin
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class DataSourceBundleTestMixin(object):
+    def setUp(self):
+        self.plugin = mock.Mock(spec=Plugin)
+        super(DataSourceBundleTestMixin, self).setUp()
+
+    # Note: we can't use metaclasses. Apparently using six.with_metaclass
+    # breaks the unittest TestCase mechanism. py3 metaclassing works.
+    @property
+    def bundle_class(self):
+        raise NotImplementedError()
+
+    @property
+    def model_class(self):
+        raise NotImplementedError()
+
+    @property
+    def data_source_class(self):
+        raise NotImplementedError()
+
+    def test_initialization(self):
+        bundle = self.bundle_class(self.plugin)
+        self.assertNotEqual(bundle.id, "")
+        self.assertEqual(bundle.plugin, self.plugin)
+
+    def test_create_model(self):
+        bundle = self.bundle_class(self.plugin)
+        model = bundle.create_model({})
+        self.assertIsInstance(model, self.model_class)
+
+        model = bundle.create_model()
+        self.assertIsInstance(model, self.model_class)
+
+    def test_create_data_source(self):
+        bundle = self.bundle_class(self.plugin)
+        ds = bundle.create_data_source()
+        self.assertIsInstance(ds, self.data_source_class)

--- a/force_bdss/core_plugins/dummy/tests/kpi_calculator_bundle_test_mixin.py
+++ b/force_bdss/core_plugins/dummy/tests/kpi_calculator_bundle_test_mixin.py
@@ -1,0 +1,42 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from envisage.api import Plugin
+
+
+class KPICalculatorBundleTestMixin(object):
+    def setUp(self):
+        self.plugin = mock.Mock(spec=Plugin)
+        super(KPICalculatorBundleTestMixin, self).setUp()
+
+    @property
+    def bundle_class(self):
+        raise NotImplementedError()
+
+    @property
+    def model_class(self):
+        raise NotImplementedError()
+
+    @property
+    def kpi_calculator_class(self):
+        raise NotImplementedError()
+
+    def test_initialization(self):
+        bundle = self.bundle_class(self.plugin)
+        self.assertNotEqual(bundle.id, "")
+        self.assertEqual(bundle.plugin, self.plugin)
+
+    def test_create_model(self):
+        bundle = self.bundle_class(self.plugin)
+        model = bundle.create_model({})
+        self.assertIsInstance(model, self.model_class)
+
+        model = bundle.create_model()
+        self.assertIsInstance(model, self.model_class)
+
+    def test_create_kpi_calculator(self):
+        bundle = self.bundle_class(self.plugin)
+        ds = bundle.create_kpi_calculator()
+        self.assertIsInstance(ds, self.kpi_calculator_class)

--- a/force_bdss/data_sources/base_data_source.py
+++ b/force_bdss/data_sources/base_data_source.py
@@ -19,5 +19,21 @@ class BaseDataSource(ABCHasStrictTraits):
 
     @abc.abstractmethod
     def run(self, model, parameters):
-        """Executes the data source evaluation/fetching and returns
-        the list of results as a DataSourceResult instance."""
+        """
+        Executes the KPI evaluation and returns the results it computes.
+        Reimplement this method in your specific KPI calculator.
+
+        Parameters
+        ----------
+        model: BaseDataSourceModel
+            The model of the DataSource, instantiated through create_model()
+
+        parameters: DataSourceParameters
+            a DataResultParameters instance containing the information coming
+            from the MCO
+
+        Returns
+        -------
+        DataSourceResult
+            Instance that holds the results computed by this DataSource.
+        """

--- a/force_bdss/data_sources/base_data_source.py
+++ b/force_bdss/data_sources/base_data_source.py
@@ -1,8 +1,6 @@
 from traits.api import ABCHasStrictTraits, Instance
 import abc
 
-from .base_data_source_model import BaseDataSourceModel
-from ..bdss_application import BDSSApplication
 from ..data_sources.i_data_source_bundle import IDataSourceBundle
 
 
@@ -14,18 +12,12 @@ class BaseDataSource(ABCHasStrictTraits):
     """
     #: A reference to the bundle
     bundle = Instance(IDataSourceBundle)
-    #: A reference to the application
-    application = Instance(BDSSApplication)
-    #: A reference to the model class
-    model = Instance(BaseDataSourceModel)
 
-    def __init__(self, bundle, application, model, *args, **kwargs):
+    def __init__(self, bundle, *args, **kwargs):
         self.bundle = bundle
-        self.application = application
-        self.model = model
         super(BaseDataSource, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
-    def run(self, parameters):
+    def run(self, model, parameters):
         """Executes the data source evaluation/fetching and returns
         the list of results as a DataSourceResult instance."""

--- a/force_bdss/data_sources/base_data_source_bundle.py
+++ b/force_bdss/data_sources/base_data_source_bundle.py
@@ -26,7 +26,7 @@ class BaseDataSourceBundle(ABCHasStrictTraits):
         super(BaseDataSourceBundle, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
-    def create_data_source(self, application, model):
+    def create_data_source(self):
         """Factory method.
         Must return the bundle-specific BaseDataSource instance.
 

--- a/force_bdss/data_sources/base_data_source_bundle.py
+++ b/force_bdss/data_sources/base_data_source_bundle.py
@@ -1,5 +1,6 @@
 import abc
-from traits.api import ABCHasStrictTraits, provides, String
+from traits.api import ABCHasStrictTraits, provides, String, Instance
+from envisage.plugin import Plugin
 
 from .i_data_source_bundle import IDataSourceBundle
 
@@ -17,6 +18,12 @@ class BaseDataSourceBundle(ABCHasStrictTraits):
 
     #: A human readable name of the bundle. Spaces allowed
     name = String()
+
+    plugin = Instance(Plugin)
+
+    def __init__(self, plugin, *args, **kwargs):
+        self.plugin = plugin
+        super(BaseDataSourceBundle, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
     def create_data_source(self, application, model):

--- a/force_bdss/data_sources/base_data_source_bundle.py
+++ b/force_bdss/data_sources/base_data_source_bundle.py
@@ -19,6 +19,7 @@ class BaseDataSourceBundle(ABCHasStrictTraits):
     #: A human readable name of the bundle. Spaces allowed
     name = String()
 
+    #: Reference to the plugin that carries this bundle
     plugin = Instance(Plugin)
 
     def __init__(self, plugin, *args, **kwargs):
@@ -29,13 +30,6 @@ class BaseDataSourceBundle(ABCHasStrictTraits):
     def create_data_source(self):
         """Factory method.
         Must return the bundle-specific BaseDataSource instance.
-
-        Parameters
-        ----------
-        application: Application
-            The envisage application.
-        model: BaseDataSourceModel
-            The model of the data source, instantiated with create_model()
 
         Returns
         -------

--- a/force_bdss/data_sources/data_source_parameters.py
+++ b/force_bdss/data_sources/data_source_parameters.py
@@ -2,8 +2,14 @@ from traits.api import HasStrictTraits, Array, List, String
 
 
 class DataSourceParameters(HasStrictTraits):
+    """Contains the parameters as passed from the MCO."""
+    #: The user-defined names associated to the values.
     value_names = List(String)
+
+    #: The CUBA types associated to the values
     value_types = List(String)
+
+    #: The values as a single array.
     values = Array(shape=(None,))
 
     def __str__(self):

--- a/force_bdss/data_sources/data_source_result.py
+++ b/force_bdss/data_sources/data_source_result.py
@@ -4,19 +4,36 @@ from .base_data_source import BaseDataSource
 
 
 class DataSourceResult(HasTraits):
-    """Represents the result of a simulator.
-    It contains the resulting cuba key, the associated uncertainty and the
-    originating simulator.
-    Difference between uncertainty and quality: uncertainty is a numerical
-    value of the value, as in the case of an experimental simulation.
-    quality is the level of accuracy of the (e.g. computational) method, as
-    the importance and reliability of that value. It should be an enumeration
-    value such as HIGH, MEDIUM, POOR"""
+    """Represents the result of a DataSource evaluation.
+
+    Note
+    ----
+    Difference between accuracy and quality:
+      - uncertainty is a numerical quantity defining the accuracy of the value.
+        For example, a pressure can be 10.4 +/- 0.1, with 0.1 being the
+        accuracy
+      - quality is the level of importance and reliability of that value.
+        It should be considered as a weight of how much trust one should hold
+        on this information.
+    """
+
+    #: A reference to the DataSource that computed this result.
     originator = Instance(BaseDataSource)
+
+    #: The user-defined names associated to each result.
     value_names = List(String)
+
+    #: The CUBA types of each value.
     value_types = List(String)
+
+    #: The values for each entry. Note that this is a NxM array, allowing
+    #: to propagate more than single scalar values associated to a given value.
     values = Array(shape=(None, None))
+
+    #: If present, the numerical accuracy of the above values.
     accuracy = ArrayOrNone(shape=(None, None))
+
+    #: If present, the assessed quality of the above values.
     quality = ArrayOrNone(shape=(None, None))
 
     def __str__(self):

--- a/force_bdss/data_sources/i_data_source_bundle.py
+++ b/force_bdss/data_sources/i_data_source_bundle.py
@@ -1,13 +1,18 @@
-from traits.api import Interface, String
+from envisage.api import Plugin
+from traits.api import Interface, String, Instance
 
 
 class IDataSourceBundle(Interface):
-    #: Unique identifier that identifies the bundle uniquely in the
-    #: universe of bundles. Create one with the function bundle_id()
+    """Envisage required interface for the BaseDataSourceBundle.
+    You should not need to use this directly.
+
+    Refer to the BaseDataSourceBundle for documentation.
+    """
     id = String()
 
-    #: A human readable name of the bundle
     name = String()
+
+    plugin = Instance(Plugin)
 
     def create_data_source(self):
         """Factory method.

--- a/force_bdss/data_sources/i_data_source_bundle.py
+++ b/force_bdss/data_sources/i_data_source_bundle.py
@@ -15,11 +15,7 @@ class IDataSourceBundle(Interface):
     plugin = Instance(Plugin)
 
     def create_data_source(self):
-        """Factory method.
-        Must return the bundle-specific BaseDataSource instance.
-        """
+        """"""
 
     def create_model(self, model_data=None):
-        """Factory method.
-        Must return the bundle-specific BaseDataSourceModel instance.
-        """
+        """"""

--- a/force_bdss/data_sources/i_data_source_bundle.py
+++ b/force_bdss/data_sources/i_data_source_bundle.py
@@ -9,7 +9,7 @@ class IDataSourceBundle(Interface):
     #: A human readable name of the bundle
     name = String()
 
-    def create_data_source(self, application, model):
+    def create_data_source(self):
         """Factory method.
         Must return the bundle-specific BaseDataSource instance.
         """

--- a/force_bdss/data_sources/tests/test_base_data_source.py
+++ b/force_bdss/data_sources/tests/test_base_data_source.py
@@ -1,15 +1,12 @@
 import unittest
 
 from force_bdss.data_sources.base_data_source import BaseDataSource
-from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
 from force_bdss.data_sources.i_data_source_bundle import IDataSourceBundle
 
 try:
     import mock
 except ImportError:
     from unittest import mock
-
-from force_bdss.bdss_application import BDSSApplication
 
 
 class DummyDataSource(BaseDataSource):
@@ -20,10 +17,6 @@ class DummyDataSource(BaseDataSource):
 class TestBaseDataSource(unittest.TestCase):
     def test_initialization(self):
         bundle = mock.Mock(spec=IDataSourceBundle)
-        application = mock.Mock(spec=BDSSApplication)
-        model = mock.Mock(spec=BaseDataSourceModel)
-        ds = DummyDataSource(bundle, application, model)
+        ds = DummyDataSource(bundle)
 
         self.assertEqual(ds.bundle, bundle)
-        self.assertEqual(ds.application, application)
-        self.assertEqual(ds.model, model)

--- a/force_bdss/data_sources/tests/test_base_data_source_bundle.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_bundle.py
@@ -1,5 +1,10 @@
 import unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
+from envisage.plugin import Plugin
 from force_bdss.data_sources.base_data_source_bundle import \
     BaseDataSourceBundle
 
@@ -9,7 +14,7 @@ class DummyDataSourceBundle(BaseDataSourceBundle):
 
     name = "bar"
 
-    def create_data_source(self, application, model):
+    def create_data_source(self):
         pass
 
     def create_model(self, model_data=None):
@@ -18,6 +23,6 @@ class DummyDataSourceBundle(BaseDataSourceBundle):
 
 class TestBaseDataSourceBundle(unittest.TestCase):
     def test_initialization(self):
-        bundle = DummyDataSourceBundle()
+        bundle = DummyDataSourceBundle(mock.Mock(spec=Plugin))
         self.assertEqual(bundle.id, 'foo')
         self.assertEqual(bundle.name, 'bar')

--- a/force_bdss/kpi/base_kpi_calculator.py
+++ b/force_bdss/kpi/base_kpi_calculator.py
@@ -2,8 +2,6 @@ import abc
 
 from traits.api import ABCHasStrictTraits, Instance
 
-from ..bdss_application import BDSSApplication
-from .base_kpi_calculator_model import BaseKPICalculatorModel
 from .i_kpi_calculator_bundle import IKPICalculatorBundle
 
 
@@ -14,19 +12,13 @@ class BaseKPICalculator(ABCHasStrictTraits):
     """
     #: A reference to the bundle
     bundle = Instance(IKPICalculatorBundle)
-    #: A reference to the application
-    application = Instance(BDSSApplication)
-    #: A reference to the model class
-    model = Instance(BaseKPICalculatorModel)
 
-    def __init__(self, bundle, application, model, *args, **kwargs):
+    def __init__(self, bundle, *args, **kwargs):
         self.bundle = bundle
-        self.application = application
-        self.model = model
         super(BaseKPICalculator, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
-    def run(self, data_source_results):
+    def run(self, model, data_source_results):
         """
         Executes the KPI evaluation and returns the list of results.
         Reimplement this method in your specific KPI calculator.

--- a/force_bdss/kpi/base_kpi_calculator.py
+++ b/force_bdss/kpi/base_kpi_calculator.py
@@ -20,12 +20,22 @@ class BaseKPICalculator(ABCHasStrictTraits):
     @abc.abstractmethod
     def run(self, model, data_source_results):
         """
-        Executes the KPI evaluation and returns the list of results.
+        Executes the KPI evaluation and returns the results it computes.
         Reimplement this method in your specific KPI calculator.
 
         Parameters
         ----------
+        model: BaseKPICalculatorModel
+            The model of the KPI Calculator, instantiated through
+            create_model()
+
         data_source_results:
             a list of DataSourceResult instances containing the results of the
-            evaluation.
+            evaluation. Each DataSourceResult contains the results from one
+            specific DataSource.
+
+        Returns
+        -------
+        KPICalculatorResult
+            Instance that holds the results computed by this KPICalculator.
         """

--- a/force_bdss/kpi/base_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/base_kpi_calculator_bundle.py
@@ -1,5 +1,6 @@
 import abc
-from traits.api import ABCHasStrictTraits, provides, String
+from envisage.plugin import Plugin
+from traits.api import ABCHasStrictTraits, provides, String, Instance
 
 from .i_kpi_calculator_bundle import IKPICalculatorBundle
 
@@ -18,6 +19,12 @@ class BaseKPICalculatorBundle(ABCHasStrictTraits):
 
     #: A UI friendly name for the bundle. Can contain spaces.
     name = String()
+
+    plugin = Instance(Plugin)
+
+    def __init__(self, plugin, *args, **kwargs):
+        self.plugin = plugin
+        super(BaseKPICalculatorBundle, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
     def create_kpi_calculator(self, application, model):

--- a/force_bdss/kpi/base_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/base_kpi_calculator_bundle.py
@@ -20,9 +20,17 @@ class BaseKPICalculatorBundle(ABCHasStrictTraits):
     #: A UI friendly name for the bundle. Can contain spaces.
     name = String()
 
+    #: A reference to the plugin that holds this bundle.
     plugin = Instance(Plugin)
 
     def __init__(self, plugin, *args, **kwargs):
+        """Initializes the instance.
+
+        Parameters
+        ----------
+        plugin: Plugin
+            The plugin that holds this bundle.
+        """
         self.plugin = plugin
         super(BaseKPICalculatorBundle, self).__init__(*args, **kwargs)
 
@@ -31,13 +39,6 @@ class BaseKPICalculatorBundle(ABCHasStrictTraits):
         """Factory method.
         Creates and returns an instance of a KPI Calculator, associated
         to the given application and model.
-
-        Parameters
-        ----------
-        application: Application
-            The envisage application.
-        model: BaseKPICalculatorModel
-            The model of the calculator, instantiated with create_model()
 
         Returns
         -------

--- a/force_bdss/kpi/base_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/base_kpi_calculator_bundle.py
@@ -27,7 +27,7 @@ class BaseKPICalculatorBundle(ABCHasStrictTraits):
         super(BaseKPICalculatorBundle, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
-    def create_kpi_calculator(self, application, model):
+    def create_kpi_calculator(self):
         """Factory method.
         Creates and returns an instance of a KPI Calculator, associated
         to the given application and model.

--- a/force_bdss/kpi/i_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/i_kpi_calculator_bundle.py
@@ -1,4 +1,5 @@
-from traits.api import Interface, String
+from traits.api import Interface, String, Instance
+from envisage.plugin import Plugin
 
 
 class IKPICalculatorBundle(Interface):
@@ -8,7 +9,8 @@ class IKPICalculatorBundle(Interface):
 
     name = String()
 
-    def create_kpi_calculator(self, application, model):
+    plugin = Instance(Plugin)
+    def create_kpi_calculator(self):
         pass
 
     def create_model(self, model_data=None):

--- a/force_bdss/kpi/i_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/i_kpi_calculator_bundle.py
@@ -15,7 +15,7 @@ class IKPICalculatorBundle(Interface):
     plugin = Instance(Plugin)
 
     def create_kpi_calculator(self):
-        pass
+        """"""
 
     def create_model(self, model_data=None):
-        pass
+        """"""

--- a/force_bdss/kpi/i_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/i_kpi_calculator_bundle.py
@@ -4,7 +4,10 @@ from envisage.plugin import Plugin
 
 class IKPICalculatorBundle(Interface):
     """Envisage required interface for the BaseKPICalculatorBundle.
-    You should not need to use this directly."""
+    You should not need to use this directly.
+
+    Refer to the BaseKPICalculatorBundle for documentation.
+    """
     id = String()
 
     name = String()

--- a/force_bdss/kpi/i_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/i_kpi_calculator_bundle.py
@@ -10,6 +10,7 @@ class IKPICalculatorBundle(Interface):
     name = String()
 
     plugin = Instance(Plugin)
+
     def create_kpi_calculator(self):
         pass
 

--- a/force_bdss/kpi/kpi_calculator_result.py
+++ b/force_bdss/kpi/kpi_calculator_result.py
@@ -4,11 +4,24 @@ from .base_kpi_calculator import BaseKPICalculator
 
 
 class KPICalculatorResult(HasTraits):
+    """Contains the results from a single KPICalculator evaluation"""
+
+    #: The originating KPI calculator
     originator = Instance(BaseKPICalculator)
+
+    #: The user-attributed names of each computed value
     value_names = List(String)
+
+    #: The CUBA types of each of the computed values
     value_types = List(String)
+
+    #: The values, as a single array of values
     values = Array(shape=(None, ))
+
+    #: If present, the numerical accuracy of the above values.
     accuracy = ArrayOrNone(shape=(None, ))
+
+    #: If present, the quality of the above values.
     quality = ArrayOrNone(shape=(None, ))
 
     def __str__(self):

--- a/force_bdss/kpi/tests/test_base_kpi_calculator.py
+++ b/force_bdss/kpi/tests/test_base_kpi_calculator.py
@@ -4,8 +4,6 @@ try:
 except ImportError:
     from unittest import mock
 
-from force_bdss.bdss_application import BDSSApplication
-from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
 from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
 from force_bdss.kpi.i_kpi_calculator_bundle import IKPICalculatorBundle
 
@@ -18,10 +16,6 @@ class DummyKPICalculator(BaseKPICalculator):
 class TestBaseKPICalculator(unittest.TestCase):
     def test_initialization(self):
         bundle = mock.Mock(spec=IKPICalculatorBundle)
-        application = mock.Mock(spec=BDSSApplication)
-        model = mock.Mock(spec=BaseKPICalculatorModel)
-        kpic = DummyKPICalculator(bundle, application, model)
+        kpic = DummyKPICalculator(bundle)
 
         self.assertEqual(kpic.bundle, bundle)
-        self.assertEqual(kpic.application, application)
-        self.assertEqual(kpic.model, model)

--- a/force_bdss/kpi/tests/test_base_kpi_calculator_bundle.py
+++ b/force_bdss/kpi/tests/test_base_kpi_calculator_bundle.py
@@ -1,4 +1,10 @@
 import unittest
+from envisage.plugin import Plugin
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from force_bdss.kpi.base_kpi_calculator_bundle import \
     BaseKPICalculatorBundle
@@ -9,7 +15,7 @@ class DummyKPICalculatorBundle(BaseKPICalculatorBundle):
 
     name = "bar"
 
-    def create_kpi_calculator(self, application, model):
+    def create_kpi_calculator(self):
         pass
 
     def create_model(self, model_data=None):
@@ -18,6 +24,6 @@ class DummyKPICalculatorBundle(BaseKPICalculatorBundle):
 
 class TestBaseKPICalculatorBundle(unittest.TestCase):
     def test_initialization(self):
-        bundle = DummyKPICalculatorBundle()
+        bundle = DummyKPICalculatorBundle(mock.Mock(spec=Plugin))
         self.assertEqual(bundle.id, 'foo')
         self.assertEqual(bundle.name, 'bar')

--- a/force_bdss/mco/base_mco.py
+++ b/force_bdss/mco/base_mco.py
@@ -2,8 +2,6 @@ import abc
 
 from traits.api import ABCHasStrictTraits, Instance
 
-from ..bdss_application import BDSSApplication
-from .base_mco_model import BaseMCOModel
 from .i_mco_bundle import IMCOBundle
 
 
@@ -14,18 +12,12 @@ class BaseMCO(ABCHasStrictTraits):
     """
     #: A reference to the bundle
     bundle = Instance(IMCOBundle)
-    #: A reference to the application
-    application = Instance(BDSSApplication)
-    #: A reference to the model class
-    model = Instance(BaseMCOModel)
 
-    def __init__(self, bundle, application, model, *args, **kwargs):
+    def __init__(self, bundle, *args, **kwargs):
         self.bundle = bundle
-        self.application = application
-        self.model = model
         super(BaseMCO, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
-    def run(self):
+    def run(self, model):
         """Reimplement this method to perform the MCO operations."""
         pass

--- a/force_bdss/mco/base_mco.py
+++ b/force_bdss/mco/base_mco.py
@@ -14,10 +14,24 @@ class BaseMCO(ABCHasStrictTraits):
     bundle = Instance(IMCOBundle)
 
     def __init__(self, bundle, *args, **kwargs):
+        """Initializes the MCO.
+
+        Parameters
+        ----------
+        bundle: BaseMCOBundle
+            The bundle this BaseMCO belongs to
+        """
         self.bundle = bundle
         super(BaseMCO, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
     def run(self, model):
-        """Reimplement this method to perform the MCO operations."""
-        pass
+        """Performs the actual MCO operations.
+        Reimplement this method to tailor to your MCO.
+
+        Parameters
+        ----------
+        model: BaseMCOModel
+            An instance of the model information, as created from
+            create_model()
+        """

--- a/force_bdss/mco/base_mco_bundle.py
+++ b/force_bdss/mco/base_mco_bundle.py
@@ -19,6 +19,7 @@ class BaseMCOBundle(ABCHasStrictTraits):
     #: A user friendly name of the bundle. Spaces allowed.
     name = String()
 
+    #: A reference to the Plugin that holds this bundle.
     plugin = Instance(Plugin)
 
     def __init__(self, plugin, *args, **kwargs):
@@ -30,14 +31,6 @@ class BaseMCOBundle(ABCHasStrictTraits):
         """Factory method.
         Creates the optimizer with the given application
         and model and returns it to the caller.
-
-        Parameters
-        ----------
-        application: Application
-            The envisage application instance
-        model: BaseMCOModel
-            The model to associate to the optimizer, instantiated through
-            create_model()
 
         Returns
         -------
@@ -70,11 +63,8 @@ class BaseMCOBundle(ABCHasStrictTraits):
         """Factory method. Returns the communicator class that allows
         exchange between the MCO and the evaluator code.
 
-        Parameters
-        ----------
-        application: Application
-            The envisage application instance
-        model: BaseMCOModel
-            The model to associate to the optimizer, instantiated through
-            create_model()
+        Returns
+        -------
+        BaseMCOCommunicator
+            An instance of the communicator
         """

--- a/force_bdss/mco/base_mco_bundle.py
+++ b/force_bdss/mco/base_mco_bundle.py
@@ -1,9 +1,9 @@
 import abc
 
-from traits.api import ABCHasStrictTraits, String
-from traits.has_traits import provides
+from traits.api import ABCHasStrictTraits, String, provides, Instance
+from envisage.plugin import Plugin
 
-from force_bdss.mco.i_mco_bundle import IMCOBundle
+from .i_mco_bundle import IMCOBundle
 
 
 @provides(IMCOBundle)
@@ -19,8 +19,14 @@ class BaseMCOBundle(ABCHasStrictTraits):
     #: A user friendly name of the bundle. Spaces allowed.
     name = String()
 
+    plugin = Instance(Plugin)
+
+    def __init__(self, plugin, *args, **kwargs):
+        self.plugin = plugin
+        super(BaseMCOBundle, self).__init__(*args, **kwargs)
+
     @abc.abstractmethod
-    def create_optimizer(self, application, model):
+    def create_optimizer(self):
         """Factory method.
         Creates the optimizer with the given application
         and model and returns it to the caller.
@@ -60,7 +66,7 @@ class BaseMCOBundle(ABCHasStrictTraits):
         """
 
     @abc.abstractmethod
-    def create_communicator(self, application, model):
+    def create_communicator(self):
         """Factory method. Returns the communicator class that allows
         exchange between the MCO and the evaluator code.
 

--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -20,18 +20,12 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
     """
     #: A reference to the bundle
     bundle = Instance(IMCOBundle)
-    #: A reference to the application
-    application = Instance(BDSSApplication)
-    #: A reference to the model class
-    model = Instance(BaseMCOModel)
 
-    def __init__(self, bundle, application, model):
+    def __init__(self, bundle):
         self.bundle = bundle
-        self.application = application
-        self.model = model
 
     @abc.abstractmethod
-    def receive_from_mco(self):
+    def receive_from_mco(self, model):
         """
         Receives the parameters from the MCO.
         The conversion is specific to the format of the communication
@@ -48,7 +42,7 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
         """
 
     @abc.abstractmethod
-    def send_to_mco(self, kpi_results):
+    def send_to_mco(self, model, kpi_results):
         """Send the KPI results from the evaluation to the MCO
         Must be reimplemented to perform the conversion between the
         two formats. This is of course dependent on the specifics of the

--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -32,6 +32,11 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
         Must return a single DataSourceParameters object, containing
         the parameters as passed by the MCO.
 
+        Parameters
+        ----------
+        model: BaseMCOModel
+            The model of the optimizer, instantiated through create_model()
+
         Returns
         -------
         DataSourceParameters
@@ -48,6 +53,9 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
 
         Parameters
         ----------
+        model: BaseMCOModel
+            The model of the optimizer, instantiated through create_model()
+
         kpi_results: List(KPICalculatorResult)
             A list of KPI calculator results, one per each KPI calculator.
         """

--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -2,8 +2,6 @@ import abc
 
 from traits.api import ABCHasStrictTraits, Instance
 
-from .base_mco_model import BaseMCOModel
-from ..bdss_application import BDSSApplication
 from .i_mco_bundle import IMCOBundle
 
 

--- a/force_bdss/mco/i_mco_bundle.py
+++ b/force_bdss/mco/i_mco_bundle.py
@@ -15,10 +15,10 @@ class IMCOBundle(Interface):
     plugin = Instance(Plugin)
 
     def create_optimizer(self):
-        pass
+        """"""
 
     def create_model(self, model_data=None):
-        pass
+        """"""
 
     def create_communicator(self):
-        pass
+        """"""

--- a/force_bdss/mco/i_mco_bundle.py
+++ b/force_bdss/mco/i_mco_bundle.py
@@ -9,11 +9,11 @@ class IMCOBundle(Interface):
 
     name = String()
 
-    def create_optimizer(self, application, model):
+    def create_optimizer(self):
         pass
 
     def create_model(self, model_data=None):
         pass
 
-    def create_communicator(self, application, model):
+    def create_communicator(self):
         pass

--- a/force_bdss/mco/i_mco_bundle.py
+++ b/force_bdss/mco/i_mco_bundle.py
@@ -1,4 +1,5 @@
-from traits.api import Interface, String
+from traits.api import Interface, String, Instance
+from envisage.plugin import Plugin
 
 
 class IMCOBundle(Interface):
@@ -8,6 +9,8 @@ class IMCOBundle(Interface):
     id = String()
 
     name = String()
+
+    plugin = Instance(Plugin)
 
     def create_optimizer(self):
         pass

--- a/force_bdss/mco/i_mco_bundle.py
+++ b/force_bdss/mco/i_mco_bundle.py
@@ -3,8 +3,10 @@ from envisage.plugin import Plugin
 
 
 class IMCOBundle(Interface):
-    """Interface for the MultiCriteria Optimizer bundle.
+    """Interface for the BaseMCOBundle.
     You should not need it, as its main use is for envisage support.
+
+    Refer to BaseMCOBundle for documentation
     """
     id = String()
 

--- a/force_bdss/mco/tests/test_base_mco.py
+++ b/force_bdss/mco/tests/test_base_mco.py
@@ -1,6 +1,5 @@
 import unittest
 
-from force_bdss.mco.base_mco_model import BaseMCOModel
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.mco.i_mco_bundle import IMCOBundle
 
@@ -9,21 +8,15 @@ try:
 except ImportError:
     from unittest import mock
 
-from force_bdss.bdss_application import BDSSApplication
-
 
 class DummyMCO(BaseMCO):
-    def run(self, *args, **kwargs):
+    def run(self, model, *args, **kwargs):
         pass
 
 
 class TestBaseMultiCriteriaOptimizer(unittest.TestCase):
     def test_initialization(self):
         bundle = mock.Mock(spec=IMCOBundle)
-        application = mock.Mock(spec=BDSSApplication)
-        model = mock.Mock(spec=BaseMCOModel)
-        mco = DummyMCO(bundle, application, model)
+        mco = DummyMCO(bundle)
 
         self.assertEqual(mco.bundle, bundle)
-        self.assertEqual(mco.application, application)
-        self.assertEqual(mco.model, model)

--- a/force_bdss/mco/tests/test_base_mco_bundle.py
+++ b/force_bdss/mco/tests/test_base_mco_bundle.py
@@ -1,5 +1,12 @@
 import unittest
 
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from envisage.plugin import Plugin
+
 from force_bdss.mco.base_mco_bundle import BaseMCOBundle
 
 
@@ -8,18 +15,18 @@ class DummyMCOBundle(BaseMCOBundle):
 
     name = "bar"
 
-    def create_optimizer(self, application, model):
+    def create_optimizer(self):
         pass
 
     def create_model(self, model_data=None):
         pass
 
-    def create_communicator(self, application, model):
+    def create_communicator(self):
         pass
 
 
 class TestBaseMCOBundle(unittest.TestCase):
     def test_initialization(self):
-        bundle = DummyMCOBundle()
+        bundle = DummyMCOBundle(mock.Mock(spec=Plugin))
         self.assertEqual(bundle.id, 'foo')
         self.assertEqual(bundle.name, 'bar')

--- a/force_bdss/mco/tests/test_base_mco_communicator.py
+++ b/force_bdss/mco/tests/test_base_mco_communicator.py
@@ -1,7 +1,6 @@
 import unittest
 
 from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
-from force_bdss.mco.base_mco_model import BaseMCOModel
 from force_bdss.mco.i_mco_bundle import IMCOBundle
 
 try:
@@ -9,24 +8,18 @@ try:
 except ImportError:
     from unittest import mock
 
-from force_bdss.bdss_application import BDSSApplication
-
 
 class DummyMCOCommunicator(BaseMCOCommunicator):
-    def receive_from_mco(self):
+    def receive_from_mco(self, model):
         pass
 
-    def send_to_mco(self, kpi_results):
+    def send_to_mco(self, model, kpi_results):
         pass
 
 
 class TestBaseMCOCommunicator(unittest.TestCase):
     def test_initialization(self):
         bundle = mock.Mock(spec=IMCOBundle)
-        application = mock.Mock(spec=BDSSApplication)
-        model = mock.Mock(spec=BaseMCOModel)
-        mcocomm = DummyMCOCommunicator(bundle, application, model)
+        mcocomm = DummyMCOCommunicator(bundle)
 
         self.assertEqual(mcocomm.bundle, bundle)
-        self.assertEqual(mcocomm.application, application)
-        self.assertEqual(mcocomm.model, model)

--- a/force_bdss/tests/test_core_evaluation_driver.py
+++ b/force_bdss/tests/test_core_evaluation_driver.py
@@ -1,0 +1,114 @@
+import unittest
+
+from force_bdss.bundle_registry_plugin import BundleRegistryPlugin
+from force_bdss.data_sources.base_data_source import BaseDataSource
+from force_bdss.data_sources.base_data_source_bundle import \
+    BaseDataSourceBundle
+from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
+from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
+from force_bdss.kpi.base_kpi_calculator_bundle import BaseKPICalculatorBundle
+from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
+from force_bdss.mco.base_mco import BaseMCO
+from force_bdss.mco.base_mco_bundle import BaseMCOBundle
+from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
+from force_bdss.mco.base_mco_model import BaseMCOModel
+from force_bdss.tests import fixtures
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from envisage.api import Application
+
+from force_bdss.core_evaluation_driver import CoreEvaluationDriver
+
+
+class NullMCOModel(BaseMCOModel):
+    pass
+
+
+class NullMCO(BaseMCO):
+    def run(self, model):
+        pass
+
+
+class NullMCOCommunicator(BaseMCOCommunicator):
+    def send_to_mco(self, model, kpi_results):
+        pass
+
+    def receive_from_mco(self, model):
+        pass
+
+
+class NullMCOBundle(BaseMCOBundle):
+    def create_model(self, model_data=None):
+        return NullMCOModel(self)
+
+    def create_communicator(self):
+        return NullMCOCommunicator(self)
+
+    def create_optimizer(self):
+        return NullMCO(self)
+
+
+class NullKPICalculatorModel(BaseKPICalculatorModel):
+    pass
+
+
+class NullKPICalculator(BaseKPICalculator):
+    def run(self, model, data_source_results):
+        pass
+
+
+class NullKPICalculatorBundle(BaseKPICalculatorBundle):
+    def create_model(self, model_data=None):
+        return NullKPICalculatorModel(self)
+
+    def create_kpi_calculator(self):
+        return NullKPICalculator(self)
+
+
+class NullDataSourceModel(BaseDataSourceModel):
+    pass
+
+
+class NullDataSource(BaseDataSource):
+    def run(self, model, parameters):
+        pass
+
+
+class NullDataSourceBundle(BaseDataSourceBundle):
+    def create_model(self, model_data=None):
+        return NullDataSourceModel(self)
+
+    def create_data_source(self):
+        return NullDataSource(self)
+
+
+def mock_bundle_registry_plugin():
+    bundle_registry_plugin = mock.Mock(spec=BundleRegistryPlugin)
+    bundle_registry_plugin.mco_bundle_by_id = mock.Mock(
+        return_value=NullMCOBundle(bundle_registry_plugin))
+    bundle_registry_plugin.kpi_calculator_bundle_by_id = mock.Mock(
+        return_value=NullKPICalculatorBundle(bundle_registry_plugin))
+    bundle_registry_plugin.data_source_bundle_by_id = mock.Mock(
+        return_value=NullDataSourceBundle(bundle_registry_plugin))
+    return bundle_registry_plugin
+
+
+class TestCoreEvaluationDriver(unittest.TestCase):
+    def setUp(self):
+        self.mock_bundle_registry_plugin = mock_bundle_registry_plugin()
+        application = mock.Mock(spec=Application)
+        application.get_plugin = mock.Mock(
+            return_value=self.mock_bundle_registry_plugin
+        )
+        application.workflow_filepath = fixtures.get("test_csv.json")
+        self.mock_application = application
+
+    def test_initialization(self):
+        driver = CoreEvaluationDriver(
+            application=self.mock_application,
+        )
+        driver.application_started()


### PR DESCRIPTION
Removed application and model from the bundles. The application is still available by traversing the plugin, which is now available and initialized. The model must be passed appropriately to the methods of the created classes.
