### PR TITLE
Introduces fast declaration style for factory

### DIFF
--- a/force_bdss/data_sources/base_data_source.py
+++ b/force_bdss/data_sources/base_data_source.py
@@ -1,5 +1,5 @@
-from traits.api import ABCHasStrictTraits, Instance
 import abc
+from traits.api import ABCHasStrictTraits, Instance
 
 from ..data_sources.i_data_source_factory import IDataSourceFactory
 

--- a/force_bdss/data_sources/base_data_source_factory.py
+++ b/force_bdss/data_sources/base_data_source_factory.py
@@ -1,10 +1,10 @@
 import logging
-from traits.api import ABCHasStrictTraits, provides, String, Instance
+from traits.api import ABCHasStrictTraits, provides, String, Instance, Type
 from envisage.plugin import Plugin
 
 from force_bdss.data_sources.base_data_source import BaseDataSource
 from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
-from .i_data_source_factory import IDataSourceFactory
+from force_bdss.data_sources.i_data_source_factory import IDataSourceFactory
 
 log = logging.getLogger(__name__)
 
@@ -24,12 +24,11 @@ class BaseDataSourceFactory(ABCHasStrictTraits):
     name = String()
 
     #: The data source to be instantiated. Define this to your DataSource
-    data_source_class = Instance(BaseDataSource)
+    data_source_class = Type(BaseDataSource)
 
     #: The model associated to the data source.
     #: Define this to your DataSourceModel
-    model_class = Instance(BaseDataSourceModel)
-
+    model_class = Type(BaseDataSourceModel)
 
     #: Reference to the plugin that carries this factory
     #: This is automatically set by the system. you should not define it

--- a/force_bdss/data_sources/i_data_source_factory.py
+++ b/force_bdss/data_sources/i_data_source_factory.py
@@ -1,9 +1,6 @@
 from envisage.api import Plugin
 from traits.api import Interface, String, Instance, Type
 
-from force_bdss.data_sources.base_data_source import BaseDataSource
-from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
-
 
 class IDataSourceFactory(Interface):
     """Envisage required interface for the BaseDataSourceFactory.
@@ -15,9 +12,13 @@ class IDataSourceFactory(Interface):
 
     name = String()
 
-    data_source_class = Type(BaseDataSource)
+    data_source_class = Type(
+        "force_bdss.data_sources.base_data_source.BaseDataSource"
+    )
 
-    model_class = Type(BaseDataSourceModel)
+    model_class = Type(
+        "force_bdss.data_sources.base_data_source_model.BaseDataSourceModel"
+    )
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/data_sources/i_data_source_factory.py
+++ b/force_bdss/data_sources/i_data_source_factory.py
@@ -1,5 +1,5 @@
 from envisage.api import Plugin
-from traits.api import Interface, String, Instance
+from traits.api import Interface, String, Instance, Type
 
 from force_bdss.data_sources.base_data_source import BaseDataSource
 from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
@@ -15,9 +15,9 @@ class IDataSourceFactory(Interface):
 
     name = String()
 
-    data_source_class = Instance(BaseDataSource)
+    data_source_class = Type(BaseDataSource)
 
-    model_class = Instance(BaseDataSourceModel)
+    model_class = Type(BaseDataSourceModel)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/data_sources/i_data_source_factory.py
+++ b/force_bdss/data_sources/i_data_source_factory.py
@@ -1,6 +1,9 @@
 from envisage.api import Plugin
 from traits.api import Interface, String, Instance
 
+from force_bdss.data_sources.base_data_source import BaseDataSource
+from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
+
 
 class IDataSourceFactory(Interface):
     """Envisage required interface for the BaseDataSourceFactory.
@@ -11,6 +14,10 @@ class IDataSourceFactory(Interface):
     id = String()
 
     name = String()
+
+    data_source_class = Instance(BaseDataSource)
+
+    model_class = Instance(BaseDataSourceModel)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/data_sources/tests/test_base_data_source_factory.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_factory.py
@@ -1,8 +1,15 @@
 import unittest
+
+from force_bdss.data_sources.tests.test_base_data_source import DummyDataSource
+from force_bdss.data_sources.tests.test_base_data_source_model import \
+    DummyDataSourceModel
+
 try:
     import mock
 except ImportError:
     from unittest import mock
+
+import testfixtures
 
 from envisage.plugin import Plugin
 from force_bdss.data_sources.base_data_source_factory import \
@@ -21,8 +28,35 @@ class DummyDataSourceFactory(BaseDataSourceFactory):
         pass
 
 
+class DummyDataSourceFactoryFast(BaseDataSourceFactory):
+    id = "foo"
+
+    name = "bar"
+
+    model_class = DummyDataSourceModel
+
+    data_source_class = DummyDataSource
+
+
 class TestBaseDataSourceFactory(unittest.TestCase):
     def test_initialization(self):
         factory = DummyDataSourceFactory(mock.Mock(spec=Plugin))
         self.assertEqual(factory.id, 'foo')
         self.assertEqual(factory.name, 'bar')
