### PR TITLE
Add CodeEditor datasource [DO NOT MERGE]

### DIFF
--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
@@ -1,0 +1,22 @@
+from force_bdss.api import BaseDataSource, DataValue
+from force_bdss.core.slot import Slot
+
+
+class CodeEditorDataSource(BaseDataSource):
+    def run(self, model, parameters):
+        outputs = [DataValue(type="PRESSURE", value=0)]
+        exec(
+            model.code,
+            {'inputs': parameters, 'outputs': outputs}
+        )
+        return outputs
+
+    def slots(self, model):
+        return (
+            (
+                Slot(type="PRESSURE"),
+            ),
+            (
+                Slot(type="PRESSURE"),
+            )
+        )

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
@@ -1,16 +1,20 @@
+import copy
+
 from force_bdss.api import BaseDataSource, DataValue
 from force_bdss.core.slot import Slot
 
 
 class CodeEditorDataSource(BaseDataSource):
     def run(self, model, parameters):
-        outputs = [DataValue(type="PRESSURE", value=0)
-                   for _ in range(model.nb_outputs)]
+        environment = {param.name: copy.deepcopy(param.value)
+                       for param in parameters}
         exec(
             model.code,
-            {'inputs': parameters, 'outputs': outputs}
+            environment
         )
-        return outputs
+
+        return [DataValue(type="PRESSURE", value=environment[output_name])
+                for output_name in model.output_slot_names]
 
     def slots(self, model):
         return (

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
@@ -4,7 +4,8 @@ from force_bdss.core.slot import Slot
 
 class CodeEditorDataSource(BaseDataSource):
     def run(self, model, parameters):
-        outputs = [DataValue(type="PRESSURE", value=0)]
+        outputs = [DataValue(type="PRESSURE", value=0)
+                   for _ in range(model.nb_outputs)]
         exec(
             model.code,
             {'inputs': parameters, 'outputs': outputs}
@@ -13,10 +14,6 @@ class CodeEditorDataSource(BaseDataSource):
 
     def slots(self, model):
         return (
-            (
-                Slot(type="PRESSURE"),
-            ),
-            (
-                Slot(type="PRESSURE"),
-            )
+            tuple(Slot(type="PRESSURE") for _ in range(model.nb_inputs)),
+            tuple(Slot(type="PRESSURE") for _ in range(model.nb_outputs))
         )

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_data_source.py
@@ -13,11 +13,14 @@ class CodeEditorDataSource(BaseDataSource):
             environment
         )
 
-        return [DataValue(type="PRESSURE", value=environment[output_name])
-                for output_name in model.output_slot_names]
+        return [DataValue(type=output_type, value=environment[output_name])
+                for output_type, output_name
+                in zip(model.output_types, model.output_slot_names)]
 
     def slots(self, model):
         return (
-            tuple(Slot(type="PRESSURE") for _ in range(model.nb_inputs)),
-            tuple(Slot(type="PRESSURE") for _ in range(model.nb_outputs))
+            tuple(Slot(type=model.input_types[i])
+                  for i in range(model.nb_inputs)),
+            tuple(Slot(type=model.output_types[i])
+                  for i in range(model.nb_outputs))
         )

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_factory.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_factory.py
@@ -1,0 +1,21 @@
+from traits.api import String
+
+from force_bdss.api import factory_id, BaseDataSourceFactory
+
+from .code_editor_model import CodeEditorModel
+from .code_editor_data_source import CodeEditorDataSource
+
+
+class CodeEditorFactory(BaseDataSourceFactory):
+    id = String(factory_id("enthought", "code_editor"))
+
+    name = String("Code editor")
+
+    def create_model(self, model_data=None):
+        if model_data is None:
+            model_data = {}
+
+        return CodeEditorModel(self, **model_data)
+
+    def create_data_source(self):
+        return CodeEditorDataSource(self)

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -12,7 +12,7 @@ class CodeEditorModel(BaseDataSourceModel):
     input_types = List(Str)
     output_types = List(Str)
 
-    @on_trait_change('nb_inputs,nb_outputs')
+    @on_trait_change('nb_inputs,nb_outputs', post_init=True)
     def update_slot_sizes(self):
         self.input_types = ['' for _ in range(self.nb_inputs)]
         self.output_types = ['' for _ in range(self.nb_outputs)]

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -39,4 +39,23 @@ class CodeEditorModel(BaseDataSourceModel):
                 show_border=True,
             ),
             Item('code'),
