### PR TITLE
Removed now useless checks as they are checked via traits

### DIFF
--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -92,13 +92,6 @@ class BaseMCOFactory(HasStrictTraits):
         BaseMCO
             The optimizer
         """
-        if self.optimizer_class is None:
-            msg = ("optimizer_class cannot be None in {}. Either define "
-                   "optimizer_class or reimplement create_optimizer on "
-                   "your factory class.".format(self.__class__.__name__))
-            log.error(msg)
-            raise RuntimeError(msg)
-
         return self.optimizer_class(self)
 
     def create_model(self, model_data=None):
@@ -122,13 +115,6 @@ class BaseMCOFactory(HasStrictTraits):
         if model_data is None:
             model_data = {}
 
-        if self.model_class is None:
-            msg = ("model_class cannot be None in {}. Either define "
-                   "model_class or reimplement create_model on your "
-                   "factory class.".format(self.__class__.__name__))
-            log.error(msg)
-            raise RuntimeError(msg)
-
         return self.model_class(self, **model_data)
 
     def create_communicator(self):
@@ -140,13 +126,6 @@ class BaseMCOFactory(HasStrictTraits):
         BaseMCOCommunicator
             An instance of the communicator
         """
-        if self.communicator_class is None:
-            msg = ("communicator_class cannot be None in {}. Either define "
-                   "communicator_class or reimplement create_communicator on "
-                   "your factory class.".format(self.__class__.__name__))
-            log.error(msg)
-            raise RuntimeError(msg)
-
         return self.communicator_class(self)
 
     def parameter_factories(self):

--- a/force_bdss/ui_hooks/base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/base_ui_hooks_factory.py
@@ -79,12 +79,4 @@ class BaseUIHooksFactory(HasStrictTraits):
         -------
         BaseUIHooksManager
         """
-        if self.ui_hooks_manager_class is None:
-            msg = ("ui_hooks_manager_class cannot be None in {}. Either "
-                   "define ui_hooks_manager_class or reimplement "
-                   "create_ui_hooks_manager on "
-                   "your factory class.".format(self.__class__.__name__))
-            log.error(msg)
-            raise RuntimeError(msg)
-
         return self.ui_hooks_manager_class(self)


### PR DESCRIPTION
Fixes #136 by rephrasing the issue.
The point is that we don't need the check as we are guaranteed by initialization
that the class will contain something that satisfies the trait, that is, it will
not be None due to the allow_none=False option. if the get_ methods are not redefined
to return something, they will raise a NotImplementedError which is self-describing.
If the trait is assigned something it doesn't like it will also report a meaningful
error message.