### PR TITLE
Introduced interface for FactoryRegistryPlugin

### DIFF
--- a/force_bdss/base_core_driver.py
+++ b/force_bdss/base_core_driver.py
@@ -3,7 +3,7 @@ from traits.trait_types import Instance
 
 from .core.workflow import Workflow
 from .factory_registry_plugin import (
-    FactoryRegistryPlugin,
+    IFactoryRegistryPlugin,
     FACTORY_REGISTRY_PLUGIN_ID
 )
 from .io.workflow_reader import WorkflowReader
@@ -15,7 +15,7 @@ class BaseCoreDriver(Plugin):
     """
 
     #: The registry of the factories
-    factory_registry = Instance(FactoryRegistryPlugin)
+    factory_registry = Instance(IFactoryRegistryPlugin)
 
     #: Deserialized content of the workflow file.
     workflow = Instance(Workflow)

--- a/force_bdss/factory_registry_plugin.py
+++ b/force_bdss/factory_registry_plugin.py
@@ -1,6 +1,6 @@
 from envisage.extension_point import ExtensionPoint
 from envisage.plugin import Plugin
-from traits.api import List
+from traits.api import List, Interface, provides
 
 from force_bdss.ids import ExtensionPointID
 from force_bdss.notification_listeners.i_notification_listener_factory import \
@@ -15,6 +15,24 @@ from .ui_hooks.i_ui_hooks_factory import IUIHooksFactory
 FACTORY_REGISTRY_PLUGIN_ID = "force.bdss.plugins.factory_registry"
 
 
+class IFactoryRegistryPlugin(Interface):
+    def data_source_factory_by_id(self, id):
+        pass
+
+    def kpi_calculator_factory_by_id(self, id):
+        pass
+
+    def mco_factory_by_id(self, id):
+        pass
+
+    def mco_parameter_factory_by_id(self, mco_id, parameter_id):
+        pass
+
+    def notification_listener_factory_by_id(self, id):
+        pass
+
+
+@provides(IFactoryRegistryPlugin)
 class FactoryRegistryPlugin(Plugin):
     """Main plugin that handles the execution of the MCO
     or the evaluation.

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -5,7 +5,7 @@ from traits.api import HasStrictTraits, Instance
 
 from force_bdss.core.input_slot_map import InputSlotMap
 from force_bdss.core.workflow import Workflow
-from ..factory_registry_plugin import FactoryRegistryPlugin
+from ..factory_registry_plugin import IFactoryRegistryPlugin
 
 SUPPORTED_FILE_VERSIONS = ["1"]
 
