### PR TITLE
Move ui_visible attribute from base notification listener factory to base factory

### DIFF
--- a/force_bdss/core/base_factory.py
+++ b/force_bdss/core/base_factory.py
@@ -43,7 +43,6 @@ class BaseFactory(HasStrictTraits):
             )
         self.id = id
 
-
     def get_name(self):
         """Must be reimplemented to return a user-visible name of the
         data source.

--- a/force_bdss/core/base_factory.py
+++ b/force_bdss/core/base_factory.py
@@ -1,5 +1,5 @@
 from envisage.plugin import Plugin
-from traits.api import HasStrictTraits, Unicode, Instance
+from traits.api import Bool, HasStrictTraits, Unicode, Instance
 
 from force_bdss.ids import factory_id
 
@@ -14,6 +14,11 @@ class BaseFactory(HasStrictTraits):
 
     #: A long description of the factory.
     description = Unicode()
+
+    #: If the factor should be visible in the UI. Set to false to make it
+    #: invisible. This is normally useful for notification systems that are
+    #: not supposed to be configured by the user.
+    ui_visible = Bool(True)
 
     #: Reference to the plugin that carries this factory
     #: This is automatically set by the system. you should not define it
@@ -37,6 +42,7 @@ class BaseFactory(HasStrictTraits):
                 )
             )
         self.id = id
+
 
     def get_name(self):
         """Must be reimplemented to return a user-visible name of the

--- a/force_bdss/notification_listeners/base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/base_notification_listener_factory.py
@@ -1,6 +1,6 @@
 import logging
 from traits.api import (
-    provides, Type, Bool
+    provides, Type
 )
 from force_bdss.core.base_factory import BaseFactory
 from force_bdss.notification_listeners.base_notification_listener import \
@@ -19,11 +19,6 @@ class BaseNotificationListenerFactory(BaseFactory):
     Notification listeners are extensions that receive event notifications
     from the MCO and perform an associated action.
     """
-    #: If the factor should be visible in the UI. Set to false to make it
-    #: invisible. This is normally useful for notification systems that are
-    #: not supposed to be configured by the user.
-    ui_visible = Bool(True)
-
     #: The listener class that must be instantiated. Define this to your
     #: listener class.
     listener_class = Type(BaseNotificationListener, allow_none=False)


### PR DESCRIPTION
This isn't a property specific to a notification listener factory, so it can be moved down to the base class. This doesn't change behaviour, but makes the different factory classes a little more consistent.