### PR TITLE
Propagate data values in MCO events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ FORCE BDSS Changelog
 Release 0.3.0
 -------------
 
+Backward incompatible changes that require rework of the plugins:
+
+- Design change of the notification infrastructure in MCO:
+    - the started and finished events do not need to be triggered anymore.
+    - the new_data method is now obsolete and must be removed.
+    - the notify_new_point() method must be called to inform of a new optimal
+      point found. The routine accepts list of DataValue objects, not plain
+      floats as before. The weights must also be passed.
+    - A more generic notify() method is available to send arbitrary events
+      (currently only MCOProgressEvent)
+
 - Installation now requires two separate steps to build the environment
   and to install the BDSS (#180)
 - Removed support for python2 (#179)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Release 0.3.0
 
 Backward incompatible changes that require rework of the plugins:
 
-- Design change of the notification infrastructure in MCO:
+- Design change of the notification infrastructure in MCO (#187):
     - the started and finished events do not need to be triggered anymore.
     - the new_data method is now obsolete and must be removed.
     - the notify_new_point() method must be called to inform of a new optimal

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -1,4 +1,4 @@
-from traits.api import HasStrictTraits, Tuple, List, Instance, Float
+from traits.api import HasStrictTraits, List, Instance, Float, Unicode
 
 from force_bdss.core.data_value import DataValue
 
@@ -9,8 +9,11 @@ class BaseDriverEvent(HasStrictTraits):
 
 class MCOStartEvent(BaseDriverEvent):
     """ The MCO driver should emit this event when the evaluation starts."""
-    input_names = Tuple()
-    output_names = Tuple()
+    #: The names assigned to the parameters.
+    parameter_names = List(Unicode())
+
+    #: The names associated to the KPIs
+    kpi_names = List(Unicode())
 
 
 class MCOFinishEvent(BaseDriverEvent):
@@ -18,9 +21,15 @@ class MCOFinishEvent(BaseDriverEvent):
 
 
 class MCOProgressEvent(BaseDriverEvent):
-    """ The MCO driver should emit this event for every new evaluation that has
-    been completed. It carries data about the evaluation, specifically the
-    input data (MCO parameter values) and the resulting output (KPIs)."""
+    """ The MCO driver should emit this event for every new optimal point
+    that is found during the evaluation.
+    """
+    #: The point in parameter space resulting from the pareto
+    #: front optimization
     optimal_point = List(Instance(DataValue))
+
+    #: The associated KPIs to the above point
     optimal_kpis = List(Instance(DataValue))
+
+    #: The weights assigned to the KPIs
     weights = List(Float())

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -1,6 +1,7 @@
 from traits.api import HasStrictTraits, List, Instance, Float, Unicode
 
 from force_bdss.core.data_value import DataValue
+from force_bdss.io.workflow_writer import pop_recursive
 
 
 class BaseDriverEvent(HasStrictTraits):
@@ -38,4 +39,5 @@ class MCOProgressEvent(BaseDriverEvent):
         d = super().__getstate__()
         d["optimal_point"] = [dv.__getstate__() for dv in d["optimal_point"]]
         d["optimal_kpis"] = [dv.__getstate__() for dv in d["optimal_kpis"]]
+        pop_recursive(d, "__traits_version__")
         return d

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -1,4 +1,6 @@
-from traits.api import HasStrictTraits, Tuple
+from traits.api import HasStrictTraits, Tuple, List, Instance, Float
+
+from force_bdss.core.data_value import DataValue
 
 
 class BaseDriverEvent(HasStrictTraits):
@@ -19,5 +21,6 @@ class MCOProgressEvent(BaseDriverEvent):
     """ The MCO driver should emit this event for every new evaluation that has
     been completed. It carries data about the evaluation, specifically the
     input data (MCO parameter values) and the resulting output (KPIs)."""
-    input = Tuple()
-    output = Tuple()
+    optimal_point = List(Instance(DataValue))
+    optimal_kpis = List(Instance(DataValue))
+    weights = List(Float())

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -33,3 +33,9 @@ class MCOProgressEvent(BaseDriverEvent):
 
     #: The weights assigned to the KPIs
     weights = List(Float())
+
+    def __getstate__(self):
+        d = super().__getstate__()
+        d["optimal_point"] = [dv.__getstate__() for dv in d["optimal_point"]]
+        d["optimal_kpis"] = [dv.__getstate__() for dv in d["optimal_kpis"]]
+        return d

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -9,7 +9,7 @@ from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.notification_listeners.base_notification_listener import \
     BaseNotificationListener
 from .base_core_driver import BaseCoreDriver
-from .core_driver_events import MCOStartEvent, MCOFinishEvent, MCOProgressEvent
+from .core_driver_events import MCOStartEvent, MCOFinishEvent
 
 log = logging.getLogger(__name__)
 

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -32,12 +32,12 @@ class CoreMCODriver(BaseCoreDriver):
             log.exception("Unable to open workflow file.")
             sys.exit(1)
 
-        errors = verify_workflow(workflow)
+        workflow_errors = verify_workflow(workflow)
 
-        if len(errors) != 0:
+        if len(workflow_errors) != 0:
             log.error("Unable to execute workflow due to verification "
                       "errors :")
-            for err in errors:
+            for err in workflow_errors:
                 log.error(err.local_error)
             sys.exit(1)
 

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -64,7 +64,8 @@ class CoreMCODriver(BaseCoreDriver):
         finally:
             self._deliver_finish_event()
 
-        sys.exit(1 if error else 0)
+        if error:
+            sys.exit(1)
 
     @on_trait_change("application:stopping")
     def application_stopping(self):

--- a/force_bdss/core_mco_driver.py
+++ b/force_bdss/core_mco_driver.py
@@ -49,6 +49,8 @@ class CoreMCODriver(BaseCoreDriver):
             )
             sys.exit(1)
 
+        error = False
+        self._deliver_start_event()
         try:
             mco.run(self.workflow.mco)
         except Exception:
@@ -58,7 +60,11 @@ class CoreMCODriver(BaseCoreDriver):
                 "programming error in the plugin.".format(
                     mco.factory.id,
                     mco.factory.plugin.id))
-            sys.exit(1)
+            error = True
+        finally:
+            self._deliver_finish_event()
+
+        sys.exit(1 if error else 0)
 
     @on_trait_change("application:stopping")
     def application_stopping(self):
@@ -86,22 +92,17 @@ class CoreMCODriver(BaseCoreDriver):
 
         return optimizer
 
-    @on_trait_change("mco:started")
     def _deliver_start_event(self):
         mco_model = self.workflow.mco
         self._deliver_event(MCOStartEvent(
-            input_names=tuple(p.name for p in mco_model.parameters),
-            output_names=tuple([kpi.name for kpi in mco_model.kpis])
+            parameter_names=list(p.name for p in mco_model.parameters),
+            kpi_names=list(kpi.name for kpi in mco_model.kpis)
         ))
 
-    @on_trait_change("mco:finished")
-    def _deliver_finished_event(self):
+    def _deliver_finish_event(self):
         self._deliver_event(MCOFinishEvent())
 
-    @on_trait_change("mco:new_data")
-    def _deliver_mco_progress_event(self, data):
-        self._deliver_event(MCOProgressEvent(**data))
-
+    @on_trait_change("mco:event")
     def _deliver_event(self, event):
         """ Delivers an event to the listeners """
         for listener in self.listeners[:]:

--- a/force_bdss/mco/base_mco.py
+++ b/force_bdss/mco/base_mco.py
@@ -1,7 +1,8 @@
 import abc
 
-from traits.api import ABCHasStrictTraits, Instance, Event, Dict, Str, Tuple
+from traits.api import ABCHasStrictTraits, Instance, Event
 
+from force_bdss.core_driver_events import MCOProgressEvent
 from .i_mco_factory import IMCOFactory
 
 
@@ -13,14 +14,8 @@ class BaseMCO(ABCHasStrictTraits):
     #: A reference to the factory
     factory = Instance(IMCOFactory)
 
-    #: Triggered when the evaluation started.
-    started = Event()
-
-    #: Triggered when the evaluation finished
-    finished = Event()
-
-    # Event triggered when the mco wants to send new data to listeners
-    new_data = Event(Dict(Str(), Tuple()))
+    #: Propagation channel for events from the MCO
+    event = Event()
 
     def __init__(self, factory, *args, **kwargs):
         """Initializes the MCO.
@@ -44,3 +39,38 @@ class BaseMCO(ABCHasStrictTraits):
             An instance of the model information, as created from
             create_model()
         """
+
+    def notify_new_point(self, optimal_point, optimal_kpis, weights):
+        """Notify the discovery of a new optimal point.
+
+        Parameters
+        ----------
+        optimal_point: List(Instance(DataValue))
+            A list of DataValue objects describing the point in parameter
+            space that produces an optimised result.
+
+        optimal_kpis: List(Instance(DataValue))
+            A list of DataValue objects describing the KPI values resulting
+            from the optimal_point values above.
+
+        weights: List(Float())
+            A list of weight values from 0.0 to 1.0 that have been assigned
+            for this point to each KPI.
+        """
+        self.notify(MCOProgressEvent(
+            optimal_point=optimal_point,
+            optimal_kpis=optimal_kpis,
+            weights=weights,
+        ))
+
+    def notify(self, event):
+        """Notify the listeners with an event. The notification will be
+        synchronous. All notification listeners will receive the event, one
+        after another.
+
+        Parameters
+        ----------
+        event: BaseMCOEvent
+            The event to broadcast.
+        """
+        self.event = event

--- a/force_bdss/tests/test_base_extension_plugin.py
+++ b/force_bdss/tests/test_base_extension_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import unittest
+import testfixtures
 try:
     import mock
 except ImportError:
@@ -25,7 +26,8 @@ class TestBaseExtensionPlugin(unittest.TestCase):
 
     def test_exception(self):
         with mock.patch.object(ProbeExtensionPlugin, "get_name") \
-                as mock_get_name:
+                as mock_get_name, \
+                testfixtures.LogCapture():
             mock_get_name.side_effect = Exception("Boom")
             plugin = ProbeExtensionPlugin()
 

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -1,0 +1,42 @@
+import unittest
+
+from force_bdss.core.data_value import DataValue
+from force_bdss.core_driver_events import MCOProgressEvent
+
+
+class TestCoreDriverEvents(unittest.TestCase):
+    def test_getstate_for_progress_event(self):
+        ev = MCOProgressEvent()
+        ev.optimal_kpis = [DataValue(value=10)]
+        ev.optimal_point = [DataValue(value=12), DataValue(value=13)]
+        ev.weights = [1.0]
+
+        self.maxDiff = 1000
+        self.assertEqual(ev.__getstate__(),
+            {
+                'optimal_kpis': [
+                    {
+                        'accuracy': None,
+                        'name': '',
+                        'quality': 'AVERAGE',
+                        'type': '',
+                        'value': 10
+                    }],
+                'optimal_point': [
+                   {
+                       'accuracy': None,
+                       'name': '',
+                       'quality': 'AVERAGE',
+                       'type': '',
+                       'value': 12},
+                   {
+                       'accuracy': None,
+                       'name': '',
+                       'quality': 'AVERAGE',
+                       'type': '',
+                       'value': 13
+                   }
+                ],
+                'weights': [1.0]
+            }
+        )

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -12,7 +12,8 @@ class TestCoreDriverEvents(unittest.TestCase):
         ev.weights = [1.0]
 
         self.maxDiff = 1000
-        self.assertEqual(ev.__getstate__(),
+        self.assertEqual(
+            ev.__getstate__(),
             {
                 'optimal_kpis': [
                     {


### PR DESCRIPTION
- Restructures events so that we propagate the full DataValue, rather than the plain values.
- Changes the naming of entities on the events.
- makes started and finished events obsolete.

This is a backward incompatible change. wfmanager and plugins must be readapted.
