### PR TITLE
Fixes docs that for some reason decided to revert to non-escaped underscores.

### DIFF
--- a/doc/source/api/force_bdss.cli.rst
+++ b/doc/source/api/force_bdss.cli.rst
@@ -1,5 +1,5 @@
-force\_bdss\.cli package
-========================
+force_bdss.cli package
+======================
 
 Subpackages
 -----------
@@ -11,8 +11,8 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.cli\.force\_bdss module
-------------------------------------
+force_bdss.cli.force_bdss module
+--------------------------------
 
 .. automodule:: force_bdss.cli.force_bdss
     :members:

--- a/doc/source/api/force_bdss.cli.tests.rst
+++ b/doc/source/api/force_bdss.cli.tests.rst
@@ -1,11 +1,11 @@
-force\_bdss\.cli\.tests package
-===============================
+force_bdss.cli.tests package
+============================
 
 Submodules
 ----------
 
-force\_bdss\.cli\.tests\.test\_execution module
------------------------------------------------
+force_bdss.cli.tests.test_execution module
+------------------------------------------
 
 .. automodule:: force_bdss.cli.tests.test_execution
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor package
-=========================================================
+force_bdss.core_plugins.dummy.csv_extractor package
+===================================================
 
 Subpackages
 -----------
@@ -11,24 +11,24 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_bundle module
---------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_bundle module
+-----------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_data\_source module
---------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source module
+----------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.csv\_extractor\_model module
--------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.csv_extractor.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests package
-================================================================
+force_bdss.core_plugins.dummy.csv_extractor.tests package
+=========================================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests\.test\_csv\_extractor\_bundle module
----------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_bundle module
+----------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.csv\_extractor\.tests\.test\_csv\_extractor\_data\_source module
----------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_data_source module
+---------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.csv_extractor.tests.test_csv_extractor_data_source
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota package
-========================================================
+force_bdss.core_plugins.dummy.dummy_dakota package
+==================================================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_bundle module
------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle module
+---------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_communicator module
------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.dakota_communicator module
+---------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_model module
-----------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.dakota_model module
+--------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.dakota\_optimizer module
---------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer module
+------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.dakota_optimizer
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_dakota.tests.rst
@@ -1,21 +1,29 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests package
-===============================================================
+force_bdss.core_plugins.dummy.dummy_dakota.tests package
+========================================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests\.test\_dakota\_bundle module
-------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_bundle module
+--------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_dakota\.tests\.test\_dakota\_communicator module
-------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_communicator module
+--------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_communicator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_optimizer module
+-----------------------------------------------------------------------------
+
+.. automodule:: force_bdss.core_plugins.dummy.dummy_dakota.tests.test_dakota_optimizer
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source package
-==============================================================
+force_bdss.core_plugins.dummy.dummy_data_source package
+=======================================================
 
 Subpackages
 -----------
@@ -11,24 +11,24 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source module
-----------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source module
+------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source\_bundle module
-------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_bundle module
+-------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.dummy\_data\_source\_model module
------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model module
+------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.dummy_data_source_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_data_source.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests package
-=====================================================================
+force_bdss.core_plugins.dummy.dummy_data_source.tests package
+=============================================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests\.test\_dummy\_data\_source module
------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source module
+-----------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_data\_source\.tests\.test\_dummy\_data\_source\_bundle module
--------------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source_bundle module
+------------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_data_source.tests.test_dummy_data_source_bundle
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator package
-=================================================================
+force_bdss.core_plugins.dummy.dummy_kpi_calculator package
+==========================================================
 
 Subpackages
 -----------
@@ -11,24 +11,24 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator module
-----------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator module
+------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator\_bundle module
-------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_bundle module
+-------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.dummy\_kpi\_calculator\_model module
------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_model module
+------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.dummy_kpi_calculator_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.rst
@@ -1,11 +1,11 @@
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.tests package
-========================================================================
+force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests package
+================================================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_kpi\_calculator\.tests\.test\_dummy\_kpi\_calculator\_bundle module
--------------------------------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.test_dummy_kpi_calculator_bundle module
+------------------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_kpi_calculator.tests.test_dummy_kpi_calculator_bundle
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder package
-=====================================================
+force_bdss.core_plugins.dummy.kpi_adder package
+===============================================
 
 Subpackages
 -----------
@@ -11,24 +11,24 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_bundle module
-------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_bundle module
+---------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_calculator module
-----------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_calculator module
+-------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.kpi\_adder\_model module
------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_model module
+--------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.kpi_adder_model
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.kpi_adder.tests.rst
@@ -1,11 +1,11 @@
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.tests package
-============================================================
+force_bdss.core_plugins.dummy.kpi_adder.tests package
+=====================================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.kpi\_adder\.tests\.test\_kpi\_adder\_bundle module
--------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.kpi_adder.tests.test_kpi_adder_bundle module
+--------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.kpi_adder.tests.test_kpi_adder_bundle
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins\.dummy package
-=========================================
+force_bdss.core_plugins.dummy package
+=====================================
 
 Subpackages
 -----------
