### PR TITLE
Fixed incorrect initialization for python 3 environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
     - edm run -e force-bootstrap -- python -m ci docs --python-version ${PYTHON_VERSION}
 after_success:
     - edm run -e force-bootstrap -- python -m ci coverage --python-version ${PYTHON_VERSION}
-    - edm run -e force-bootstrap -- pip install codecov --python-version ${PYTHON_VERSION}
+    - edm run -e force-bootstrap -- pip install codecov
     - edm run -e force-bootstrap -- codecov
     - bash <(curl -s https://codecov.io/bash)

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -50,7 +50,8 @@ def build_env(python_version):
         "edm", "environments", "remove", "--purge", "--force",
         "--yes", env_name])
     check_call(
-        ["edm", "environments", "create", env_name])
+        ["edm", "environments", "create", "--version", python_version,
+         env_name])
 
     check_call([
         "edm", "install", "-e", env_name,


### PR DESCRIPTION
Fixes an incorrect setup for python 3.5 environment. It was creating a 2.7 one.
Removed incorrect use of python-version in the travis in the meantime.