### PR TITLE
Removed force-bootstrap from the travis environment. using default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ before_install:
     - export PATH=/usr/lib/ccache:${PATH}
     - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     - export PATH=${HOME}/edm/bin:${PATH}
-    - edm install -y -e force-bootstrap click setuptools
-    - edm run -e force-bootstrap -- python -m ci build-env
+    - edm install -y click setuptools pyyaml
+    - edm run -- python -m ci build-env
 script:
-    - edm run -e force-bootstrap -- python -m ci install
-    - edm run -e force-bootstrap -- python -m ci flake8
-    - edm run -e force-bootstrap -- python -m ci test
-    - edm run -e force-bootstrap -- python -m ci docs
+    - edm run -- python -m ci install
+    - edm run -- python -m ci flake8
+    - edm run -- python -m ci test
+    - edm run -- python -m ci docs
 after_success:
-    - edm run -e force-bootstrap -- python -m ci coverage
-    - edm run -e force-bootstrap -- pip install codecov
-    - edm run -e force-bootstrap -- codecov
+    - edm run -- python -m ci coverage
+    - edm run -- pip install codecov
+    - edm run -- codecov
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - export PATH=/usr/lib/ccache:${PATH}
     - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     - export PATH=${HOME}/edm/bin:${PATH}
-    - edm install -y click setuptools pyyaml
+    - edm install --version 3.5 -y click setuptools
     - edm run -- python -m ci build-env
 script:
     - edm run -- python -m ci install

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -15,7 +15,7 @@ We assume the bootstrap environment is the default one (called ``edm``)::
 
     wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     export PATH=${HOME}/edm/bin:${PATH}
-    edm install --version 3.5 -y pyyaml click setuptools
+    edm install --version 3.5 -y click setuptools
     edm shell
 
 Verify that your prompt changes to add "(edm)".

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -10,21 +10,30 @@ git repositories::
 The last repository is optional, but recommended if you want to practice
 writing plugins.
 
-Next, download EDM package manager, and create a bootstrap environment.
-We assume the bootstrap environment is the default one (called ``edm``)::
+If you never installed the Enthought Deployment Manager, perform the following operations::
 
     wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     export PATH=${HOME}/edm/bin:${PATH}
     edm install --version 3.5 -y click setuptools
     edm shell
 
-Verify that your prompt changes to add "(edm)".
+If you instead already have an EDM installation and a default environment, perform the following:
+
+    edm shell
+    edm install -y click setuptools
+
+Verify that your shell prompt now contains the string "(edm)".
+You are now in your default EDM environment, and we assume this environment to be the bootstrap environment.
+The BDSS software will not be installed in this environment, but in a separate one. The following
+commands however must be executed from the bootstrap environment.
+
 Installation of the force BDSS runtime environment is performed with the
 following command::
 
     python -m ci build-env
 
 This will create another edm environment called ``force-py35``.
+Do not enter this environment. 
 
 To install the BDSS::
 


### PR DESCRIPTION
Staying true to the documentation, we use the default environment to setup the bootstrap