+            buttons=['OK', 'Cancel'],
+        )
+
+    def _code_default(self):
+        return (
+            "# You can import any module you want which is installed in\n "
+            "# your environment:\n"
+            "#\n"
+            "import math\n"
+            "#\n"
+            "# You have access to the input parameters you defined in the\n"
+            "# tree editor of the Workflow (e.g. if you set \"p1\" as an \n"
+            "# input for this data source, you have access to \"p1\" value\n"
+            "# in the scope of this code)\n"
+            "#\n"
+            "# You must set all the values you defined as ouput of this data\n"
+            "# source inside this code (e.g. if you set \"p_out\" as an\n"
+            "# output of this data source, you must set a value for\n"
+            "# \"p_out\" inside of this code\n"
         )

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -14,11 +14,13 @@ class CodeEditorModel(BaseDataSourceModel):
 
     load_button = Button('Load python script')
 
-    @on_trait_change('nb_inputs,nb_outputs', post_init=True)
-    def update_slot_sizes(self):
+    @on_trait_change('nb_inputs', post_init=True)
+    def update_input_slot_sizes(self):
         self.input_types = ['' for _ in range(self.nb_inputs)]
+
+    @on_trait_change('nb_outputs', post_init=True)
+    def update_output_slot_sizes(self):
         self.output_types = ['' for _ in range(self.nb_outputs)]
-        self.changes_slots = True
 
     @on_trait_change('input_types[],output_types[]')
     def update_slot_types(self):

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -1,4 +1,4 @@
-from traits.api import Code, Int, on_trait_change, List, Str
+from traits.api import Code, Int, on_trait_change, List, Str, Button
 
 from force_bdss.api import BaseDataSourceModel
 
@@ -12,6 +12,8 @@ class CodeEditorModel(BaseDataSourceModel):
     input_types = List(Str)
     output_types = List(Str)
 
+    load_button = Button('Load python script')
+
     @on_trait_change('nb_inputs,nb_outputs', post_init=True)
     def update_slot_sizes(self):
         self.input_types = ['' for _ in range(self.nb_inputs)]
@@ -22,8 +24,25 @@ class CodeEditorModel(BaseDataSourceModel):
     def update_slot_types(self):
         self.changes_slots = True
 
+    @on_trait_change('load_button')
+    def load_python_script(self):
+        from pyface.api import FileDialog, OK
+
+        dialog = FileDialog(
+            action="open",
+            wildcard='Python files (*.py)|*.py|'
+        )
+
+        result = dialog.open()
+
+        if result is not OK:
+            return
+
+        with open(dialog.path, 'r') as fobj:
+            self.code = fobj.read()
+
     def default_traits_view(self):
-        from traitsui.api import View, Item, HGroup
+        from traitsui.api import View, Item, UItem, HGroup
 
         return View(
             HGroup(
@@ -38,6 +57,7 @@ class CodeEditorModel(BaseDataSourceModel):
                 label='Outputs',
                 show_border=True,
             ),
+            UItem('load_button'),
             Item('code'),
             buttons=['OK', 'Cancel'],
         )

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -26,7 +26,7 @@ class CodeEditorModel(BaseDataSourceModel):
 
     @on_trait_change('load_button')
     def load_python_script(self):