+
+    def test_fast_specification(self):
+        factory = DummyDataSourceFactoryFast(mock.Mock(spec=Plugin))
+        self.assertIsInstance(factory.create_data_source(), DummyDataSource)
+        self.assertIsInstance(factory.create_model(), DummyDataSourceModel)
+
+    def test_fast_specification_errors(self):
+        factory = DummyDataSourceFactoryFast(mock.Mock(spec=Plugin))
+        factory.model_class = None
+        factory.data_source_class = None
+
+        with testfixtures.LogCapture():
+            with self.assertRaises(RuntimeError):
+                factory.create_data_source()
+
+            with self.assertRaises(RuntimeError):
+                factory.create_model()

--- a/force_bdss/kpi/base_kpi_calculator_factory.py
+++ b/force_bdss/kpi/base_kpi_calculator_factory.py
@@ -63,7 +63,7 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
             log.error(msg)
             raise RuntimeError(msg)
 
-        return self.data_source_class(self)
+        return self.kpi_calculator_class(self)
 
     def create_model(self, model_data=None):
         """Factory method.

--- a/force_bdss/kpi/base_kpi_calculator_factory.py
+++ b/force_bdss/kpi/base_kpi_calculator_factory.py
@@ -1,8 +1,13 @@
-import abc
+import logging
 from envisage.plugin import Plugin
 from traits.api import ABCHasStrictTraits, provides, String, Instance
 
+from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
+from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
 from .i_kpi_calculator_factory import IKPICalculatorFactory
+
+
+log = logging.getLogger(__name__)
 
 
 @provides(IKPICalculatorFactory)
@@ -20,6 +25,13 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
     #: A UI friendly name for the factory. Can contain spaces.
     name = String()
 
+    #: The KPI calculator to be instantiated. Define this to your KPICalculator
+    kpi_calculator_class = Instance(BaseKPICalculator)
+
+    #: The model associated to the KPI calculator.
+    #: Define this to your KPICalculatorModel
+    model_class = Instance(BaseKPICalculatorModel)
+
     #: A reference to the plugin that holds this factory.
     plugin = Instance(Plugin)
 
@@ -34,7 +46,6 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
         self.plugin = plugin
         super(BaseKPICalculatorFactory, self).__init__(*args, **kwargs)
 
-    @abc.abstractmethod
     def create_kpi_calculator(self):
         """Factory method.
         Creates and returns an instance of a KPI Calculator, associated
@@ -45,8 +56,15 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
         BaseKPICalculator
             The specific instance of the generated KPICalculator
         """
+        if self.kpi_calculator_class is None:
+            msg = ("kpi_calculator_class cannot be None in {}. Either define "
+                   "kpi_calculator_class or reimplement create_kpi_calculator "
+                   "on your factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
 
-    @abc.abstractmethod
+        return self.data_source_class(self)
+
     def create_model(self, model_data=None):
         """Factory method.
         Creates the model object (or network of model objects) of the KPI
@@ -64,3 +82,14 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
         BaseKPICalculatorModel
             The model
         """
+        if model_data is None:
+            model_data = {}
+
+        if self.model_class is None:
+            msg = ("model_class cannot be None in {}. Either define "
+                   "model_class or reimplement create_model on your "
+                   "factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        return self.model_class(self, **model_data)

--- a/force_bdss/kpi/base_kpi_calculator_factory.py
+++ b/force_bdss/kpi/base_kpi_calculator_factory.py
@@ -1,6 +1,6 @@
 import logging
 from envisage.plugin import Plugin
-from traits.api import ABCHasStrictTraits, provides, String, Instance
+from traits.api import ABCHasStrictTraits, provides, String, Instance, Type
 
 from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
 from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
@@ -26,11 +26,11 @@ class BaseKPICalculatorFactory(ABCHasStrictTraits):
     name = String()
 
     #: The KPI calculator to be instantiated. Define this to your KPICalculator
-    kpi_calculator_class = Instance(BaseKPICalculator)
+    kpi_calculator_class = Type(BaseKPICalculator)
 
     #: The model associated to the KPI calculator.
     #: Define this to your KPICalculatorModel
-    model_class = Instance(BaseKPICalculatorModel)
+    model_class = Type(BaseKPICalculatorModel)
 
     #: A reference to the plugin that holds this factory.
     plugin = Instance(Plugin)

--- a/force_bdss/kpi/i_kpi_calculator_factory.py
+++ b/force_bdss/kpi/i_kpi_calculator_factory.py
@@ -1,6 +1,9 @@
 from traits.api import Interface, String, Instance
 from envisage.plugin import Plugin
 
+from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
+from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
+
 
 class IKPICalculatorFactory(Interface):
     """Envisage required interface for the BaseKPICalculatorFactory.
@@ -11,6 +14,10 @@ class IKPICalculatorFactory(Interface):
     id = String()
 
     name = String()
+
+    kpi_calculator_class = Instance(BaseKPICalculator)
+
+    model_class = Instance(BaseKPICalculatorModel)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/kpi/i_kpi_calculator_factory.py
+++ b/force_bdss/kpi/i_kpi_calculator_factory.py
@@ -1,9 +1,6 @@
 from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
 