@@ -16,8 +16,8 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.dummy\_plugin module
--------------------------------------------------------
+force_bdss.core_plugins.dummy.dummy_plugin module
+-------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.dummy_plugin
     :members:

--- a/doc/source/api/force_bdss.core_plugins.dummy.tests.rst
+++ b/doc/source/api/force_bdss.core_plugins.dummy.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.core\_plugins\.dummy\.tests package
-================================================
+force_bdss.core_plugins.dummy.tests package
+===========================================
 
 Submodules
 ----------
 
-force\_bdss\.core\_plugins\.dummy\.tests\.data\_source\_bundle\_test\_mixin module
-----------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.tests.data_source_bundle_test_mixin module
+------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.tests.data_source_bundle_test_mixin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_plugins\.dummy\.tests\.kpi\_calculator\_bundle\_test\_mixin module
--------------------------------------------------------------------------------------
+force_bdss.core_plugins.dummy.tests.kpi_calculator_bundle_test_mixin module
+---------------------------------------------------------------------------
 
 .. automodule:: force_bdss.core_plugins.dummy.tests.kpi_calculator_bundle_test_mixin
     :members:

--- a/doc/source/api/force_bdss.core_plugins.rst
+++ b/doc/source/api/force_bdss.core_plugins.rst
@@ -1,5 +1,5 @@
-force\_bdss\.core\_plugins package
-==================================
+force_bdss.core_plugins package
+===============================
 
 Subpackages
 -----------

--- a/doc/source/api/force_bdss.data_sources.rst
+++ b/doc/source/api/force_bdss.data_sources.rst
@@ -1,5 +1,5 @@
-force\_bdss\.data\_sources package
-==================================
+force_bdss.data_sources package
+===============================
 
 Subpackages
 -----------
@@ -11,48 +11,48 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.data\_sources\.base\_data\_source module
------------------------------------------------------
+force_bdss.data_sources.base_data_source module
+-----------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.base\_data\_source\_bundle module
--------------------------------------------------------------
+force_bdss.data_sources.base_data_source_bundle module
+------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.base\_data\_source\_model module
-------------------------------------------------------------
+force_bdss.data_sources.base_data_source_model module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.data\_source\_parameters module
------------------------------------------------------------
+force_bdss.data_sources.data_source_parameters module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.data_source_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.data\_source\_result module
--------------------------------------------------------
+force_bdss.data_sources.data_source_result module
+-------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.data_source_result
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.i\_data\_source\_bundle module
-----------------------------------------------------------
+force_bdss.data_sources.i_data_source_bundle module
+---------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.i_data_source_bundle
     :members:

--- a/doc/source/api/force_bdss.data_sources.tests.rst
+++ b/doc/source/api/force_bdss.data_sources.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.data\_sources\.tests package
-=========================================
+force_bdss.data_sources.tests package
+=====================================
 
 Submodules
 ----------
 
-force\_bdss\.data\_sources\.tests\.test\_base\_data\_source module
-------------------------------------------------------------------
+force_bdss.data_sources.tests.test_base_data_source module
+----------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.data\_sources\.tests\.test\_base\_data\_source\_bundle module
---------------------------------------------------------------------------
+force_bdss.data_sources.tests.test_base_data_source_bundle module
+-----------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source_bundle
     :members:

--- a/doc/source/api/force_bdss.io.rst
+++ b/doc/source/api/force_bdss.io.rst
@@ -1,5 +1,5 @@
-force\_bdss\.io package
-=======================
+force_bdss.io package
+=====================
 
 Subpackages
 -----------
@@ -11,16 +11,16 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.io\.workflow\_reader module
-----------------------------------------
+force_bdss.io.workflow_reader module
+------------------------------------
 
 .. automodule:: force_bdss.io.workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.io\.workflow\_writer module
-----------------------------------------
+force_bdss.io.workflow_writer module
+------------------------------------
 
 .. automodule:: force_bdss.io.workflow_writer
     :members:

--- a/doc/source/api/force_bdss.io.tests.rst
+++ b/doc/source/api/force_bdss.io.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.io\.tests package
-==============================
+force_bdss.io.tests package
+===========================
 
 Submodules
 ----------
 
-force\_bdss\.io\.tests\.test\_workflow\_reader module
------------------------------------------------------
+force_bdss.io.tests.test_workflow_reader module
+-----------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.io\.tests\.test\_workflow\_writer module
------------------------------------------------------
+force_bdss.io.tests.test_workflow_writer module
+-----------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_writer
     :members:

