### PR TITLE
Renamed trait ExecutionLayer.data_source_models to data_sources

### DIFF
--- a/force_bdss/core/execution_layer.py
+++ b/force_bdss/core/execution_layer.py
@@ -7,4 +7,4 @@ class ExecutionLayer(HasStrictTraits):
     """Represents a single layer in the execution stack.
     It contains a list of the data source models that must be executed.
     """
-    data_source_models = List(BaseDataSourceModel)
+    data_sources = List(BaseDataSourceModel)

--- a/force_bdss/core_evaluation_driver.py
+++ b/force_bdss/core_evaluation_driver.py
@@ -88,7 +88,7 @@ def _compute_layer_results(environment_data_values,
     """
     results = []
 
-    for model in layer.data_source_models:
+    for model in layer.data_sources:
         factory = model.factory
         data_source = factory.create_data_source()
 

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -57,7 +57,7 @@ class CoreMCODriver(BaseCoreDriver):
     def _deliver_start_event(self):
         output_names = []
         for layer in self.workflow.execution_layers:
-            for data_source in layer.data_source_models:
+            for data_source in layer.data_sources:
                 output_names.extend(info.name
                                     for info in data_source.output_slot_info
                                     if info.is_kpi

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -71,9 +71,9 @@ class TestWorkflowWriter(unittest.TestCase):
                          wf.mco.factory.id)
         self.assertEqual(len(wf_result.execution_layers), 2)
         self.assertEqual(
-            len(wf_result.execution_layers[0].data_source_models), 2)
+            len(wf_result.execution_layers[0].data_sources), 2)
         self.assertEqual(
-            len(wf_result.execution_layers[1].data_source_models), 1)
+            len(wf_result.execution_layers[1].data_sources), 1)
 
     def _create_mock_workflow(self):
         wf = Workflow()
@@ -90,7 +90,7 @@ class TestWorkflowWriter(unittest.TestCase):
             )
         ]
         wf.execution_layers = [
-            ExecutionLayer(data_source_models=[
+            ExecutionLayer(data_sources=[
                 BaseDataSourceModel(
                     mock.Mock(spec=IDataSourceFactory,
                               id=factory_id("enthought", "mock2"))),
@@ -98,7 +98,7 @@ class TestWorkflowWriter(unittest.TestCase):
                     mock.Mock(spec=IDataSourceFactory,
                               id=factory_id("enthought", "mock2"))),
             ]),
-            ExecutionLayer(data_source_models=[
+            ExecutionLayer(data_sources=[
                 BaseDataSourceModel(
                     mock.Mock(spec=IDataSourceFactory,
                               id=factory_id("enthought", "mock2")))

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -162,7 +162,7 @@ class WorkflowReader(HasStrictTraits):
                     self._extract_output_slot_info(
                         model_data["output_slot_info"]
                     )
-                layer.data_source_models.append(
+                layer.data_sources.append(
                     ds_factory.create_model(model_data))
             layers.append(layer)
 

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -66,7 +66,7 @@ class WorkflowWriter(HasStrictTraits):
         """Extracts the execution layer list of DataSource models"""
         data = []
 
-        for ds in layer.data_source_models:
+        for ds in layer.data_sources:
             data.append(self._model_data(ds))
 
         return data

--- a/force_bdss/tests/test_core_evaluation_driver.py
+++ b/force_bdss/tests/test_core_evaluation_driver.py
@@ -180,7 +180,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
 
         res = _compute_layer_results(
             data_values,
-            ExecutionLayer(data_source_models=[evaluator_model]),
+            ExecutionLayer(data_sources=[evaluator_model]),
         )
         self.assertEqual(len(res), 2)
         self.assertEqual(res[0].name, "one")
@@ -248,7 +248,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         model.output_slot_info = [
             OutputSlotInfo(name="res1")
         ]
-        wf.execution_layers[0].data_source_models.append(model)
+        wf.execution_layers[0].data_sources.append(model)
 
         model = adder_factory.create_model()
         model.input_slot_info = [
@@ -258,7 +258,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         model.output_slot_info = [
             OutputSlotInfo(name="res2")
         ]
-        wf.execution_layers[0].data_source_models.append(model)
+        wf.execution_layers[0].data_sources.append(model)
 
         # layer 1
         model = adder_factory.create_model()
@@ -269,7 +269,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         model.output_slot_info = [
             OutputSlotInfo(name="res3")
         ]
-        wf.execution_layers[1].data_source_models.append(model)
+        wf.execution_layers[1].data_sources.append(model)
 
         # layer 2
         model = multiplier_factory.create_model()
@@ -280,7 +280,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         model.output_slot_info = [
             OutputSlotInfo(name="res4")
         ]
-        wf.execution_layers[2].data_source_models.append(model)
+        wf.execution_layers[2].data_sources.append(model)
 
         # layer 3
         model = multiplier_factory.create_model()
@@ -291,7 +291,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         model.output_slot_info = [
             OutputSlotInfo(name="out1", is_kpi=True)
         ]
-        wf.execution_layers[3].data_source_models.append(model)
+        wf.execution_layers[3].data_sources.append(model)
 
         kpi_results = execute_workflow(wf, data_values)
         self.assertEqual(len(kpi_results), 1)


### PR DESCRIPTION
Better name to keep consistency with the other entities.