-from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
-from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
-
 
 class IKPICalculatorFactory(Interface):
     """Envisage required interface for the BaseKPICalculatorFactory.
@@ -15,9 +12,13 @@ class IKPICalculatorFactory(Interface):
 
     name = String()
 
-    kpi_calculator_class = Type(BaseKPICalculator)
+    kpi_calculator_class = Type(
+        "force_bdss.kpi.base_kpi_calculator.BaseKPICalculator"
+    )
 
-    model_class = Type(BaseKPICalculatorModel)
+    model_class = Type(
+        "force_bdss.kpi.base_kpi_calculator_model.BaseKPICalculatorModel"
+    )
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/kpi/i_kpi_calculator_factory.py
+++ b/force_bdss/kpi/i_kpi_calculator_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Interface, String, Instance
+from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
 
 from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
@@ -15,9 +15,9 @@ class IKPICalculatorFactory(Interface):
 
     name = String()
 
-    kpi_calculator_class = Instance(BaseKPICalculator)
+    kpi_calculator_class = Type(BaseKPICalculator)
 
-    model_class = Instance(BaseKPICalculatorModel)
+    model_class = Type(BaseKPICalculatorModel)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/kpi/tests/test_base_kpi_calculator_factory.py
+++ b/force_bdss/kpi/tests/test_base_kpi_calculator_factory.py
@@ -1,6 +1,9 @@
 import unittest
 from envisage.plugin import Plugin
 
+from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
+from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
+
 try:
     import mock
 except ImportError:
@@ -8,6 +11,9 @@ except ImportError:
 
 from force_bdss.kpi.base_kpi_calculator_factory import \
     BaseKPICalculatorFactory
+
+kpi_calculator = mock.Mock(spec=BaseKPICalculator)
+kpi_calculator_model = mock.Mock(spec=BaseKPICalculatorModel)
 
 
 class DummyKPICalculatorFactory(BaseKPICalculatorFactory):
@@ -22,8 +28,21 @@ class DummyKPICalculatorFactory(BaseKPICalculatorFactory):
         pass
 
 
+class DummyKPICalculatorFactory2(BaseKPICalculatorFactory):
+    id = "foo"
+
+    name = "bar"
+
+    kpi_calculator_class = kpi_calculator
+
+    model_class = kpi_calculator_model
+
+
 class TestBaseKPICalculatorFactory(unittest.TestCase):
     def test_initialization(self):
         factory = DummyKPICalculatorFactory(mock.Mock(spec=Plugin))
         self.assertEqual(factory.id, 'foo')
         self.assertEqual(factory.name, 'bar')
+
+    def test_fast_definition(self):
+        factory = DummyKPICalculatorFactory2(mock.Mock(spec=Plugin))

--- a/force_bdss/kpi/tests/test_base_kpi_calculator_factory.py
+++ b/force_bdss/kpi/tests/test_base_kpi_calculator_factory.py
@@ -1,8 +1,10 @@
 import unittest
+import testfixtures
 from envisage.plugin import Plugin
 
-from force_bdss.kpi.base_kpi_calculator import BaseKPICalculator
-from force_bdss.kpi.base_kpi_calculator_model import BaseKPICalculatorModel
+from force_bdss.kpi.tests.test_base_kpi_calculator import DummyKPICalculator
+from force_bdss.kpi.tests.test_base_kpi_calculator_model import \
+    DummyKPICalculatorModel
 
 try:
     import mock
@@ -11,9 +13,6 @@ except ImportError:
 
 from force_bdss.kpi.base_kpi_calculator_factory import \
     BaseKPICalculatorFactory
-
-kpi_calculator = mock.Mock(spec=BaseKPICalculator)
-kpi_calculator_model = mock.Mock(spec=BaseKPICalculatorModel)
 
 
 class DummyKPICalculatorFactory(BaseKPICalculatorFactory):
@@ -28,14 +27,14 @@ class DummyKPICalculatorFactory(BaseKPICalculatorFactory):
         pass
 
 
-class DummyKPICalculatorFactory2(BaseKPICalculatorFactory):
+class DummyKPICalculatorFactoryFast(BaseKPICalculatorFactory):
     id = "foo"
 
     name = "bar"
 
-    kpi_calculator_class = kpi_calculator
+    kpi_calculator_class = DummyKPICalculator
 
-    model_class = kpi_calculator_model
+    model_class = DummyKPICalculatorModel
 
 
 class TestBaseKPICalculatorFactory(unittest.TestCase):
@@ -45,4 +44,21 @@ class TestBaseKPICalculatorFactory(unittest.TestCase):
         self.assertEqual(factory.name, 'bar')
 
     def test_fast_definition(self):
-        factory = DummyKPICalculatorFactory2(mock.Mock(spec=Plugin))
+        factory = DummyKPICalculatorFactoryFast(mock.Mock(spec=Plugin))
+        self.assertIsInstance(factory.create_kpi_calculator(),
+                              DummyKPICalculator)
+
+        self.assertIsInstance(factory.create_model(),
+                              DummyKPICalculatorModel)
+
+    def test_fast_definition_errors(self):
+        factory = DummyKPICalculatorFactoryFast(mock.Mock(spec=Plugin))
+        factory.kpi_calculator_class = None
+        factory.model_class = None
+
+        with testfixtures.LogCapture():
+            with self.assertRaises(RuntimeError):
+                factory.create_kpi_calculator()
+
+            with self.assertRaises(RuntimeError):
+                factory.create_model()

--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -1,5 +1,5 @@
 import logging
-from traits.api import ABCHasStrictTraits, String, provides, Instance
+from traits.api import ABCHasStrictTraits, String, provides, Instance, Type
 from envisage.plugin import Plugin
 
 from force_bdss.mco.base_mco import BaseMCO
@@ -24,13 +24,13 @@ class BaseMCOFactory(ABCHasStrictTraits):
     name = String()
 
     #: The optimizer class to instantiate. Define this to your MCO class.
-    optimizer_class = Instance(BaseMCO)
+    optimizer_class = Type(BaseMCO)
 
     #: The model associated to the MCO. Define this to your MCO model class.
-    model_class = Instance(BaseMCOModel)
+    model_class = Type(BaseMCOModel)
 
     #: The communicator associated to the MCO. Define this to your MCO comm.
-    communicator_class = Instance(BaseMCOCommunicator)
+    communicator_class = Type(BaseMCOCommunicator)
 
     #: A reference to the Plugin that holds this factory.
     plugin = Instance(Plugin)

--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -1,9 +1,13 @@
-import abc
-
+import logging
 from traits.api import ABCHasStrictTraits, String, provides, Instance
 from envisage.plugin import Plugin
 
+from force_bdss.mco.base_mco import BaseMCO
+from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
+from force_bdss.mco.base_mco_model import BaseMCOModel
 from .i_mco_factory import IMCOFactory
+
+log = logging.getLogger(__name__)
 
 
 @provides(IMCOFactory)
@@ -19,6 +23,15 @@ class BaseMCOFactory(ABCHasStrictTraits):
     #: A user friendly name of the factory. Spaces allowed.
     name = String()
 
+    #: The optimizer class to instantiate. Define this to your MCO class.
+    optimizer_class = Instance(BaseMCO)
+
+    #: The model associated to the MCO. Define this to your MCO model class.
+    model_class = Instance(BaseMCOModel)
+
+    #: The communicator associated to the MCO. Define this to your MCO comm.
+    communicator_class = Instance(BaseMCOCommunicator)
+
     #: A reference to the Plugin that holds this factory.
     plugin = Instance(Plugin)
 
@@ -26,7 +39,6 @@ class BaseMCOFactory(ABCHasStrictTraits):
         self.plugin = plugin
         super(BaseMCOFactory, self).__init__(*args, **kwargs)
 
-    @abc.abstractmethod
     def create_optimizer(self):
         """Factory method.
         Creates the optimizer with the given application
