### PR TITLE
Removed __traits_version__ from json files

### DIFF
--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -16,6 +16,7 @@ from force_bdss.tests.dummy_classes.factory_registry_plugin import \
 from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
     pop_recursive
 from force_bdss.core.workflow import Workflow
+from force_bdss.core.input_slot_info import InputSlotInfo
 
 
 class TestWorkflowWriter(unittest.TestCase):
@@ -89,7 +90,18 @@ class TestWorkflowWriter(unittest.TestCase):
 
         self.assertEqual(traits_to_dict(mock_traits), {"foo": "bar"})
 
-    def test_pop_recursive(self):
+    def test_traits_to_dict(self):
+
+        wfwriter = WorkflowWriter()
+        wf = self._create_workflow()
+        exec_layer = wf.execution_layers[0]
+        exec_layer.data_sources[0].input_slot_info = [InputSlotInfo()]
+        slotdata = exec_layer.data_sources[0].input_slot_info[0].__getstate__()
+        self.assertTrue("__traits_version__" in slotdata)
+        # Calls traits_to_dict for each data source
+        datastore_list = wfwriter._execution_layer_data(exec_layer)
+        new_slotdata = datastore_list[0]['model_data']['input_slot_info']
+        self.assertTrue("__traits_version__" not in new_slotdata)
 
         test_dictionary = {'K1': {'K1': 'V1', 'K2': 'V2', 'K3': 'V3'},
                            'K2': ['V1', 'V2', {'K1': 'V1', 'K2': 'V2',

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -14,7 +14,7 @@ from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
 from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
-    pop_traits_version
+    pop_recursive
 from force_bdss.core.workflow import Workflow
 
 
@@ -89,13 +89,17 @@ class TestWorkflowWriter(unittest.TestCase):
 
         self.assertEqual(traits_to_dict(mock_traits), {"foo": "bar"})
 
-    def test_pop_traits_version(self):
+    def test_pop_recursive(self):
 
-        test_dictionary = {'Entry1': {'Entry1-1': 4, '__traits_version__': 67},
-                           'Entry2': [3, 'a', {'Entry2-1': 5,
-                                               '__traits_version__': 9001}],
-                           '__traits_version__': 13}
-        result_dictionary = {'Entry1': {'Entry1-1': 4, },
-                             'Entry2': [3, 'a', {'Entry2-1': 5, }], }
-        traitless_dictionary = pop_traits_version(test_dictionary)
-        self.assertEqual(traitless_dictionary, result_dictionary)
+        test_dictionary = {'K1': {'K1': 'V1', 'K2': 'V2', 'K3': 'V3'},
+                           'K2': ['V1', 'V2', {'K1': 'V1', 'K2': 'V2',
+                                               'K3': 'V3'}],
+                           'K3': 'V3',
+                           'K4': ('V1', {'K3': 'V3'},)}
+
+        result_dictionary = {'K1': {'K1': 'V1', 'K2': 'V2', },
+                             'K2': ['V1', 'V2', {'K1': 'V1', 'K2': 'V2', }],
+                             'K4': ('V1', {},)}
+
+        test_result_dictionary = pop_recursive(test_dictionary, )
+        self.assertEqual(test_result_dictionary, result_dictionary)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -101,5 +101,5 @@ class TestWorkflowWriter(unittest.TestCase):
                              'K2': ['V1', 'V2', {'K1': 'V1', 'K2': 'V2', }],
                              'K4': ('V1', {},)}
 
-        test_result_dictionary = pop_recursive(test_dictionary, )
+        test_result_dictionary = pop_recursive(test_dictionary, 'K3')
         self.assertEqual(test_result_dictionary, result_dictionary)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -14,7 +14,7 @@ from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
 from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
-    pop_traits
+    pop_traits_version
 from force_bdss.core.workflow import Workflow
 
 
@@ -91,11 +91,11 @@ class TestWorkflowWriter(unittest.TestCase):
 
     def test_pop_traits_version(self):
 
-        test_dictionary = {'Entry1': {'Entry1-1': 4, '__traits_version__':67},
+        test_dictionary = {'Entry1': {'Entry1-1': 4, '__traits_version__': 67},
                            'Entry2': [3, 'a', {'Entry2-1': 5,
                                                '__traits_version__': 9001}],
                            '__traits_version__': 13}
         result_dictionary = {'Entry1': {'Entry1-1': 4, },
                              'Entry2': [3, 'a', {'Entry2-1': 5, }], }
-        traitless_dictionary = pop_traits(test_dictionary)
-        self.assertEqual(traitless_dictionary,result_dictionary)
+        traitless_dictionary = pop_traits_version(test_dictionary)
+        self.assertEqual(traitless_dictionary, result_dictionary)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -13,7 +13,8 @@ from force_bdss.io.workflow_reader import WorkflowReader
 from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
-from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict
+from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
+    pop_traits
 from force_bdss.core.workflow import Workflow
 
 
@@ -87,3 +88,14 @@ class TestWorkflowWriter(unittest.TestCase):
         mock_traits.__getstate__ = mock.Mock(return_value={"foo": "bar"})
 
         self.assertEqual(traits_to_dict(mock_traits), {"foo": "bar"})
+
+    def test_pop_traits_version(self):
+
+        test_dictionary = {'Entry1': {'Entry1-1': 4, '__traits_version__':67},
+                           'Entry2': [3, 'a', {'Entry2-1': 5,
+                                               '__traits_version__': 9001}],
+                           '__traits_version__': 13}
+        result_dictionary = {'Entry1': {'Entry1-1': 4, },
+                             'Entry2': [3, 'a', {'Entry2-1': 5, }], }
+        traitless_dictionary = pop_traits(test_dictionary)
+        self.assertEqual(traitless_dictionary,result_dictionary)

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -93,29 +93,30 @@ def traits_to_dict(traits_obj):
     """Converts a traits class into a dict, removing the pesky
     traits version."""
 
-    def pop_traits(dictionary):
-        """Recursively remove the __traits_version__ attribute
-        from dictionary."""
-        try:
-            dictionary.pop("__traits_version__")
-        except KeyError:
-            pass
-
-        for key in dictionary:
-            # If we have a dict, remove the traits version
-            if isinstance(dictionary[key], dict):
-                pop_traits(dictionary[key])
-            # If we have a non-dict which contains a dict, remove traits from
-            # that as well
-            elif isinstance(dictionary[key], Iterable):
-                for element in dictionary[key]:
-                    if isinstance(element, dict):
-                        pop_traits(element)
-
-        return dictionary
-
     state = traits_obj.__getstate__()
 
-    state = pop_traits(state)
+    state = pop_traits_version(state)
 
     return state
+
+
+def pop_traits_version(dictionary):
+    """Recursively remove the __traits_version__ attribute
+    from dictionary."""
+    try:
+        dictionary.pop("__traits_version__")
+    except KeyError:
+        pass
+
+    for key in dictionary:
+        # If we have a dict, remove the traits version
+        if isinstance(dictionary[key], dict):
+            pop_traits(dictionary[key])
+        # If we have a non-dict which contains a dict, remove traits from
+        # that as well
+        elif isinstance(dictionary[key], Iterable):
+            for element in dictionary[key]:
+                if isinstance(element, dict):
+                    pop_traits(element)
+
+    return dictionary

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -1,6 +1,5 @@
 import json
 from traits.api import HasStrictTraits
-from collections import Iterable
 
 
 class WorkflowWriter(HasStrictTraits):
@@ -108,7 +107,7 @@ def pop_recursive(dictionary, remove_key):
     except KeyError:
         pass
 
-    for key,value in dictionary.items():
+    for key, value in dictionary.items():
         # If remove_key is in the dict, remove it
         if isinstance(value, dict):
             pop_recursive(value, remove_key)

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -108,14 +108,14 @@ def pop_recursive(dictionary, remove_key):
     except KeyError:
         pass
 
-    for key in dictionary:
+    for key,value in dictionary.items():
         # If remove_key is in the dict, remove it
-        if isinstance(dictionary[key], dict):
-            pop_recursive(dictionary[key], remove_key)
+        if isinstance(value, dict):
+            pop_recursive(value, remove_key)
         # If we have a non-dict iterable which contains a dict,
         # call pop.(remove_key) from that as well
-        elif isinstance(dictionary[key], Iterable):
-            for element in dictionary[key]:
+        elif isinstance(value, (tuple, list)):
+            for element in value:
                 if isinstance(element, dict):
                     pop_recursive(element, remove_key)
 

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -1,5 +1,6 @@
 import json
 from traits.api import HasStrictTraits
+from collections import Iterable
 
 
 class WorkflowWriter(HasStrictTraits):
@@ -91,10 +92,30 @@ class WorkflowWriter(HasStrictTraits):
 def traits_to_dict(traits_obj):
     """Converts a traits class into a dict, removing the pesky
     traits version."""
+
+    def pop_traits(dictionary):
+        """Recursively remove the __traits_version__ attribute
+        from dictionary."""
+        try:
+            dictionary.pop("__traits_version__")
+        except KeyError:
+            pass
+
+        for key in dictionary:
+            # If we have a dict, remove the traits version
+            if isinstance(dictionary[key], dict):
+                pop_traits(dictionary[key])
+            # If we have a non-dict which contains a dict, remove traits from
+            # that as well
+            elif isinstance(dictionary[key], Iterable):
+                for element in dictionary[key]:
+                    if isinstance(element, dict):
+                        pop_traits(element)
+
+        return dictionary
+
     state = traits_obj.__getstate__()
-    try:
-        state.pop("__traits_version__")
-    except KeyError:
-        pass
+
+    state = pop_traits(state)
 
     return state

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -95,12 +95,12 @@ def traits_to_dict(traits_obj):
 
     state = traits_obj.__getstate__()
 
-    state = pop_recursive(state,'__traits_version__')
+    state = pop_recursive(state, '__traits_version__')
 
     return state
 
 
-def pop_recursive(dictionary,remove_key):
+def pop_recursive(dictionary, remove_key):
     """Recursively remove a named key from dictionary and any contained
     dictionaries."""
     try:

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -95,28 +95,28 @@ def traits_to_dict(traits_obj):
 
     state = traits_obj.__getstate__()
 
-    state = pop_traits_version(state)
+    state = pop_recursive(state,'__traits_version__')
 
     return state
 
 
-def pop_traits_version(dictionary):
-    """Recursively remove the __traits_version__ attribute
-    from dictionary."""
+def pop_recursive(dictionary,remove_key):
+    """Recursively remove a named key from dictionary and any contained
+    dictionaries."""
     try:
-        dictionary.pop("__traits_version__")
+        dictionary.pop(remove_key)
     except KeyError:
         pass
 
     for key in dictionary:
-        # If we have a dict, remove the traits version
+        # If remove_key is in the dict, remove it
         if isinstance(dictionary[key], dict):
-            pop_traits_version(dictionary[key])
-        # If we have a non-dict which contains a dict, remove traits from
-        # that as well
+            pop_recursive(dictionary[key], remove_key)
+        # If we have a non-dict iterable which contains a dict,
+        # call pop.(remove_key) from that as well
         elif isinstance(dictionary[key], Iterable):
             for element in dictionary[key]:
                 if isinstance(element, dict):
-                    pop_traits_version(element)
+                    pop_recursive(element, remove_key)
 
     return dictionary

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -111,12 +111,12 @@ def pop_traits_version(dictionary):
     for key in dictionary:
         # If we have a dict, remove the traits version
         if isinstance(dictionary[key], dict):
-            pop_traits(dictionary[key])
+            pop_traits_version(dictionary[key])
         # If we have a non-dict which contains a dict, remove traits from
         # that as well
         elif isinstance(dictionary[key], Iterable):
             for element in dictionary[key]:
                 if isinstance(element, dict):
-                    pop_traits(element)
+                    pop_traits_version(element)
 
     return dictionary


### PR DESCRIPTION
The workflow is a dictionary which contains lists of dictionaries, so only the __traits_version__ keys in the top level dict were being removed. This changed the function so it should do it recursively.
It seems fine but the only test is a on a single hardcoded example at the minute. Refs. issue https://github.com/force-h2020/force-bdss/issues/134