### PR TITLE
Hide base attributes of the models for the GUI

### DIFF
--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -19,11 +19,11 @@ class BaseDataSourceModel(ABCHasStrictTraits):
     #: Specifies binding between input slots and source for that value.
     #: Each InputSlotMap instance specifies this information for each of the
     #: slots.
-    input_slot_maps = List(Instance(InputSlotMap))
+    input_slot_maps = List(Instance(InputSlotMap), visible=False)
 
     #: Allows to assign names to the output slots, so that they can be
     #: referenced somewhere else (e.g. the KPICalculators).
-    output_slot_names = List(String())
+    output_slot_names = List(String(), visible=False)
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory

--- a/force_bdss/kpi/base_kpi_calculator_model.py
+++ b/force_bdss/kpi/base_kpi_calculator_model.py
@@ -19,11 +19,11 @@ class BaseKPICalculatorModel(ABCHasStrictTraits):
     #: Specifies binding between input slots and source for that value.
     #: Each InputSlotMap instance specifies this information for each of the
     #: slots.
-    input_slot_maps = List(Instance(InputSlotMap))
+    input_slot_maps = List(Instance(InputSlotMap), visible=False)
 
     #: Allows to assign names to the output slots, so that they can be
     #: referenced somewhere else (e.g. the KPICalculators).
-    output_slot_names = List(String())
+    output_slot_names = List(String(), visible=False)
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -18,7 +18,7 @@ class BaseMCOModel(ABCHasStrictTraits):
                        transient=True)
 
     # A list of the parameters for the MCO
-    parameters = List(BaseMCOParameter)
+    parameters = List(BaseMCOParameter, visible=False)
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory

--- a/force_bdss/mco/parameters/base_mco_parameter.py
+++ b/force_bdss/mco/parameters/base_mco_parameter.py
@@ -14,10 +14,10 @@ class BaseMCOParameter(HasStrictTraits):
     factory = Instance(BaseMCOParameterFactory, visible=False, transient=True)
 
     #: A user defined name for the parameter
-    name = String()
+    name = String(visible=False)
 
     #: A CUBA key describing the type of the parameter
-    type = String()
+    type = String(visible=False)
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory


### PR DESCRIPTION
We don't want the base attributes to be part of the base view, when used in the GUI. We only want to be able to edit the attributes that are defined by the plugin author.
The base attributes will be editable through views defined in `force_wfmanager`, on which we have control.