@@ -34,11 +46,18 @@ class BaseMCOFactory(ABCHasStrictTraits):
 
         Returns
         -------
-        BaseMCOOptimizer
+        BaseMCO
             The optimizer
         """
+        if self.optimizer_class is None:
+            msg = ("optimizer_class cannot be None in {}. Either define "
+                   "optimizer_class or reimplement create_optimizer on "
+                   "your factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
 
-    @abc.abstractmethod
+        return self.optimizer_class(self)
+
     def create_model(self, model_data=None):
         """Factory method.
         Creates the model object (or network of model objects) of the MCO.
@@ -57,8 +76,18 @@ class BaseMCOFactory(ABCHasStrictTraits):
         BaseMCOModel
             The MCOModel
         """
+        if model_data is None:
+            model_data = {}
 
-    @abc.abstractmethod
+        if self.model_class is None:
+            msg = ("model_class cannot be None in {}. Either define "
+                   "model_class or reimplement create_model on your "
+                   "factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        return self.model_class(self, **model_data)
+
     def create_communicator(self):
         """Factory method. Returns the communicator class that allows
         exchange between the MCO and the evaluator code.
@@ -68,8 +97,15 @@ class BaseMCOFactory(ABCHasStrictTraits):
         BaseMCOCommunicator
             An instance of the communicator
         """
+        if self.communicator_class is None:
+            msg = ("communicator_class cannot be None in {}. Either define "
+                   "communicator_class or reimplement create_communicator on "
+                   "your factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
 
-    @abc.abstractmethod
+        return self.communicator_class(self)
+
     def parameter_factories(self):
         """Returns the parameter factories supported by this MCO
 

--- a/force_bdss/mco/i_mco_factory.py
+++ b/force_bdss/mco/i_mco_factory.py
@@ -1,10 +1,6 @@
 from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
 