--- a/doc/source/api/force_bdss.kpi.rst
+++ b/doc/source/api/force_bdss.kpi.rst
@@ -1,5 +1,5 @@
-force\_bdss\.kpi package
-========================
+force_bdss.kpi package
+======================
 
 Subpackages
 -----------
@@ -11,40 +11,40 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.kpi\.base\_kpi\_calculator module
-----------------------------------------------
+force_bdss.kpi.base_kpi_calculator module
+-----------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.kpi\.base\_kpi\_calculator\_bundle module
-------------------------------------------------------
+force_bdss.kpi.base_kpi_calculator_bundle module
+------------------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.kpi\.base\_kpi\_calculator\_model module
------------------------------------------------------
+force_bdss.kpi.base_kpi_calculator_model module
+-----------------------------------------------
 
 .. automodule:: force_bdss.kpi.base_kpi_calculator_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.kpi\.i\_kpi\_calculator\_bundle module
----------------------------------------------------
+force_bdss.kpi.i_kpi_calculator_bundle module
+---------------------------------------------
 
 .. automodule:: force_bdss.kpi.i_kpi_calculator_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.kpi\.kpi\_calculator\_result module
-------------------------------------------------
+force_bdss.kpi.kpi_calculator_result module
+-------------------------------------------
 
 .. automodule:: force_bdss.kpi.kpi_calculator_result
     :members:

--- a/doc/source/api/force_bdss.kpi.tests.rst
+++ b/doc/source/api/force_bdss.kpi.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss\.kpi\.tests package
-===============================
+force_bdss.kpi.tests package
+============================
 
 Submodules
 ----------
 
-force\_bdss\.kpi\.tests\.test\_base\_kpi\_calculator module
------------------------------------------------------------
+force_bdss.kpi.tests.test_base_kpi_calculator module
+----------------------------------------------------
 
 .. automodule:: force_bdss.kpi.tests.test_base_kpi_calculator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.kpi\.tests\.test\_base\_kpi\_calculator\_bundle module
--------------------------------------------------------------------
+force_bdss.kpi.tests.test_base_kpi_calculator_bundle module
+-----------------------------------------------------------
 
 .. automodule:: force_bdss.kpi.tests.test_base_kpi_calculator_bundle
     :members:

--- a/doc/source/api/force_bdss.mco.parameters.rst
+++ b/doc/source/api/force_bdss.mco.parameters.rst
@@ -1,5 +1,5 @@
-force\_bdss\.mco\.parameters package
-====================================
+force_bdss.mco.parameters package
+=================================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.mco\.parameters\.base\_mco\_parameter module
----------------------------------------------------------
+force_bdss.mco.parameters.base_mco_parameter module
+---------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.base\_mco\_parameter\_factory module
-------------------------------------------------------------------
+force_bdss.mco.parameters.base_mco_parameter_factory module
+-----------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.core\_mco\_parameters module
-----------------------------------------------------------
+force_bdss.mco.parameters.core_mco_parameters module
+----------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.core_mco_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.mco\_parameter\_factory\_registry module
-----------------------------------------------------------------------
+force_bdss.mco.parameters.mco_parameter_factory_registry module
+---------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.mco_parameter_factory_registry
     :members:

--- a/doc/source/api/force_bdss.mco.parameters.tests.rst
+++ b/doc/source/api/force_bdss.mco.parameters.tests.rst
@@ -1,35 +1,35 @@
-force\_bdss\.mco\.parameters\.tests package
-===========================================
+force_bdss.mco.parameters.tests package
+=======================================
 
 Submodules
 ----------
 
-force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter module
-----------------------------------------------------------------------
+force_bdss.mco.parameters.tests.test_base_mco_parameter module
+--------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter\_factory module
--------------------------------------------------------------------------------
+force_bdss.mco.parameters.tests.test_base_mco_parameter_factory module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.tests\.test\_core\_mco\_parameters module
------------------------------------------------------------------------
+force_bdss.mco.parameters.tests.test_core_mco_parameters module
+---------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_core_mco_parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.parameters\.tests\.test\_parameter\_factory\_registry module
-------------------------------------------------------------------------------
+force_bdss.mco.parameters.tests.test_parameter_factory_registry module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_parameter_factory_registry
     :members:

--- a/doc/source/api/force_bdss.mco.rst
+++ b/doc/source/api/force_bdss.mco.rst
@@ -1,5 +1,5 @@
-force\_bdss\.mco package
-========================
+force_bdss.mco package
+======================
 
 Subpackages
 -----------
@@ -12,40 +12,40 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.mco\.base\_mco module
-----------------------------------
+force_bdss.mco.base_mco module
+------------------------------
 
 .. automodule:: force_bdss.mco.base_mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.base\_mco\_bundle module
