### PR TITLE
Added incorrect calls to base constructor of MCOCommunicator and BaseMCOParameterFactory.

### DIFF
--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -19,8 +19,9 @@ class BaseMCOCommunicator(ABCHasStrictTraits):
     #: A reference to the factory
     factory = Instance(IMCOFactory)
 
-    def __init__(self, factory):
+    def __init__(self, factory, *args, **kwargs):
         self.factory = factory
+        super(BaseMCOCommunicator, self).__init__(*args, **kwargs)
 
     @abc.abstractmethod
     def receive_from_mco(self, model):

--- a/force_bdss/mco/parameters/base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/base_mco_parameter_factory.py
@@ -27,9 +27,9 @@ class BaseMCOParameterFactory(HasStrictTraits):
     # The model class to instantiate when create_model is called.
     model_class = Type('BaseMCOParameter')
 
-    def __init__(self, mco_factory):
+    def __init__(self, mco_factory, *args, **kwargs):
         self.mco_factory = mco_factory
-        super(BaseMCOParameterFactory, self).__init__()
+        super(BaseMCOParameterFactory, self).__init__(*args, **kwargs)
 
     def create_model(self, data_values=None):
         """Creates the instance of the model class and returns it.


### PR DESCRIPTION
1. Call to base constructor was missing in BaseMCOCommunicator. 
2. Passing arguments to BaseMCOParameterFactory was missing.