-from force_bdss.mco.base_mco import BaseMCO
-from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
-from force_bdss.mco.base_mco_model import BaseMCOModel
-
 
 class IMCOFactory(Interface):
     """Interface for the BaseMCOFactory.
@@ -16,11 +12,17 @@ class IMCOFactory(Interface):
 
     name = String()
 
-    optimizer_class = Type(BaseMCO)
+    optimizer_class = Type(
+        "force_bdss.mco.base_mco.BaseMCO"
+    )
 
-    model_class = Type(BaseMCOModel)
+    model_class = Type(
+        "force_bdss.mco.base_mco_communicator.BaseMCOCommunicator"
+    )
 
-    communicator_class = Type(BaseMCOCommunicator)
+    communicator_class = Type(
+        "force_bdss.mco.base_mco_model.BaseMCOModel"
+    )
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/mco/i_mco_factory.py
+++ b/force_bdss/mco/i_mco_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Interface, String, Instance
+from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
 
 from force_bdss.mco.base_mco import BaseMCO
@@ -16,11 +16,11 @@ class IMCOFactory(Interface):
 
     name = String()
 
-    optimizer_class = Instance(BaseMCO)
+    optimizer_class = Type(BaseMCO)
 
-    model_class = Instance(BaseMCOModel)
+    model_class = Type(BaseMCOModel)
 
-    communicator_class = Instance(BaseMCOCommunicator)
+    communicator_class = Type(BaseMCOCommunicator)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/mco/i_mco_factory.py
+++ b/force_bdss/mco/i_mco_factory.py
@@ -1,6 +1,10 @@
 from traits.api import Interface, String, Instance
 from envisage.plugin import Plugin
 
+from force_bdss.mco.base_mco import BaseMCO
+from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator
+from force_bdss.mco.base_mco_model import BaseMCOModel
+
 
 class IMCOFactory(Interface):
     """Interface for the BaseMCOFactory.
@@ -11,6 +15,12 @@ class IMCOFactory(Interface):
     id = String()
 
     name = String()
+
+    optimizer_class = Instance(BaseMCO)
+
+    model_class = Instance(BaseMCOModel)
+
+    communicator_class = Instance(BaseMCOCommunicator)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/mco/parameters/base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/base_mco_parameter_factory.py
@@ -1,7 +1,5 @@
 from traits.api import HasStrictTraits, String, Type, Instance
 
-from ..base_mco_factory import BaseMCOFactory
-
 
 class BaseMCOParameterFactory(HasStrictTraits):
     """Factory that produces the model instance of a given BASEMCOParameter
@@ -13,7 +11,7 @@ class BaseMCOParameterFactory(HasStrictTraits):
     """
 
     #: A reference to the MCO factory this parameter factory lives in.
-    mco_factory = Instance(BaseMCOFactory)
+    mco_factory = Instance('force_bdss.mco.base_mco_factory.BaseMCOFactory')
 
     #: A unique string identifying the parameter
     id = String()
@@ -25,7 +23,9 @@ class BaseMCOParameterFactory(HasStrictTraits):
     description = String("Undefined parameter")
 
     # The model class to instantiate when create_model is called.
-    model_class = Type('BaseMCOParameter')
+    model_class = Type(
+        "force_bdss.mco.parameters.base_mco_parameter.BaseMCOParameter"
+    )
 
     def __init__(self, mco_factory, *args, **kwargs):
         self.mco_factory = mco_factory

--- a/force_bdss/mco/parameters/tests/test_base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/tests/test_base_mco_parameter_factory.py
@@ -1,5 +1,7 @@
 import unittest
 
+from envisage.plugin import Plugin
+
 from force_bdss.mco.base_mco_factory import BaseMCOFactory
 
 try:
@@ -25,9 +27,14 @@ class DummyMCOParameterFactory(BaseMCOParameterFactory):
     model_class = DummyMCOParameter
 
 
+class DummyMCOFactory(BaseMCOFactory):
+    pass
+
+
 class TestBaseMCOParameterFactory(unittest.TestCase):
     def test_initialization(self):
-        factory = DummyMCOParameterFactory(mock.Mock(spec=BaseMCOFactory))
+        factory = DummyMCOParameterFactory(
+            mco_factory=BaseMCOFactory(plugin=mock.Mock(spec=Plugin)))
         model = factory.create_model({"x": 42})
         self.assertIsInstance(model, DummyMCOParameter)
         self.assertEqual(model.x, 42)

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -1,5 +1,12 @@
 import unittest
 
+import testfixtures
+
+from force_bdss.mco.base_mco_model import BaseMCOModel
+from force_bdss.mco.tests.test_base_mco import DummyMCO
+from force_bdss.mco.tests.test_base_mco_communicator import \
+    DummyMCOCommunicator
+
 try:
     import mock
 except ImportError:
@@ -28,8 +35,49 @@ class DummyMCOFactory(BaseMCOFactory):
         return []
 
 
+class DummyMCOModel(BaseMCOModel):
+    pass
+
+
+class DummyMCOFactoryFast(BaseMCOFactory):
+    id = "foo"
+
+    name = "bar"
+
+    optimizer_class = DummyMCO
+
+    model_class = DummyMCOModel
+
+    communicator_class = DummyMCOCommunicator
+
+
 class TestBaseMCOFactory(unittest.TestCase):
     def test_initialization(self):
         factory = DummyMCOFactory(mock.Mock(spec=Plugin))
         self.assertEqual(factory.id, 'foo')
         self.assertEqual(factory.name, 'bar')
