### PR TITLE
Instantiate parameter factories once

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Release 0.3.0
 
 Backward incompatible changes that require rework of the plugins:
 
+- Parameter factories are now instantiated once and for all (#135).
+  - requires to change the plugins to return a list of factory classes
+    in the get_parameter_factory_classes() method, instead of the
+    parameter_factories() method. This method becomes a trait now.
+    All plugins exporting an MCO must be updated.
 - Design change of the notification infrastructure in MCO (#187):
     - the started and finished events do not need to be triggered anymore.
     - the new_data method is now obsolete and must be removed.

--- a/doc/source/api/force_bdss.cli.rst
+++ b/doc/source/api/force_bdss.cli.rst
@@ -1,5 +1,5 @@
-force\_bdss.cli package
-=======================
+force\_bdss\.cli package
+========================
 
 Subpackages
 -----------
@@ -11,8 +11,8 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.cli.force\_bdss module
-----------------------------------
+force\_bdss\.cli\.force\_bdss module
+------------------------------------
 
 .. automodule:: force_bdss.cli.force_bdss
     :members:

--- a/doc/source/api/force_bdss.cli.tests.rst
+++ b/doc/source/api/force_bdss.cli.tests.rst
@@ -1,11 +1,11 @@
-force\_bdss.cli.tests package
-=============================
+force\_bdss\.cli\.tests package
+===============================
 
 Submodules
 ----------
 
-force\_bdss.cli.tests.test\_execution module
---------------------------------------------
+force\_bdss\.cli\.tests\.test\_execution module
+-----------------------------------------------
 
 .. automodule:: force_bdss.cli.tests.test_execution
     :members:

--- a/doc/source/api/force_bdss.core.rst
+++ b/doc/source/api/force_bdss.core.rst
@@ -1,5 +1,5 @@
-force\_bdss.core package
-========================
+force\_bdss\.core package
+=========================
 
 Subpackages
 -----------
@@ -11,48 +11,96 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.core.data\_value module
------------------------------------
+force\_bdss\.core\.base\_factory module
+---------------------------------------
+
+.. automodule:: force_bdss.core.base_factory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.base\_model module
+-------------------------------------
+
+.. automodule:: force_bdss.core.base_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.data\_value module
+-------------------------------------
 
 .. automodule:: force_bdss.core.data_value
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.execution\_layer module
-----------------------------------------
+force\_bdss\.core\.execution module
+-----------------------------------
+
+.. automodule:: force_bdss.core.execution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.execution\_layer module
+------------------------------------------
 
 .. automodule:: force_bdss.core.execution_layer
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.input\_slot\_info module
------------------------------------------
+force\_bdss\.core\.i\_factory module
+------------------------------------
+
+.. automodule:: force_bdss.core.i_factory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.input\_slot\_info module
+-------------------------------------------
 
 .. automodule:: force_bdss.core.input_slot_info
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.output\_slot\_info module
-------------------------------------------
+force\_bdss\.core\.kpi\_specification module
+--------------------------------------------
+
+.. automodule:: force_bdss.core.kpi_specification
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.output\_slot\_info module
+--------------------------------------------
 
 .. automodule:: force_bdss.core.output_slot_info
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.slot module
-----------------------------
+force\_bdss\.core\.slot module
+------------------------------
 
 .. automodule:: force_bdss.core.slot
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.workflow module
---------------------------------
+force\_bdss\.core\.verifier module
+----------------------------------
+
+.. automodule:: force_bdss.core.verifier
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.workflow module
+----------------------------------
 
 .. automodule:: force_bdss.core.workflow
     :members:

--- a/doc/source/api/force_bdss.core.tests.rst
+++ b/doc/source/api/force_bdss.core.tests.rst
@@ -1,29 +1,45 @@
-force\_bdss.core.tests package
-==============================
+force\_bdss\.core\.tests package
+================================
 
 Submodules
 ----------
 
-force\_bdss.core.tests.test\_data\_value module
------------------------------------------------
+force\_bdss\.core\.tests\.test\_data\_value module
+--------------------------------------------------
 
 .. automodule:: force_bdss.core.tests.test_data_value
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.tests.test\_input\_slot\_info module
------------------------------------------------------
+force\_bdss\.core\.tests\.test\_execution module
+------------------------------------------------
+
+.. automodule:: force_bdss.core.tests.test_execution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.tests\.test\_input\_slot\_info module
+--------------------------------------------------------
 
 .. automodule:: force_bdss.core.tests.test_input_slot_info
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core.tests.test\_slot module
-----------------------------------------
+force\_bdss\.core\.tests\.test\_slot module
+-------------------------------------------
 
 .. automodule:: force_bdss.core.tests.test_slot
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.core\.tests\.test\_verifier module
+-----------------------------------------------
+
+.. automodule:: force_bdss.core.tests.test_verifier
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.core_plugins.rst
+++ b/doc/source/api/force_bdss.core_plugins.rst
@@ -1,5 +1,5 @@
-force\_bdss.core\_plugins package
-=================================
+force\_bdss\.core\_plugins package
+==================================
 
 Module contents
 ---------------

--- a/doc/source/api/force_bdss.data_sources.rst
+++ b/doc/source/api/force_bdss.data_sources.rst
@@ -1,5 +1,5 @@
-force\_bdss.data\_sources package
-=================================
+force\_bdss\.data\_sources package
+==================================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.data\_sources.base\_data\_source module
----------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.data\_sources.base\_data\_source\_factory module
-------------------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source\_factory module
+--------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.data\_sources.base\_data\_source\_model module
-----------------------------------------------------------
+force\_bdss\.data\_sources\.base\_data\_source\_model module
+------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.base_data_source_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.data\_sources.i\_data\_source\_factory module
----------------------------------------------------------
+force\_bdss\.data\_sources\.i\_data\_source\_factory module
+-----------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.i_data_source_factory
     :members:

--- a/doc/source/api/force_bdss.data_sources.tests.rst
+++ b/doc/source/api/force_bdss.data_sources.tests.rst
@@ -1,27 +1,27 @@
-force\_bdss.data\_sources.tests package
-=======================================
+force\_bdss\.data\_sources\.tests package
+=========================================
 
 Submodules
 ----------
 
-force\_bdss.data\_sources.tests.test\_base\_data\_source module
----------------------------------------------------------------
+force\_bdss\.data\_sources\.tests\.test\_base\_data\_source module
+------------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.data\_sources.tests.test\_base\_data\_source\_factory module
-------------------------------------------------------------------------
+force\_bdss\.data\_sources\.tests\.test\_base\_data\_source\_factory module
+---------------------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.data\_sources.tests.test\_base\_data\_source\_model module
-----------------------------------------------------------------------
+force\_bdss\.data\_sources\.tests\.test\_base\_data\_source\_model module
+-------------------------------------------------------------------------
 
 .. automodule:: force_bdss.data_sources.tests.test_base_data_source_model
     :members:

--- a/doc/source/api/force_bdss.io.rst
+++ b/doc/source/api/force_bdss.io.rst
@@ -1,5 +1,5 @@
-force\_bdss.io package
-======================
+force\_bdss\.io package
+=======================
 
 Subpackages
 -----------
@@ -11,16 +11,16 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.io.workflow\_reader module
---------------------------------------
+force\_bdss\.io\.workflow\_reader module
+----------------------------------------
 
 .. automodule:: force_bdss.io.workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.io.workflow\_writer module
---------------------------------------
+force\_bdss\.io\.workflow\_writer module
+----------------------------------------
 
 .. automodule:: force_bdss.io.workflow_writer
     :members:

--- a/doc/source/api/force_bdss.io.tests.rst
+++ b/doc/source/api/force_bdss.io.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss.io.tests package
-============================
+force\_bdss\.io\.tests package
+==============================
 
 Submodules
 ----------
 
-force\_bdss.io.tests.test\_workflow\_reader module
---------------------------------------------------
+force\_bdss\.io\.tests\.test\_workflow\_reader module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_reader
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.io.tests.test\_workflow\_writer module
---------------------------------------------------
+force\_bdss\.io\.tests\.test\_workflow\_writer module
+-----------------------------------------------------
 
 .. automodule:: force_bdss.io.tests.test_workflow_writer
     :members:

--- a/doc/source/api/force_bdss.mco.parameters.rst
+++ b/doc/source/api/force_bdss.mco.parameters.rst
@@ -1,5 +1,5 @@
-force\_bdss.mco.parameters package
-==================================
+force\_bdss\.mco\.parameters package
+====================================
 
 Subpackages
 -----------
@@ -11,18 +11,26 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.mco.parameters.base\_mco\_parameter module
-------------------------------------------------------
+force\_bdss\.mco\.parameters\.base\_mco\_parameter module
+---------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.parameters.base\_mco\_parameter\_factory module
----------------------------------------------------------------
+force\_bdss\.mco\.parameters\.base\_mco\_parameter\_factory module
+------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.base_mco_parameter_factory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.mco\.parameters\.i\_mco\_parameter\_factory module
+---------------------------------------------------------------
+
+.. automodule:: force_bdss.mco.parameters.i_mco_parameter_factory
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/force_bdss.mco.parameters.tests.rst
+++ b/doc/source/api/force_bdss.mco.parameters.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss.mco.parameters.tests package
-========================================
+force\_bdss\.mco\.parameters\.tests package
+===========================================
 
 Submodules
 ----------
 
-force\_bdss.mco.parameters.tests.test\_base\_mco\_parameter module
-------------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter module
+----------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.parameters.tests.test\_base\_mco\_parameter\_factory module
----------------------------------------------------------------------------
+force\_bdss\.mco\.parameters\.tests\.test\_base\_mco\_parameter\_factory module
+-------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.parameters.tests.test_base_mco_parameter_factory
     :members:

--- a/doc/source/api/force_bdss.mco.rst
+++ b/doc/source/api/force_bdss.mco.rst
@@ -1,5 +1,5 @@
-force\_bdss.mco package
-=======================
+force\_bdss\.mco package
+========================
 
 Subpackages
 -----------
@@ -12,40 +12,40 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.mco.base\_mco module
---------------------------------
+force\_bdss\.mco\.base\_mco module
+----------------------------------
 
 .. automodule:: force_bdss.mco.base_mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.base\_mco\_communicator module
-----------------------------------------------
+force\_bdss\.mco\.base\_mco\_communicator module
+------------------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.base\_mco\_factory module
------------------------------------------
+force\_bdss\.mco\.base\_mco\_factory module
+-------------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.base\_mco\_model module
----------------------------------------
+force\_bdss\.mco\.base\_mco\_model module
+-----------------------------------------
 
 .. automodule:: force_bdss.mco.base_mco_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.i\_mco\_factory module
---------------------------------------
+force\_bdss\.mco\.i\_mco\_factory module
+----------------------------------------
 
 .. automodule:: force_bdss.mco.i_mco_factory
     :members:

--- a/doc/source/api/force_bdss.mco.tests.rst
+++ b/doc/source/api/force_bdss.mco.tests.rst
@@ -1,27 +1,27 @@
-force\_bdss.mco.tests package
-=============================
+force\_bdss\.mco\.tests package
+===============================
 
 Submodules
 ----------
 
-force\_bdss.mco.tests.test\_base\_mco module
---------------------------------------------
+force\_bdss\.mco\.tests\.test\_base\_mco module
+-----------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.tests.test\_base\_mco\_communicator module
-----------------------------------------------------------
+force\_bdss\.mco\.tests\.test\_base\_mco\_communicator module
+-------------------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_communicator
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.mco.tests.test\_base\_mco\_factory module
------------------------------------------------------
+force\_bdss\.mco\.tests\.test\_base\_mco\_factory module
+--------------------------------------------------------
 
 .. automodule:: force_bdss.mco.tests.test_base_mco_factory
     :members:

--- a/doc/source/api/force_bdss.notification_listeners.rst
+++ b/doc/source/api/force_bdss.notification_listeners.rst
@@ -1,5 +1,5 @@
-force\_bdss.notification\_listeners package
-===========================================
+force\_bdss\.notification\_listeners package
+============================================
 
 Subpackages
 -----------
@@ -11,32 +11,32 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.notification\_listeners.base\_notification\_listener module
------------------------------------------------------------------------
+force\_bdss\.notification\_listeners\.base\_notification\_listener module
+-------------------------------------------------------------------------
 
 .. automodule:: force_bdss.notification_listeners.base_notification_listener
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.notification\_listeners.base\_notification\_listener\_factory module
---------------------------------------------------------------------------------
+force\_bdss\.notification\_listeners\.base\_notification\_listener\_factory module
+----------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.notification_listeners.base_notification_listener_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.notification\_listeners.base\_notification\_listener\_model module
-------------------------------------------------------------------------------
+force\_bdss\.notification\_listeners\.base\_notification\_listener\_model module
+--------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.notification_listeners.base_notification_listener_model
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.notification\_listeners.i\_notification\_listener\_factory module
------------------------------------------------------------------------------
+force\_bdss\.notification\_listeners\.i\_notification\_listener\_factory module
+-------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.notification_listeners.i_notification_listener_factory
     :members:

--- a/doc/source/api/force_bdss.notification_listeners.tests.rst
+++ b/doc/source/api/force_bdss.notification_listeners.tests.rst
@@ -1,11 +1,11 @@
-force\_bdss.notification\_listeners.tests package
-=================================================
+force\_bdss\.notification\_listeners\.tests package
+===================================================
 
 Submodules
 ----------
 
-force\_bdss.notification\_listeners.tests.test\_base\_notification\_listener\_factory module
---------------------------------------------------------------------------------------------
+force\_bdss\.notification\_listeners\.tests\.test\_base\_notification\_listener\_factory module
+-----------------------------------------------------------------------------------------------
 
 .. automodule:: force_bdss.notification_listeners.tests.test_base_notification_listener_factory
     :members:

--- a/doc/source/api/force_bdss.rst
+++ b/doc/source/api/force_bdss.rst
@@ -19,88 +19,88 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.api module
-----------------------
+force\_bdss\.api module
+-----------------------
 
 .. automodule:: force_bdss.api
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.base\_core\_driver module
--------------------------------------
+force\_bdss\.base\_core\_driver module
+--------------------------------------
 
 .. automodule:: force_bdss.base_core_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.base\_extension\_plugin module
-------------------------------------------
+force\_bdss\.base\_extension\_plugin module
+-------------------------------------------
 
 .. automodule:: force_bdss.base_extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.bdss\_application module
-------------------------------------
+force\_bdss\.bdss\_application module
+-------------------------------------
 
 .. automodule:: force_bdss.bdss_application
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core\_driver\_events module
----------------------------------------
+force\_bdss\.core\_driver\_events module
+----------------------------------------
 
 .. automodule:: force_bdss.core_driver_events
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core\_evaluation\_driver module
--------------------------------------------
+force\_bdss\.core\_evaluation\_driver module
+--------------------------------------------
 
 .. automodule:: force_bdss.core_evaluation_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.core\_mco\_driver module
-------------------------------------
+force\_bdss\.core\_mco\_driver module
+-------------------------------------
 
 .. automodule:: force_bdss.core_mco_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.factory\_registry\_plugin module
---------------------------------------------
+force\_bdss\.factory\_registry\_plugin module
+---------------------------------------------
 
 .. automodule:: force_bdss.factory_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.ids module
-----------------------
+force\_bdss\.ids module
+-----------------------
 
 .. automodule:: force_bdss.ids
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.local\_traits module
---------------------------------
+force\_bdss\.local\_traits module
+---------------------------------
 
 .. automodule:: force_bdss.local_traits
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.version module
---------------------------
+force\_bdss\.version module
+---------------------------
 
 .. automodule:: force_bdss.version
     :members:

--- a/doc/source/api/force_bdss.tests.dummy_classes.rst
+++ b/doc/source/api/force_bdss.tests.dummy_classes.rst
@@ -1,51 +1,51 @@
-force\_bdss.tests.dummy\_classes package
-========================================
+force\_bdss\.tests\.dummy\_classes package
+==========================================
 
 Submodules
 ----------
 
-force\_bdss.tests.dummy\_classes.data\_source module
-----------------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.data\_source module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.dummy\_classes.extension\_plugin module
----------------------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.extension\_plugin module
+------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.dummy\_classes.factory\_registry\_plugin module
------------------------------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.factory\_registry\_plugin module
+--------------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.factory_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.dummy\_classes.mco module
--------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.mco module
+----------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.dummy\_classes.notification\_listener module
---------------------------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.notification\_listener module
+-----------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.notification_listener
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.dummy\_classes.ui\_hooks module
--------------------------------------------------
+force\_bdss\.tests\.dummy\_classes\.ui\_hooks module
+----------------------------------------------------
 
 .. automodule:: force_bdss.tests.dummy_classes.ui_hooks
     :members:

--- a/doc/source/api/force_bdss.tests.fixtures.rst
+++ b/doc/source/api/force_bdss.tests.fixtures.rst
@@ -1,5 +1,5 @@
-force\_bdss.tests.fixtures package
-==================================
+force\_bdss\.tests\.fixtures package
+====================================
 
 Module contents
 ---------------

--- a/doc/source/api/force_bdss.tests.probe_classes.rst
+++ b/doc/source/api/force_bdss.tests.probe_classes.rst
@@ -1,51 +1,51 @@
-force\_bdss.tests.probe\_classes package
-========================================
+force\_bdss\.tests\.probe\_classes package
+==========================================
 
 Submodules
 ----------
 
-force\_bdss.tests.probe\_classes.data\_source module
-----------------------------------------------------
+force\_bdss\.tests\.probe\_classes\.data\_source module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.data_source
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.probe\_classes.factory\_registry\_plugin module
------------------------------------------------------------------
+force\_bdss\.tests\.probe\_classes\.factory\_registry\_plugin module
+--------------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.factory_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.probe\_classes.mco module
--------------------------------------------
+force\_bdss\.tests\.probe\_classes\.mco module
+----------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.mco
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.probe\_classes.notification\_listener module
---------------------------------------------------------------
+force\_bdss\.tests\.probe\_classes\.notification\_listener module
+-----------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.notification_listener
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.probe\_classes.probe\_extension\_plugin module
-----------------------------------------------------------------
+force\_bdss\.tests\.probe\_classes\.probe\_extension\_plugin module
+-------------------------------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.probe_extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.probe\_classes.ui\_hooks module
--------------------------------------------------
+force\_bdss\.tests\.probe\_classes\.ui\_hooks module
+----------------------------------------------------
 
 .. automodule:: force_bdss.tests.probe_classes.ui_hooks
     :members:

--- a/doc/source/api/force_bdss.tests.rst
+++ b/doc/source/api/force_bdss.tests.rst
@@ -1,5 +1,5 @@
-force\_bdss.tests package
-=========================
+force\_bdss\.tests package
+==========================
 
 Subpackages
 -----------
@@ -13,64 +13,72 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.tests.test\_base\_extension\_plugin module
-------------------------------------------------------
+force\_bdss\.tests\.test\_base\_extension\_plugin module
+--------------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_base_extension_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_bdss\_application module
-------------------------------------------------
+force\_bdss\.tests\.test\_bdss\_application module
+--------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_bdss_application
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_core\_evaluation\_driver module
--------------------------------------------------------
+force\_bdss\.tests\.test\_core\_driver\_events module
+-----------------------------------------------------
+
+.. automodule:: force_bdss.tests.test_core_driver_events
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+force\_bdss\.tests\.test\_core\_evaluation\_driver module
+---------------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_core_evaluation_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_core\_mco\_driver module
-------------------------------------------------
+force\_bdss\.tests\.test\_core\_mco\_driver module
+--------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_core_mco_driver
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_factory\_registry\_plugin module
---------------------------------------------------------
+force\_bdss\.tests\.test\_factory\_registry\_plugin module
+----------------------------------------------------------
 
 .. automodule:: force_bdss.tests.test_factory_registry_plugin
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_ids module
-----------------------------------
+force\_bdss\.tests\.test\_ids module
+------------------------------------
 
 .. automodule:: force_bdss.tests.test_ids
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.test\_local\_traits module
---------------------------------------------
+force\_bdss\.tests\.test\_local\_traits module
+----------------------------------------------
 
 .. automodule:: force_bdss.tests.test_local_traits
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.tests.utils module
-------------------------------
+force\_bdss\.tests\.utils module
+--------------------------------
 
 .. automodule:: force_bdss.tests.utils
     :members:

--- a/doc/source/api/force_bdss.ui_hooks.rst
+++ b/doc/source/api/force_bdss.ui_hooks.rst
@@ -1,5 +1,5 @@
-force\_bdss.ui\_hooks package
-=============================
+force\_bdss\.ui\_hooks package
+==============================
 
 Subpackages
 -----------
@@ -11,24 +11,24 @@ Subpackages
 Submodules
 ----------
 
-force\_bdss.ui\_hooks.base\_ui\_hooks\_factory module
------------------------------------------------------
+force\_bdss\.ui\_hooks\.base\_ui\_hooks\_factory module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.ui_hooks.base_ui_hooks_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.ui\_hooks.base\_ui\_hooks\_manager module
------------------------------------------------------
+force\_bdss\.ui\_hooks\.base\_ui\_hooks\_manager module
+-------------------------------------------------------
 
 .. automodule:: force_bdss.ui_hooks.base_ui_hooks_manager
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.ui\_hooks.i\_ui\_hooks\_factory module
---------------------------------------------------
+force\_bdss\.ui\_hooks\.i\_ui\_hooks\_factory module
+----------------------------------------------------
 
 .. automodule:: force_bdss.ui_hooks.i_ui_hooks_factory
     :members:

--- a/doc/source/api/force_bdss.ui_hooks.tests.rst
+++ b/doc/source/api/force_bdss.ui_hooks.tests.rst
@@ -1,19 +1,19 @@
-force\_bdss.ui\_hooks.tests package
-===================================
+force\_bdss\.ui\_hooks\.tests package
+=====================================
 
 Submodules
 ----------
 
-force\_bdss.ui\_hooks.tests.test\_base\_ui\_hooks\_factory module
------------------------------------------------------------------
+force\_bdss\.ui\_hooks\.tests\.test\_base\_ui\_hooks\_factory module
+--------------------------------------------------------------------
 
 .. automodule:: force_bdss.ui_hooks.tests.test_base_ui_hooks_factory
     :members:
     :undoc-members:
     :show-inheritance:
 
-force\_bdss.ui\_hooks.tests.test\_base\_ui\_hooks\_manager module
------------------------------------------------------------------
+force\_bdss\.ui\_hooks\.tests\.test\_base\_ui\_hooks\_manager module
+--------------------------------------------------------------------
 
 .. automodule:: force_bdss.ui_hooks.tests.test_base_ui_hooks_manager
     :members:

--- a/doc/source/plugin_development.rst
+++ b/doc/source/plugin_development.rst
@@ -149,9 +149,9 @@ as in data source factory. The following::
 
 Must return classes of the MCO and the MCOCommunicator. Finally::
 
-    def parameter_factories(self):
+    def get_parameter_factory_classes(self):
 
-Must return a list of instances (NOT classes) of the parameter factories.
+Must return a list of classes of the parameter factories.
 
 MCO Communicator
 ^^^^^^^^^^^^^^^^

--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -38,7 +38,7 @@ class TestVerifier(unittest.TestCase):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
         wf.mco = mco_factory.create_model()
-        parameter_factory = mco_factory.parameter_factories()[0]
+        parameter_factory = mco_factory.parameter_factories[0]
         wf.mco.parameters.append(parameter_factory.create_model())
 
         errors = verify_workflow(wf)
@@ -66,7 +66,7 @@ class TestVerifier(unittest.TestCase):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
         wf.mco = mco_factory.create_model()
-        parameter_factory = mco_factory.parameter_factories()[0]
+        parameter_factory = mco_factory.parameter_factories[0]
         wf.mco.parameters.append(parameter_factory.create_model())
         wf.mco.parameters[0].name = "name"
         wf.mco.parameters[0].type = "type"
@@ -83,7 +83,7 @@ class TestVerifier(unittest.TestCase):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
         wf.mco = mco_factory.create_model()
-        parameter_factory = mco_factory.parameter_factories()[0]
+        parameter_factory = mco_factory.parameter_factories[0]
         wf.mco.parameters.append(parameter_factory.create_model())
         wf.mco.parameters[0].name = "name"
         wf.mco.parameters[0].type = "type"

--- a/force_bdss/factory_registry_plugin.py
+++ b/force_bdss/factory_registry_plugin.py
@@ -132,7 +132,7 @@ class FactoryRegistryPlugin(Plugin):
         """
         mco_factory = self.mco_factory_by_id(mco_id)
 
-        for factory in mco_factory.parameter_factories():
+        for factory in mco_factory.parameter_factories:
             if factory.id == parameter_id:
                 return factory
 

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -20,7 +20,7 @@ class TestWorkflowWriter(unittest.TestCase):
     def setUp(self):
         self.registry = DummyFactoryRegistryPlugin()
         self.mco_factory = self.registry.mco_factories[0]
-        self.mco_parameter_factory = self.mco_factory.parameter_factories()[0]
+        self.mco_parameter_factory = self.mco_factory.parameter_factories[0]
         self.data_source_factory = self.registry.data_source_factories[0]
 
     def test_write(self):

--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -119,6 +119,6 @@ class BaseMCOFactory(BaseFactory):
         -------
         List of BaseMCOParameterFactory
         """
-        return [factory(self)
-                for factory in self.parameter_factory_classes
+        return [factory_cls(self)
+                for factory_cls in self.parameter_factory_classes
                 ]

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -29,6 +29,9 @@ class MCOFactory(BaseMCOFactory):
     def get_optimizer_class(self):
         return DummyMCO
 
+    def get_parameter_factory_classes(self):
+        return []
+
 
 class TestBaseMCOFactory(unittest.TestCase):
     def setUp(self):
@@ -47,7 +50,7 @@ class TestBaseMCOFactory(unittest.TestCase):
 
     def test_base_object_parameter_factories(self):
         factory = MCOFactory(self.plugin)
-        self.assertEqual(factory.parameter_factories(), [])
+        self.assertEqual(factory.parameter_factories, [])
 
     def test_broken_get_identifier(self):
         class Broken(DummyMCOFactory):

--- a/force_bdss/tests/dummy_classes/factory_registry_plugin.py
+++ b/force_bdss/tests/dummy_classes/factory_registry_plugin.py
@@ -52,7 +52,7 @@ class DummyFactoryRegistryPlugin(HasStrictTraits):
     def mco_parameter_factory_by_id(self, mco_id, parameter_id):
         mco_factory = self.mco_factory_by_id(mco_id)
 
-        for factory in mco_factory.parameter_factories():
+        for factory in mco_factory.parameter_factories:
             if factory.id == parameter_id:
                 return factory
 

--- a/force_bdss/tests/dummy_classes/mco.py
+++ b/force_bdss/tests/dummy_classes/mco.py
@@ -59,5 +59,5 @@ class DummyMCOFactory(BaseMCOFactory):
     def get_optimizer_class(self):
         return DummyMCO
 
-    def parameter_factories(self):
-        return [DummyMCOParameterFactory(mco_factory=self)]
+    def get_parameter_factory_classes(self):
+        return [DummyMCOParameterFactory]

--- a/force_bdss/tests/probe_classes/factory_registry_plugin.py
+++ b/force_bdss/tests/probe_classes/factory_registry_plugin.py
@@ -51,7 +51,7 @@ class ProbeFactoryRegistryPlugin(HasStrictTraits):
     def mco_parameter_factory_by_id(self, mco_id, parameter_id):
         mco_factory = self.mco_factory_by_id(mco_id)
 
-        for factory in mco_factory.parameter_factories():
+        for factory in mco_factory.parameter_factories:
             if factory.id == parameter_id:
                 return factory
 

--- a/force_bdss/tests/probe_classes/mco.py
+++ b/force_bdss/tests/probe_classes/mco.py
@@ -118,4 +118,3 @@ class ProbeMCOFactory(BaseMCOFactory):
 
     def get_parameter_factory_classes(self):
         return [ProbeParameterFactory]
-

--- a/force_bdss/tests/probe_classes/mco.py
+++ b/force_bdss/tests/probe_classes/mco.py
@@ -116,5 +116,6 @@ class ProbeMCOFactory(BaseMCOFactory):
 
         return self.optimizer
 
-    def parameter_factories(self):
-        return [ProbeParameterFactory(mco_factory=self)]
+    def get_parameter_factory_classes(self):
+        return [ProbeParameterFactory]
+


### PR DESCRIPTION
Backward incompatible change. Requires updating the plugins.
Requires to specify the factory classes for the MCO parameters, instead of instantiating them every time.

Required changes to the plugins:
- a new method on the MCO factory get_parameter_factory_classes() must return the parameter factory classes.
- the current parameter_factories() method must be removed.

Fixes #135 