### PR TITLE
Added an empty list return from parameter factories

### DIFF
--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -135,3 +135,4 @@ class BaseMCOFactory(HasStrictTraits):
         -------
         List of BaseMCOParameterFactory
         """
+        return []

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -2,6 +2,7 @@ import unittest
 
 from traits.trait_errors import TraitError
 
+from force_bdss.mco.base_mco_factory import BaseMCOFactory
 from force_bdss.mco.tests.test_base_mco import DummyMCO
 from force_bdss.mco.tests.test_base_mco_communicator import \
     DummyMCOCommunicator
@@ -29,6 +30,9 @@ class TestBaseMCOFactory(unittest.TestCase):
                               DummyMCOCommunicator)
         self.assertIsInstance(factory.create_model(),
                               DummyMCOModel)
+
+    def test_base_object_parameter_factories(self):
+        factory = BaseMCOFactory(self.plugin)
         self.assertNotEqual(factory.parameter_factories(), [])
 
     def test_broken_get_identifier(self):

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -17,8 +17,20 @@ from envisage.plugin import Plugin
 
 
 class MCOFactory(BaseMCOFactory):
+    def get_identifier(self):
+        return "dummy_mco_2"
+
     def get_name(self):
-        return "foo"
+        return "Dummy MCO 2"
+
+    def get_model_class(self):
+        return DummyMCOModel
+
+    def get_communicator_class(self):
+        return DummyMCOCommunicator
+
+    def get_optimizer_class(self):
+        return DummyMCO
 
 
 class TestBaseMCOFactory(unittest.TestCase):
@@ -38,7 +50,7 @@ class TestBaseMCOFactory(unittest.TestCase):
 
     def test_base_object_parameter_factories(self):
         factory = MCOFactory(self.plugin)
-        self.assertNotEqual(factory.parameter_factories(), [])
+        self.assertEqual(factory.parameter_factories(), [])
 
     def test_broken_get_identifier(self):
         class Broken(DummyMCOFactory):

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -16,6 +16,11 @@ except ImportError:
 from envisage.plugin import Plugin
 
 
+class MCOFactory(BaseMCOFactory):
+    def get_name(self):
+        return "foo"
+
+
 class TestBaseMCOFactory(unittest.TestCase):
     def setUp(self):
         self.plugin = mock.Mock(spec=Plugin, id="pid")
@@ -32,7 +37,7 @@ class TestBaseMCOFactory(unittest.TestCase):
                               DummyMCOModel)
 
     def test_base_object_parameter_factories(self):
-        factory = BaseMCOFactory(self.plugin)
+        factory = MCOFactory(self.plugin)
         self.assertNotEqual(factory.parameter_factories(), [])
 
     def test_broken_get_identifier(self):

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -29,6 +29,7 @@ class TestBaseMCOFactory(unittest.TestCase):
                               DummyMCOCommunicator)
         self.assertIsInstance(factory.create_model(),
                               DummyMCOModel)
+        self.assertEqual(factory.parameter_factories(), [])
 
     def test_broken_get_identifier(self):
         class Broken(DummyMCOFactory):

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -29,7 +29,7 @@ class TestBaseMCOFactory(unittest.TestCase):
                               DummyMCOCommunicator)
         self.assertIsInstance(factory.create_model(),
                               DummyMCOModel)
-        self.assertEqual(factory.parameter_factories(), [])
+        self.assertNotEqual(factory.parameter_factories(), [])
 
     def test_broken_get_identifier(self):
         class Broken(DummyMCOFactory):


### PR DESCRIPTION
Small fix to return an empty list if the parameter_factories is undeclared. The default implementation should just return an empty list.