+
+    def test_fast_definition(self):
+        factory = DummyMCOFactoryFast(mock.Mock(spec=Plugin))
+        self.assertIsInstance(factory.create_optimizer(),
+                              DummyMCO)
+        self.assertIsInstance(factory.create_communicator(),
+                              DummyMCOCommunicator)
+        self.assertIsInstance(factory.create_model(),
+                              DummyMCOModel)
+
+    def test_fast_definition_errors(self):
+        factory = DummyMCOFactoryFast(mock.Mock(spec=Plugin))
+        factory.optimizer_class = None
+        factory.model_class = None
+        factory.communicator_class = None
+
+        with testfixtures.LogCapture():
+            with self.assertRaises(RuntimeError):
+                factory.create_optimizer()
+
+            with self.assertRaises(RuntimeError):
+                factory.create_communicator()
+
+            with self.assertRaises(RuntimeError):
+                factory.create_model()

--- a/force_bdss/notification_listeners/base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/base_notification_listener_factory.py
@@ -1,5 +1,5 @@
 import logging
-from traits.api import ABCHasStrictTraits, Instance, String, provides
+from traits.api import ABCHasStrictTraits, Instance, String, provides, Type
 from envisage.plugin import Plugin
 
 from force_bdss.notification_listeners.base_notification_listener import \
@@ -26,11 +26,11 @@ class BaseNotificationListenerFactory(ABCHasStrictTraits):
 
     #: The listener class that must be instantiated. Define this to your
     #: listener class.
-    listener_class = Instance(BaseNotificationListener)
+    listener_class = Type(BaseNotificationListener)
 
     #: The associated model to the listener. Define this to your
     #: listener model class.
-    model_class = Instance(BaseNotificationListenerModel)
+    model_class = Type(BaseNotificationListenerModel)
 
     #: A reference to the containing plugin
     plugin = Instance(Plugin)

--- a/force_bdss/notification_listeners/base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/base_notification_listener_factory.py
@@ -1,9 +1,15 @@
-import abc
-
+import logging
 from traits.api import ABCHasStrictTraits, Instance, String, provides
 from envisage.plugin import Plugin
 
+from force_bdss.notification_listeners.base_notification_listener import \
+    BaseNotificationListener
+from force_bdss.notification_listeners.base_notification_listener_model \
+    import \
+    BaseNotificationListenerModel
 from .i_notification_listener_factory import INotificationListenerFactory
+
+log = logging.getLogger(__name__)
 
 
 @provides(INotificationListenerFactory)
@@ -17,6 +23,14 @@ class BaseNotificationListenerFactory(ABCHasStrictTraits):
 
     #: Name of the factory. User friendly for UI
     name = String()
+
+    #: The listener class that must be instantiated. Define this to your
+    #: listener class.
+    listener_class = Instance(BaseNotificationListener)
+
+    #: The associated model to the listener. Define this to your
+    #: listener model class.
+    model_class = Instance(BaseNotificationListenerModel)
 
     #: A reference to the containing plugin
     plugin = Instance(Plugin)
@@ -32,13 +46,19 @@ class BaseNotificationListenerFactory(ABCHasStrictTraits):
         self.plugin = plugin
         super(BaseNotificationListenerFactory, self).__init__(*args, **kwargs)
 
-    @abc.abstractmethod
     def create_listener(self):
         """
         Creates an instance of the listener.
         """