@@ -25,7 +25,7 @@ class WorkflowReader(HasStrictTraits):
     """
     #: The Factory registry. The reader needs it to create the
     #: specific model objects.
-    factory_registry = Instance(FactoryRegistryPlugin)
+    factory_registry = Instance(IFactoryRegistryPlugin)
 
     def __init__(self,
                  factory_registry,

--- a/force_bdss/tests/probe_classes/factory_registry_plugin.py
+++ b/force_bdss/tests/probe_classes/factory_registry_plugin.py
@@ -1,6 +1,6 @@
-from traits.api import List
+from traits.api import List, HasStrictTraits, provides
 
-from force_bdss.factory_registry_plugin import FactoryRegistryPlugin
+from force_bdss.factory_registry_plugin import IFactoryRegistryPlugin
 
 from .mco import ProbeMCOFactory
 from .kpi_calculator import ProbeKPICalculatorFactory
@@ -8,20 +8,58 @@ from .data_source import ProbeDataSourceFactory
 from .notification_listener import ProbeNotificationListenerFactory
 
 
-class ProbeFactoryRegistryPlugin(FactoryRegistryPlugin):
+@provides(IFactoryRegistryPlugin)
+class ProbeFactoryRegistryPlugin(HasStrictTraits):
     mco_factories = List()
     kpi_calculator_factories = List()
     data_source_factories = List()
     notification_listener_factories = List()
 
     def _mco_factories_default(self):
-        return [ProbeMCOFactory(self)]
+        return [ProbeMCOFactory(None)]
 
     def _kpi_calculator_factories_default(self):
-        return [ProbeKPICalculatorFactory(self)]
+        return [ProbeKPICalculatorFactory(None)]
 
     def _data_source_factories_default(self):
-        return [ProbeDataSourceFactory(self)]
+        return [ProbeDataSourceFactory(None)]
 
     def _notification_listener_factories_default(self):
-        return [ProbeNotificationListenerFactory(self)]
+        return [ProbeNotificationListenerFactory(None)]
+
+    def data_source_factory_by_id(self, id):
+        for ds in self.data_source_factories:
+            if ds.id == id:
+                return ds
+
+        raise KeyError(id)
+
+    def kpi_calculator_factory_by_id(self, id):
+        for kpic in self.kpi_calculator_factories:
+            if kpic.id == id:
+                return kpic
+
+        raise KeyError(id)
+
+    def mco_factory_by_id(self, id):
+        for mco in self.mco_factories:
+            if mco.id == id:
+                return mco
+
+        raise KeyError(id)
+
+    def mco_parameter_factory_by_id(self, mco_id, parameter_id):
+        mco_factory = self.mco_factory_by_id(mco_id)
+
+        for factory in mco_factory.parameter_factories():
+            if factory.id == parameter_id:
+                return factory
+
+        raise KeyError(parameter_id)
+
+    def notification_listener_factory_by_id(self, id):
+        for nl in self.notification_listener_factories:
+            if nl.id == id:
+                return nl
+
+        raise KeyError(id)

--- a/force_bdss/tests/probe_classes/factory_registry_plugin.py
+++ b/force_bdss/tests/probe_classes/factory_registry_plugin.py
@@ -6,6 +6,7 @@ from .mco import ProbeMCOFactory
 from .kpi_calculator import ProbeKPICalculatorFactory
 from .data_source import ProbeDataSourceFactory
 from .notification_listener import ProbeNotificationListenerFactory
+from .ui_hooks import ProbeUIHooksFactory
 
 
 @provides(IFactoryRegistryPlugin)
@@ -14,6 +15,7 @@ class ProbeFactoryRegistryPlugin(HasStrictTraits):
     kpi_calculator_factories = List()
     data_source_factories = List()
     notification_listener_factories = List()
+    ui_hooks_factories = List()
 
     def _mco_factories_default(self):
         return [ProbeMCOFactory(None)]
@@ -26,6 +28,9 @@ class ProbeFactoryRegistryPlugin(HasStrictTraits):
 
     def _notification_listener_factories_default(self):
         return [ProbeNotificationListenerFactory(None)]
+
+    def _ui_hooks_factories_default(self):
+        return [ProbeUIHooksFactory(None)]
 
     def data_source_factory_by_id(self, id):
         for ds in self.data_source_factories:
@@ -63,3 +68,4 @@ class ProbeFactoryRegistryPlugin(HasStrictTraits):
                 return nl
 
         raise KeyError(id)
+

--- a/force_bdss/tests/probe_classes/factory_registry_plugin.py
+++ b/force_bdss/tests/probe_classes/factory_registry_plugin.py
@@ -68,4 +68,3 @@ class ProbeFactoryRegistryPlugin(HasStrictTraits):
                 return nl
 
         raise KeyError(id)
-

--- a/force_bdss/tests/probe_classes/ui_hooks.py
+++ b/force_bdss/tests/probe_classes/ui_hooks.py
@@ -1,0 +1,52 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from envisage.api import Plugin
+
+from traits.api import Bool
+from force_bdss.api import BaseUIHooksFactory, BaseUIHooksManager
+
+
+class ProbeUIHooksManager(BaseUIHooksManager):
+    before_execution_called = Bool()
+    after_execution_called = Bool()
+    before_save_called = Bool()
+
+    # Set this one to raise an exception in the methods
+    before_execution_raises = Bool(False)
+    after_execution_raises = Bool(False)
+    before_save_raises = Bool(False)
+
+    def before_execution(self, task):
+        self.before_execution_called = True
+        if self.before_execution_raises:
+            raise Exception("Boom")
+
+    def after_execution(self, task):
+        self.after_execution_called = True
+        if self.after_execution_raises:
+            raise Exception("Boom")
+
+    def before_save(self, task):
+        self.before_save_called = True
+        if self.before_save_raises:
+            raise Exception("Boom")
+
+
+class ProbeUIHooksFactory(BaseUIHooksFactory):
+    create_ui_hooks_manager_raises = Bool()
+
+    def __init__(self, plugin=None, *args, **kwargs):
+        if plugin is None:
+            plugin = mock.Mock(Plugin)
+
+        super(ProbeUIHooksFactory, self).__init__(
+            plugin=plugin, *args, **kwargs)
+
+    def create_ui_hooks_manager(self):
+        if self.create_ui_hooks_manager_raises:
+            raise Exception("Boom")
+
+        return ProbeUIHooksManager(self)


### PR DESCRIPTION
To simplify testing, we needed to introduce probe classes. The initial approach was to override the FactoryRegistryPlugin and replace the extension points with simple lists, but this turned out not to work.
We therefore introduced an interface, and changed all traits to handle the interface instead of the class.
