### PR TITLE
Added flag for notification listener visibility

### DIFF
--- a/force_bdss/notification_listeners/base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/base_notification_listener_factory.py
@@ -1,5 +1,7 @@
 import logging
-from traits.api import ABCHasStrictTraits, Instance, String, provides, Type
+from traits.api import (
+    ABCHasStrictTraits, Instance, String, provides, Type, Bool
+)
 from envisage.plugin import Plugin
 
 from force_bdss.notification_listeners.base_notification_listener import \
@@ -23,6 +25,11 @@ class BaseNotificationListenerFactory(ABCHasStrictTraits):
 
     #: Name of the factory. User friendly for UI
     name = String()
+
+    #: If the factor should be visible in the UI. Set to false to make it
+    #: invisible. This is normally useful for notification systems that are
+    #: not supposed to be configured by the user.
+    ui_visible = Bool(True)
 
     #: The listener class that must be instantiated. Define this to your
     #: listener class.

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Interface, String, Instance, Type
+from traits.api import Interface, String, Instance, Type, Bool
 from envisage.plugin import Plugin
 
 
@@ -11,6 +11,8 @@ class INotificationListenerFactory(Interface):
     id = String()
 
     name = String()
+
+    ui_visible = Bool()
 
     listener_class = Type(
         "force_bdss.notification_listeners"


### PR DESCRIPTION
Some notification listeners should not be configurable in the UI, so they should not appear in the factory list. This flag allows to filter those plugins that need to stay hidden.