+        if self.listener_class is None:
+            msg = ("listener_class cannot be None in {}. Either define "
+                   "listener_class or reimplement create_listener on "
+                   "your factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
 
-    @abc.abstractmethod
+        return self.listener_class(self)
+
     def create_model(self, model_data=None):
         """
         Creates an instance of the model.
@@ -48,3 +68,14 @@ class BaseNotificationListenerFactory(ABCHasStrictTraits):
         model_data: dict
             Data to use to fill the model.
         """
+        if model_data is None:
+            model_data = {}
+
+        if self.model_class is None:
+            msg = ("model_class cannot be None in {}. Either define "
+                   "model_class or reimplement create_model on your "
+                   "factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        return self.model_class(self, **model_data)

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -1,6 +1,12 @@
 from traits.api import Interface, String, Instance
 from envisage.plugin import Plugin
 
+from force_bdss.notification_listeners.base_notification_listener import \
+    BaseNotificationListener
+from force_bdss.notification_listeners.base_notification_listener_model \
+    import \
+    BaseNotificationListenerModel
+
 
 class INotificationListenerFactory(Interface):
     """Envisage required interface for the BaseNotificationListenerFactory.
@@ -11,6 +17,10 @@ class INotificationListenerFactory(Interface):
     id = String()
 
     name = String()
+
+    listener_class = Instance(BaseNotificationListener)
+
+    model_class = Instance(BaseNotificationListenerModel)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -1,11 +1,5 @@
-from traits.api import Interface, String, Instance
+from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
-
-from force_bdss.notification_listeners.base_notification_listener import \
-    BaseNotificationListener
-from force_bdss.notification_listeners.base_notification_listener_model \
-    import \
-    BaseNotificationListenerModel
 
 
 class INotificationListenerFactory(Interface):
@@ -18,9 +12,15 @@ class INotificationListenerFactory(Interface):
 
     name = String()
 
-    listener_class = Instance(BaseNotificationListener)
+    listener_class = Type(
+        "force_bdss.notification_listeners"
+        ".base_notification_listener.BaseNotificationListener"
+    )
 
-    model_class = Instance(BaseNotificationListenerModel)
+    model_class = Type(
+        "force_bdss.notification_listeners"
+        ".base_notification_listener_model.BaseNotificationListenerModel"
+    )
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/notification_listeners/tests/test_base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/tests/test_base_notification_listener_factory.py
@@ -1,0 +1,77 @@
+import unittest
+
+import testfixtures
+from envisage.plugin import Plugin
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from force_bdss.notification_listeners.base_notification_listener import \
+    BaseNotificationListener
+from force_bdss.notification_listeners.base_notification_listener_factory \
+    import \
+    BaseNotificationListenerFactory
+from force_bdss.notification_listeners.base_notification_listener_model \
+    import \
+    BaseNotificationListenerModel
+
+
+class DummyNotificationListener(BaseNotificationListener):
+    def deliver(self, event):
+        pass
+
+
+class DummyNotificationListenerModel(BaseNotificationListenerModel):
+    pass
+
+
+class DummyNotificationListenerFactory(BaseNotificationListenerFactory):
+    id = "foo"
+
+    name = "bar"
+
+    def create_listener(self):
+        return DummyNotificationListener(self)
+
+    def create_model(self, model_data=None):
+        return DummyNotificationListenerModel(self)
+
+
+class DummyNotificationListenerFactoryFast(BaseNotificationListenerFactory):
+    id = "foo"
+
+    name = "bar"
+
+    listener_class = DummyNotificationListener
+
+    model_class = DummyNotificationListenerModel
+
+
+class TestBaseNotificationListenerFactory(unittest.TestCase):
+    def test_initialization(self):
+        factory = DummyNotificationListenerFactory(mock.Mock(spec=Plugin))
+        self.assertEqual(factory.id, 'foo')
+        self.assertEqual(factory.name, 'bar')
+
+    def test_fast_definition(self):
+        factory = DummyNotificationListenerFactoryFast(mock.Mock(spec=Plugin))
+
+        self.assertIsInstance(factory.create_listener(),
+                              DummyNotificationListener)
+
+        self.assertIsInstance(factory.create_model(),
+                              DummyNotificationListenerModel)
+
+    def test_fast_definition_errors(self):
+        factory = DummyNotificationListenerFactoryFast(mock.Mock(spec=Plugin))
+        factory.listener_class = None
+        factory.model_class = None
+
+        with testfixtures.LogCapture():
+            with self.assertRaises(RuntimeError):
+                factory.create_model()
+
+            with self.assertRaises(RuntimeError):
+                factory.create_listener()

--- a/force_bdss/ui_hooks/base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/base_ui_hooks_factory.py
@@ -1,9 +1,11 @@
-import abc
-
+import logging
 from traits.api import ABCHasStrictTraits, Instance, String, provides
 from envisage.plugin import Plugin
 
+from force_bdss.ui_hooks.base_ui_hooks_manager import BaseUIHooksManager
 from .i_ui_hooks_factory import IUIHooksFactory
+
+log = logging.getLogger(__name__)
 
 
 @provides(IUIHooksFactory)
@@ -17,6 +19,10 @@ class BaseUIHooksFactory(ABCHasStrictTraits):
 
     #: Name of the factory. User friendly for UI
     name = String()
+
+    #: The UI Hooks manager class to instantiate. Define this to your
+    #: base hook managers.
+    ui_hooks_manager_class = Instance(BaseUIHooksManager)
 
     #: A reference to the containing plugin
     plugin = Instance(Plugin)
@@ -32,7 +38,6 @@ class BaseUIHooksFactory(ABCHasStrictTraits):
         self.plugin = plugin
         super(BaseUIHooksFactory, self).__init__(*args, **kwargs)
 
-    @abc.abstractmethod
     def create_ui_hooks_manager(self):
         """Creates an instance of the hook manager.
         The hooks manager contains a set of methods that are applicable in
@@ -42,3 +47,12 @@ class BaseUIHooksFactory(ABCHasStrictTraits):
         -------
         BaseUIHooksManager
         """
+        if self.ui_hooks_manager_class is None:
+            msg = ("ui_hooks_manager_class cannot be None in {}. Either "
+                   "define ui_hooks_manager_class or reimplement "
+                   "create_ui_hooks_manager on "
+                   "your factory class.".format(self.__class__.__name__))
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        return self.ui_hooks_manager_class(self)

--- a/force_bdss/ui_hooks/base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/base_ui_hooks_factory.py
@@ -1,5 +1,5 @@
 import logging
-from traits.api import ABCHasStrictTraits, Instance, String, provides
+from traits.api import ABCHasStrictTraits, Instance, String, provides, Type
 from envisage.plugin import Plugin
 
 from force_bdss.ui_hooks.base_ui_hooks_manager import BaseUIHooksManager
@@ -22,7 +22,7 @@ class BaseUIHooksFactory(ABCHasStrictTraits):
 
     #: The UI Hooks manager class to instantiate. Define this to your
     #: base hook managers.
-    ui_hooks_manager_class = Instance(BaseUIHooksManager)
+    ui_hooks_manager_class = Type(BaseUIHooksManager)
 
     #: A reference to the containing plugin
     plugin = Instance(Plugin)

--- a/force_bdss/ui_hooks/i_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/i_ui_hooks_factory.py
@@ -1,7 +1,5 @@
-from traits.api import Interface, String, Instance
+from traits.api import Interface, String, Instance, Type
 from envisage.plugin import Plugin
-
-from force_bdss.ui_hooks.base_ui_hooks_manager import BaseUIHooksManager
 
 
 class IUIHooksFactory(Interface):
@@ -14,7 +12,9 @@ class IUIHooksFactory(Interface):
 
     name = String()
 
-    ui_hooks_manager_class = Instance(BaseUIHooksManager)
+    ui_hooks_manager_class = Type(
+        "force_bdss.ui_hooks.base_ui_hooks_manager.BaseUIHooksManager"
+    )
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/ui_hooks/i_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/i_ui_hooks_factory.py
@@ -1,6 +1,8 @@
 from traits.api import Interface, String, Instance
 from envisage.plugin import Plugin
 
+from force_bdss.ui_hooks.base_ui_hooks_manager import BaseUIHooksManager
+
 
 class IUIHooksFactory(Interface):
     """Envisage required interface for the BaseUIHooksFactory.
@@ -11,6 +13,8 @@ class IUIHooksFactory(Interface):
     id = String()
 
     name = String()
+
+    ui_hooks_manager_class = Instance(BaseUIHooksManager)
 
     plugin = Instance(Plugin)
 

--- a/force_bdss/ui_hooks/tests/test_base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/tests/test_base_ui_hooks_factory.py
@@ -1,5 +1,10 @@
 import unittest
 
+import testfixtures
+
+from force_bdss.ui_hooks.tests.test_base_ui_hooks_manager import \
+    DummyUIHooksManager
+
 try:
     import mock
 except ImportError:
@@ -9,13 +14,34 @@ from envisage.api import Plugin
 from ..base_ui_hooks_factory import BaseUIHooksFactory
 
 
-class NullUIHooksFactory(BaseUIHooksFactory):
+class DummyUIHooksFactory(BaseUIHooksFactory):
     def create_ui_hooks_manager(self):
-        return None
+        return DummyUIHooksManager(self)
+
+
+class DummyUIHooksFactoryFast(BaseUIHooksFactory):
+    ui_hooks_manager_class = DummyUIHooksManager
 
 
 class TestBaseUIHooksFactory(unittest.TestCase):
     def test_initialize(self):
         mock_plugin = mock.Mock(spec=Plugin)
-        factory = NullUIHooksFactory(plugin=mock_plugin)
+        factory = DummyUIHooksFactory(plugin=mock_plugin)
         self.assertEqual(factory.plugin, mock_plugin)
+
+    def test_fast_definition(self):
+        mock_plugin = mock.Mock(spec=Plugin)
+        factory = DummyUIHooksFactoryFast(plugin=mock_plugin)
+
+        self.assertIsInstance(
+            factory.create_ui_hooks_manager(),
+            DummyUIHooksManager)
+
+    def test_fast_definition_errors(self):
+        mock_plugin = mock.Mock(spec=Plugin)
+        factory = DummyUIHooksFactoryFast(plugin=mock_plugin)
+        factory.ui_hooks_manager_class = None
+
+        with testfixtures.LogCapture():
+            with self.assertRaises(RuntimeError):
+                factory.create_ui_hooks_manager()

--- a/force_bdss/ui_hooks/tests/test_base_ui_hooks_manager.py
+++ b/force_bdss/ui_hooks/tests/test_base_ui_hooks_manager.py
@@ -8,9 +8,13 @@ except ImportError:
     from unittest import mock
 
 
+class DummyUIHooksManager(BaseUIHooksManager):
+    pass
+
+
 class TestBaseUIHooksManager(unittest.TestCase):
     def test_initialization(self):
         mock_factory = mock.Mock(spec=BaseUIHooksFactory)
-        mgr = BaseUIHooksManager(mock_factory)
+        mgr = DummyUIHooksManager(mock_factory)
 
         self.assertEqual(mgr.factory, mock_factory)


### PR DESCRIPTION
Makes it faster to define the factory by specifying just the class, factoring out 
the boilerplate of the reimplementation of the method. 

This is backward compatible with the current plugins