### PR TITLE
Adds the missing optional parameter to ProbeMCOFactory.create_model

### DIFF
--- a/force_bdss/tests/probe_classes/mco.py
+++ b/force_bdss/tests/probe_classes/mco.py
@@ -101,7 +101,7 @@ class ProbeMCOFactory(BaseMCOFactory):
             self,
             nb_output_data_values=self.nb_output_data_values)
 
-    def create_model(self, model_data):
+    def create_model(self, model_data=None):
         if self.raises_on_create_model:
             raise Exception("ProbeMCOFactory.create_model")
 


### PR DESCRIPTION
The create_model routine for the probe factory should have an optional parameter that is currently missing.