-------------------------------------------
+force_bdss.mco.base_mco_bundle module
+-------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.base\_mco\_communicator module
-------------------------------------------------
+force_bdss.mco.base_mco_communicator module
+-------------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.base\_mco\_model module
------------------------------------------
+force_bdss.mco.base_mco_model module
+------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.i\_mco\_bundle module
----------------------------------------
+force_bdss.mco.i_mco_bundle module
+----------------------------------
 
 .. automodule:: force_bdss.mco.i_mco_bundle
     :members:

--- a/doc/source/api/force_bdss.mco.tests.rst
+++ b/doc/source/api/force_bdss.mco.tests.rst
@@ -1,27 +1,27 @@
-force\_bdss\.mco\.tests package
-===============================
+force_bdss.mco.tests package
+============================
 
 Submodules
 ----------
 
-force\_bdss\.mco\.tests\.test\_base\_mco module
------------------------------------------------
+force_bdss.mco.tests.test_base_mco module
+-----------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.tests\.test\_base\_mco\_bundle module
--------------------------------------------------------
+force_bdss.mco.tests.test_base_mco_bundle module
+------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_bundle
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.mco\.tests\.test\_base\_mco\_communicator module
--------------------------------------------------------------
+force_bdss.mco.tests.test_base_mco_communicator module
+------------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_communicator
     :members:

--- a/doc/source/api/force_bdss.rst
+++ b/doc/source/api/force_bdss.rst
@@ -1,5 +1,5 @@
-force\_bdss package
-===================
+force_bdss package
+==================
 
 Subpackages
 -----------
@@ -18,66 +18,74 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.api module
------------------------
+force_bdss.api module
+---------------------
 
 .. automodule:: force_bdss.api
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.base\_core\_driver module
---------------------------------------
+force_bdss.base_core_driver module
+----------------------------------
 
 .. automodule:: force_bdss.base_core_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.base\_extension\_plugin module
--------------------------------------------
+force_bdss.base_extension_plugin module
+---------------------------------------
 
 .. automodule:: force_bdss.base_extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.bdss\_application module
--------------------------------------
+force_bdss.bdss_application module
+----------------------------------
 
 .. automodule:: force_bdss.bdss_application
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.bundle\_registry\_plugin module
---------------------------------------------
+force_bdss.bundle_registry_plugin module
+----------------------------------------
 
 .. automodule:: force_bdss.bundle_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_evaluation\_driver module
---------------------------------------------
+force_bdss.core_evaluation_driver module
+----------------------------------------
 
 .. automodule:: force_bdss.core_evaluation_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.core\_mco\_driver module
--------------------------------------
+force_bdss.core_mco_driver module
+---------------------------------
 
 .. automodule:: force_bdss.core_mco_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.ids module
------------------------
+force_bdss.ids module
+---------------------
 
 .. automodule:: force_bdss.ids
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force_bdss.version module
+-------------------------
+
+.. automodule:: force_bdss.version
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.tests.fixtures.rst
+++ b/doc/source/api/force_bdss.tests.fixtures.rst
@@ -1,5 +1,5 @@
-force\_bdss\.tests\.fixtures package
-====================================
+force_bdss.tests.fixtures package
+=================================
 
 Module contents
 ---------------

--- a/doc/source/api/force_bdss.tests.rst
+++ b/doc/source/api/force_bdss.tests.rst
@@ -1,5 +1,5 @@
-force\_bdss\.tests package
-==========================
+force_bdss.tests package
+========================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss\.tests\.test\_bdss\_application module
---------------------------------------------------
+force_bdss.tests.test_bdss_application module
+---------------------------------------------
 
 .. automodule:: force_bdss.tests.test_bdss_application
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.tests\.test\_bundle\_registry\_plugin module
----------------------------------------------------------
+force_bdss.tests.test_bundle_registry_plugin module
+---------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_bundle_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.tests\.test\_core\_evaluation\_driver module
----------------------------------------------------------
+force_bdss.tests.test_core_evaluation_driver module
+---------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_core_evaluation_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss\.tests\.test\_ids module
-------------------------------------
+force_bdss.tests.test_ids module
+--------------------------------
 
 .. automodule:: force_bdss.tests.test_ids
     :members:

--- a/doc/source/api/force_bdss.workspecs.rst
+++ b/doc/source/api/force_bdss.workspecs.rst
@@ -1,11 +1,11 @@
-force\_bdss\.workspecs package
-==============================
+force_bdss.workspecs package
+============================
 
 Submodules
 ----------
 
-force\_bdss\.workspecs\.workflow module
----------------------------------------
+force_bdss.workspecs.workflow module
+------------------------------------
 
 .. automodule:: force_bdss.workspecs.workflow
     :members:


### PR DESCRIPTION
Titles are now without the underscore, for unknown sphinx reason