### PR TITLE
Adds change_slots event to notify UI of slot-modifying changes

### DIFF
--- a/doc/source/plugin_development.rst
+++ b/doc/source/plugin_development.rst
@@ -11,14 +11,29 @@ one of the above pluggable entities and its associated classes.
 To implement a new plugin, you must
 
 - define the entity you want to extend (e.g. ``MyOwnDataSource``) as a derived
-  class of the appropriate class (e.g. BaseDataSource), and reimplement
-  the appropriate methods.
-- Define the model that this DataSource needs, by extending
+  class of the appropriate class (e.g. ``BaseDataSource``), and reimplement
+  the appropriate methods:
+  - ``run()``: where the actual computation takes place, given the
+    configuration options specified in the model (which is received as an
+    argument). It is strongly advised that the ``run()`` method is stateless.
+  - ``slots()``: must return a 2-tuple of tuples. Each tuple contains instances
+    of the ``Slot`` class. Slots are the input and output entities of the
+    data source or KPI calculator. Given that this information depends on the
+    configuration options, ``slots()`` accepts the model and must return the
+    appropriate values according to the model options.
+- Define the model that this ``DataSource`` needs, by extending
   ``BaseDataSourceModel`` and adding, with traits, the appropriate data that
   are required by your data source to perform its task.
+  If a trait change in your model influences the input/output slots, you must
+  make sure that the event ``changes_slots`` is fired as a consequence of
+  those changes. This will notify the UI that the new slots need to be
+  recomputed and presented to the user. Failing to do so will have unexpected
+  consequences.
 - Define the Factory, by reimplementing BaseDataSourceFactory and reimplementing
   its ``create_*`` methods to return the above entities.
 - Define a ``Plugin`` by reimplementing ``BaseExtensionPlugin`` and
   reimplementing its initialization defaults methods to return your factory.
 - add the plugin class in the setup.py entry_point, under the namespace
   ``force.bdss.extensions``
+
+

--- a/doc/source/plugin_development.rst
+++ b/doc/source/plugin_development.rst
@@ -13,14 +13,16 @@ To implement a new plugin, you must
 - define the entity you want to extend (e.g. ``MyOwnDataSource``) as a derived
   class of the appropriate class (e.g. ``BaseDataSource``), and reimplement
   the appropriate methods:
-  - ``run()``: where the actual computation takes place, given the
-    configuration options specified in the model (which is received as an
-    argument). It is strongly advised that the ``run()`` method is stateless.
-  - ``slots()``: must return a 2-tuple of tuples. Each tuple contains instances
-    of the ``Slot`` class. Slots are the input and output entities of the
-    data source or KPI calculator. Given that this information depends on the
-    configuration options, ``slots()`` accepts the model and must return the
-    appropriate values according to the model options.
+
+   - ``run()``: where the actual computation takes place, given the
+     configuration options specified in the model (which is received as an
+     argument). It is strongly advised that the ``run()`` method is stateless.
+   - ``slots()``: must return a 2-tuple of tuples. Each tuple contains instances
+     of the ``Slot`` class. Slots are the input and output entities of the
+     data source or KPI calculator. Given that this information depends on the
+     configuration options, ``slots()`` accepts the model and must return the
+     appropriate values according to the model options.
+
 - Define the model that this ``DataSource`` needs, by extending
   ``BaseDataSourceModel`` and adding, with traits, the appropriate data that
   are required by your data source to perform its task.

--- a/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_model.py
+++ b/force_bdss/core_plugins/dummy/csv_extractor/csv_extractor_model.py
@@ -1,4 +1,4 @@
-from traits.api import Int, String
+from traits.api import Int, String, on_trait_change
 
 from force_bdss.api import BaseDataSourceModel
 
@@ -8,3 +8,7 @@ class CSVExtractorModel(BaseDataSourceModel):
     row = Int()
     column = Int()
     cuba_type = String()
+
+    @on_trait_change("cuba_type")
+    def _notify_changes_slots(self):
+        self.changes_slots = True

--- a/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_model.py
+++ b/force_bdss/core_plugins/dummy/kpi_adder/kpi_adder_model.py
@@ -1,4 +1,4 @@
-from traits.api import String
+from traits.api import String, on_trait_change
 
 from force_bdss.api import BaseKPICalculatorModel
 
@@ -6,3 +6,7 @@ from force_bdss.api import BaseKPICalculatorModel
 class KPIAdderModel(BaseKPICalculatorModel):
     cuba_type_in = String()
     cuba_type_out = String()
+
+    @on_trait_change("cuba_type_in,cuba_type_out")
+    def _notify_slots_changed(self):
+        self.changes_slots = True

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -41,4 +41,3 @@ class BaseDataSourceModel(ABCHasStrictTraits):
             x.__getstate__() for x in self.input_slot_maps
         ]
         return state
-

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -1,4 +1,4 @@
-from traits.api import ABCHasStrictTraits, Instance, List, String
+from traits.api import ABCHasStrictTraits, Instance, List, String, Event
 
 from force_bdss.core.input_slot_map import InputSlotMap
 from .i_data_source_factory import IDataSourceFactory
@@ -25,6 +25,12 @@ class BaseDataSourceModel(ABCHasStrictTraits):
     #: referenced somewhere else (e.g. the KPICalculators).
     output_slot_names = List(String(), visible=False)
 
+    #: This event claims that a change in the model influences the slots
+    #: (either input or output). It must be triggered every time a specific
+    #: option in your model implies a change in the slots. The UI will detect
+    #: this and adapt the visual entries.
+    changes_slots = Event()
+
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory
         super(BaseDataSourceModel, self).__init__(*args, **kwargs)
@@ -35,3 +41,4 @@ class BaseDataSourceModel(ABCHasStrictTraits):
             x.__getstate__() for x in self.input_slot_maps
         ]
         return state
+

--- a/force_bdss/kpi/base_kpi_calculator_model.py
+++ b/force_bdss/kpi/base_kpi_calculator_model.py
@@ -1,4 +1,4 @@
-from traits.api import ABCHasStrictTraits, Instance, List, String
+from traits.api import ABCHasStrictTraits, Instance, List, String, Event
 
 from ..core.input_slot_map import InputSlotMap
 from .i_kpi_calculator_factory import IKPICalculatorFactory
@@ -24,6 +24,12 @@ class BaseKPICalculatorModel(ABCHasStrictTraits):
     #: Allows to assign names to the output slots, so that they can be
     #: referenced somewhere else (e.g. the KPICalculators).
     output_slot_names = List(String(), visible=False)
+
+    #: This event claims that a change in the model influences the slots
+    #: (either input or output). It must be triggered every time a specific
+    #: option in your model implies a change in the slots. The UI will detect
+    #: this and adapt the visual entries.
+    changes_slots = Event()
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory


### PR DESCRIPTION
When the model contains options that might modify the resulting slots,
a notification must be issued, so that the UI can take appropriate action.

Provides that mechanism, and documents it.

Fixes #74 