### PR TITLE
Changed plugin ids for internal plugins to prevent conflicts.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Backward incompatible changes that require rework of the plugins:
 
 Internal changes:
 
-- Changed internal plugin ids to prevent conflicts with external ones.
+- Changed internal plugin ids to prevent conflicts with external ones (#131)
 
 Release 0.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Backward incompatible changes that require rework of the plugins:
   and to install the BDSS (#180)
 - Removed support for python2 (#179)
 
+Internal changes:
+
+- Changed internal plugin ids to prevent conflicts with external ones.
+
 Release 0.2.0
 -------------
 
@@ -27,4 +31,5 @@ Release 0.2.0
 Release 0.1.0
 -------------
 
-- Initial release. Implements basic functionality of the BDSS and its plugin system.
+- Initial release. Implements basic functionality of the BDSS and its
+  plugin system.

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 class BDSSApplication(Application):
     """Main application for the BDSS.
     """
-    id = "force_bdss.bdss_application"
+    id = "force.bdss_core.bdss_application"
 
     #: The path of the workflow file to open
     workflow_filepath = Unicode()

--- a/force_bdss/ids.py
+++ b/force_bdss/ids.py
@@ -6,16 +6,16 @@ class ExtensionPointID:
     as they just have to reimplement the plugin base class and implement
     the appropriate default methods.
     """
-    MCO_FACTORIES = 'force.bdss.mco.factories'
-    DATA_SOURCE_FACTORIES = 'force.bdss.data_source.factories'
+    MCO_FACTORIES = 'force.bdss_core.mco.factories'
+    DATA_SOURCE_FACTORIES = 'force.bdss_core.data_source.factories'
     NOTIFICATION_LISTENER_FACTORIES = \
-        'force.bdss.notification_listener.factories'
-    UI_HOOKS_FACTORIES = 'force.bdss.ui_hooks.factories'
+        'force.bdss_core.notification_listener.factories'
+    UI_HOOKS_FACTORIES = 'force.bdss_core.ui_hooks.factories'
 
 
 class InternalPluginID:
-    CORE_MCO_DRIVER_ID = "force.bdss.core.CoreMCODriver"
-    CORE_EVALUATION_DRIVER_ID = "force.bdss.core.CoreEvaluationDriver"
+    CORE_MCO_DRIVER_ID = "force.bdss_core.CoreMCODriver"
+    CORE_EVALUATION_DRIVER_ID = "force.bdss_core.CoreEvaluationDriver"
 
 
 def factory_id(plugin_id, identifier):


### PR DESCRIPTION
To prevent conflicts with external plugins having "core" as producer, changes the internal plugin identifier. 
For consistency, also changes the rest of the internal ids to follow the same naming scheme.