-        from pyface.api import FileDialog, OK
+        from pyface.api import FileDialog, OK, error
 
         dialog = FileDialog(
             action="open",
@@ -38,8 +38,17 @@ class CodeEditorModel(BaseDataSourceModel):
         if result is not OK:
             return
 
-        with open(dialog.path, 'r') as fobj:
-            self.code = fobj.read()
+        try:
+            with open(dialog.path, 'r') as fobj:
+                self.code = fobj.read()
+        except IOError as e:
+            error(
+                None,
+                "Oups ! Something went wrong when "
+                "opening the file {}: \n{}".format(
+                    dialog.path, str(e)
+                )
+            )
 
     def default_traits_view(self):
         from traitsui.api import View, Item, UItem, HGroup

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -1,7 +1,14 @@
-from traits.api import Code
+from traits.api import Code, Int, on_trait_change
 
 from force_bdss.api import BaseDataSourceModel
 
 
 class CodeEditorModel(BaseDataSourceModel):
     code = Code()
+
+    nb_inputs = Int()
+    nb_outputs = Int()
+
+    @on_trait_change('nb_inputs,nb_outputs')
+    def update_slots(self):
+        self.changes_slots = True

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -1,0 +1,7 @@
+from traits.api import Code
+
+from force_bdss.api import BaseDataSourceModel
+
+
+class CodeEditorModel(BaseDataSourceModel):
+    code = Code()

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -1,4 +1,4 @@
-from traits.api import Code, Int, on_trait_change
+from traits.api import Code, Int, on_trait_change, List, Str
 
 from force_bdss.api import BaseDataSourceModel
 
@@ -9,6 +9,15 @@ class CodeEditorModel(BaseDataSourceModel):
     nb_inputs = Int()
     nb_outputs = Int()
 
+    input_types = List(Str)
+    output_types = List(Str)
+
     @on_trait_change('nb_inputs,nb_outputs')
-    def update_slots(self):
+    def update_slot_sizes(self):
+        self.input_types = ['' for _ in range(self.nb_inputs)]
+        self.output_types = ['' for _ in range(self.nb_outputs)]
+        self.changes_slots = True
+
+    @on_trait_change('input_types[],output_types[]')
+    def update_slot_types(self):
         self.changes_slots = True

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -1,4 +1,4 @@
-from traits.api import Code, Int, on_trait_change, List, Str, Button
+from traits.api import Code, Range, on_trait_change, List, Str, Button
 
 from force_bdss.api import BaseDataSourceModel
 
@@ -6,8 +6,8 @@ from force_bdss.api import BaseDataSourceModel
 class CodeEditorModel(BaseDataSourceModel):
     code = Code()
 
-    nb_inputs = Int()
-    nb_outputs = Int()
+    nb_inputs = Range(value=0, low=0, high=15)
+    nb_outputs = Range(value=0, low=0, high=15)
 
     input_types = List(Str)
     output_types = List(Str)
@@ -57,13 +57,13 @@ class CodeEditorModel(BaseDataSourceModel):
 
         return View(
             HGroup(
-                Item('nb_inputs', label='Number'),
+                Item('nb_inputs', label='Number', style='text'),
                 Item('input_types', label='Types'),
                 label='Inputs',
                 show_border=True,
             ),
             HGroup(
-                Item('nb_outputs', label='Number'),
+                Item('nb_outputs', label='Number', style='text'),
                 Item('output_types', label='Types'),
                 label='Outputs',
                 show_border=True,

--- a/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
+++ b/force_bdss/core_plugins/dummy/code_editor/code_editor_model.py
@@ -21,3 +21,22 @@ class CodeEditorModel(BaseDataSourceModel):
     @on_trait_change('input_types[],output_types[]')
     def update_slot_types(self):
         self.changes_slots = True
+
+    def default_traits_view(self):
+        from traitsui.api import View, Item, HGroup
+
+        return View(
+            HGroup(
+                Item('nb_inputs', label='Number'),
+                Item('input_types', label='Types'),
+                label='Inputs',
+                show_border=True,
+            ),
+            HGroup(
+                Item('nb_outputs', label='Number'),
+                Item('output_types', label='Types'),
+                label='Outputs',
+                show_border=True,
+            ),
+            Item('code'),
+        )

--- a/force_bdss/core_plugins/dummy/dummy_plugin.py
+++ b/force_bdss/core_plugins/dummy/dummy_plugin.py
@@ -4,6 +4,7 @@ from .dummy_notification_listener.dummy_notification_listener_factory import (
 )
 from .csv_extractor.csv_extractor_factory import CSVExtractorFactory
 from .power_evaluator.power_evaluator_factory import PowerEvaluatorFactory
+from .code_editor.code_editor_factory import CodeEditorFactory
 from .kpi_adder.kpi_adder_factory import KPIAdderFactory
 from .dummy_dakota.dakota_factory import DummyDakotaFactory
 from .dummy_data_source.dummy_data_source_factory import DummyDataSourceFactory
@@ -18,7 +19,8 @@ class DummyPlugin(BaseExtensionPlugin):
     def _data_source_factories_default(self):
         return [DummyDataSourceFactory(self),
                 CSVExtractorFactory(self),
-                PowerEvaluatorFactory(self)]
+                PowerEvaluatorFactory(self),
+                CodeEditorFactory(self)]
 
     def _mco_factories_default(self):
         return [DummyDakotaFactory(self)]


### PR DESCRIPTION
This data source allows the user to type python code or load an external python script which define his data source.

This branch must NOT be merged in `force_bdss` master. It will eventually be added to the Enthought plugins when those plugins will be extracted from this repository. It depends on `traitsui` and `pyface`, which shouldn't be the case of the `force_bdss`.
This PR is only here for showing that some work has been done on a CodeEditor plugin, and that it should be moved later to an other repository.