### PR TITLE
Removed difference in KPI vs DataSource - Step 1

### DIFF
--- a/force_bdss/tests/test_core_evaluation_driver.py
+++ b/force_bdss/tests/test_core_evaluation_driver.py
@@ -228,7 +228,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
             with self.assertRaisesRegexp(
                     RuntimeError,
                     "The number of data values \(1 values\)"
-                    " returned by the DataSource 'null_ds' does not match"
+                    " returned by 'null_ds' does not match"
                     " the number of output slots"):
                 driver.application_started()
 
@@ -243,7 +243,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
             with self.assertRaisesRegexp(
                     RuntimeError,
                     "The number of data values \(1 values\)"
-                    " returned by the DataSource 'null_ds' does not match"
+                    " returned by 'null_ds' does not match"
                     " the number of user-defined names"):
                 driver.application_started()
 
@@ -258,7 +258,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
             with self.assertRaisesRegexp(
                     RuntimeError,
                     "The number of data values \(1 values\)"
-                    " returned by the KPICalculator 'null_kpic' does not match"
+                    " returned by 'null_kpic' does not match"
                     " the number of output slots"):
                 driver.application_started()
 
@@ -273,6 +273,6 @@ class TestCoreEvaluationDriver(unittest.TestCase):
             with self.assertRaisesRegexp(
                     RuntimeError,
                     "The number of data values \(1 values\)"
-                    " returned by the KPICalculator 'null_kpic' does not match"
+                    " returned by 'null_kpic' does not match"
                     " the number of user-defined names"):
                 driver.application_started()


### PR DESCRIPTION
This PR is the first step in uniform handling of data sources and KPI calculators, as they are pretty much equivalent.
The result is that KPI calculators will eventually go away, and we will only have data sources, or a base class and still keep the KPI calculators but just for ease of classification