### PR TITLE
Bumped Python version to 3.6 and added Traits 5.0.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 doc/build/
 *.pyc
 force_bdss/version.py
+.DS_Store

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,12 +1,12 @@
 import click
 from subprocess import check_call
 
-DEFAULT_PYTHON_VERSION = "3.5"
-PYTHON_VERSIONS = ["3.5"]
+DEFAULT_PYTHON_VERSION = "3.6"
+PYTHON_VERSIONS = ["3.6"]
 
 CORE_DEPS = [
     "distribute_remove==1.0.0-4",
-    "pip==10.0.1-1",
+    "pip==18.1-1",
     "setuptools==38.2.5-1",
     "envisage==4.6.0-1",
     "click==6.7-1",

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -8,7 +8,7 @@ CORE_DEPS = [
     "distribute_remove==1.0.0-4",
     "pip==18.1-1",
     "setuptools==38.2.5-1",
-    "envisage==4.6.0-1",
+    "envisage==4.7.1-1",
     "click==6.7-1",
 ]
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -14,7 +14,7 @@ If you never installed the Enthought Deployment Manager, perform the following o
 
     wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     export PATH=${HOME}/edm/bin:${PATH}
-    edm install --version 3.5 -y click setuptools
+    edm install --version 3.6 -y click setuptools
     edm shell
 
 If you instead already have an EDM installation and a default environment, perform the following:
@@ -33,7 +33,7 @@ following command. This should be done from the directory containing the 'force-
     pushd force-bdss
     python -m ci build-env
 
-This will create another edm environment called ``force-py35``.
+This will create another edm environment called ``force-py36``.
 Do not enter this environment. 
 
 To install the BDSS::
@@ -55,7 +55,7 @@ and (optional, but recommended), the example plugins::
 
 Now you can enter the deployed environment and invoke the programs::
 
-    edm shell -e force-py35
+    edm shell -e force-py36
     # Invokes the workflow manager UI
     force_wfmanager
     # Invokes the CLI BDSS evaluator

--- a/force_bdss/core/base_model.py
+++ b/force_bdss/core/base_model.py
@@ -1,6 +1,7 @@
 from traits.api import ABCHasStrictTraits, Instance
 
 from force_bdss.core.base_factory import BaseFactory
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class BaseModel(ABCHasStrictTraits):
@@ -12,3 +13,6 @@ class BaseModel(ABCHasStrictTraits):
 
     def __init__(self, factory, *args, **kwargs):
         super(BaseModel, self).__init__(factory=factory, *args, **kwargs)
+
+    def __getstate__(self):
+        return pop_dunder_recursive(super(BaseModel, self).__getstate__())

--- a/force_bdss/core/data_value.py
+++ b/force_bdss/core/data_value.py
@@ -1,4 +1,5 @@
 from traits.api import HasStrictTraits, Any, String, Enum
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class DataValue(HasStrictTraits):
@@ -33,3 +34,6 @@ class DataValue(HasStrictTraits):
         s += " ({})".format(str(self.quality))
 
         return s
+
+    def __getstate__(self):
+        return pop_dunder_recursive(super().__getstate__())

--- a/force_bdss/core/input_slot_info.py
+++ b/force_bdss/core/input_slot_info.py
@@ -1,6 +1,7 @@
 from traits.api import HasStrictTraits, Enum
 
 from ..local_traits import Identifier
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class InputSlotInfo(HasStrictTraits):
@@ -19,3 +20,6 @@ class InputSlotInfo(HasStrictTraits):
 
     #: The user defined name of the variable containing the value.
     name = Identifier()
+
+    def __getstate__(self):
+        return pop_dunder_recursive(super().__getstate__())

--- a/force_bdss/core/output_slot_info.py
+++ b/force_bdss/core/output_slot_info.py
@@ -1,6 +1,7 @@
 from traits.api import HasStrictTraits
 
 from ..local_traits import Identifier
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class OutputSlotInfo(HasStrictTraits):
@@ -13,3 +14,6 @@ class OutputSlotInfo(HasStrictTraits):
     """
     #: The user defined name of the variable containing the value.
     name = Identifier()
+
+    def __getstate__(self):
+        return pop_dunder_recursive(super().__getstate__())

--- a/force_bdss/core/slot.py
+++ b/force_bdss/core/slot.py
@@ -1,5 +1,6 @@
 from traits.api import HasStrictTraits, Unicode
 from ..local_traits import CUBAType
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class Slot(HasStrictTraits):
@@ -14,3 +15,6 @@ class Slot(HasStrictTraits):
 
     #: The CUBA key of the slot
     type = CUBAType()
+
+    def __getstate__(self):
+        return pop_dunder_recursive(super().__getstate__())

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -1,11 +1,13 @@
 from traits.api import HasStrictTraits, List, Instance, Float, Unicode
 
 from force_bdss.core.data_value import DataValue
-from force_bdss.io.workflow_writer import pop_recursive
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class BaseDriverEvent(HasStrictTraits):
     """ Base event for the MCO driver."""
+    def __getstate__(self):
+        return pop_dunder_recursive(super(BaseDriverEvent, self).__getstate__())
 
 
 class MCOStartEvent(BaseDriverEvent):
@@ -36,8 +38,7 @@ class MCOProgressEvent(BaseDriverEvent):
     weights = List(Float())
 
     def __getstate__(self):
-        d = super().__getstate__()
+        d = pop_dunder_recursive(super().__getstate__())
         d["optimal_point"] = [dv.__getstate__() for dv in d["optimal_point"]]
         d["optimal_kpis"] = [dv.__getstate__() for dv in d["optimal_kpis"]]
-        pop_recursive(d, "__traits_version__")
         return d

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -7,7 +7,7 @@ from force_bdss.io.workflow_writer import pop_dunder_recursive
 class BaseDriverEvent(HasStrictTraits):
     """ Base event for the MCO driver."""
     def __getstate__(self):
-        return pop_dunder_recursive(super(BaseDriverEvent, self).__getstate__())
+        return pop_dunder_recursive(super().__getstate__())
 
 
 class MCOStartEvent(BaseDriverEvent):

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -6,6 +6,7 @@ from force_bdss.core.base_model import BaseModel
 from force_bdss.core.input_slot_info import InputSlotInfo
 from force_bdss.core.output_slot_info import OutputSlotInfo
 from force_bdss.data_sources.i_data_source_factory import IDataSourceFactory
+from force_bdss.io.workflow_writer import pop_dunder_recursive
 
 
 class BaseDataSourceModel(BaseModel):
@@ -40,13 +41,14 @@ class BaseDataSourceModel(BaseModel):
     changes_slots = Event()
 
     def __getstate__(self):
-        state = super(BaseDataSourceModel, self).__getstate__()
+        state = pop_dunder_recursive(super(BaseDataSourceModel, self).__getstate__())
         state["input_slot_info"] = [
             x.__getstate__() for x in self.input_slot_info
         ]
         state["output_slot_info"] = [
             x.__getstate__() for x in self.output_slot_info
         ]
+
         return state
 
     @on_trait_change("+changes_slots")

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -41,7 +41,7 @@ class BaseDataSourceModel(BaseModel):
     changes_slots = Event()
 
     def __getstate__(self):
-        state = pop_dunder_recursive(super(BaseDataSourceModel, self).__getstate__())
+        state = pop_dunder_recursive(super().__getstate__())
         state["input_slot_info"] = [
             x.__getstate__() for x in self.input_slot_info
         ]

--- a/force_bdss/data_sources/tests/test_base_data_source_model.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_model.py
@@ -25,10 +25,9 @@ class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
 
     def test_getstate(self):
         model = DummyDataSourceModel(self.mock_factory)
-        self.assertEqual(
+        self.assertDictEqual(
             model.__getstate__(),
             {
-                "__traits_version__": "4.6.0",
                 "input_slot_info": [],
                 "output_slot_info": []
             })
@@ -46,29 +45,24 @@ class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
             OutputSlotInfo(name="quux")
         ]
 
-        self.assertEqual(
+        self.assertDictEqual(
             model.__getstate__(),
             {
-                "__traits_version__": "4.6.0",
                 "input_slot_info": [
                     {
-                        "__traits_version__": "4.6.0",
                         "source": "Environment",
                         "name": "foo"
                     },
                     {
-                        "__traits_version__": "4.6.0",
                         "source": "Environment",
                         "name": "bar"
                     }
                 ],
                 "output_slot_info": [
                     {
-                        "__traits_version__": "4.6.0",
                         "name": "baz",
                     },
                     {
-                        "__traits_version__": "4.6.0",
                         "name": "quux",
                     }
                 ]

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -10,7 +10,8 @@ from force_bdss.io.workflow_reader import WorkflowReader
 from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
-from force_bdss.io.workflow_writer import WorkflowWriter, pop_recursive, pop_dunder_recursive
+from force_bdss.io.workflow_writer import WorkflowWriter, pop_recursive, \
+    pop_dunder_recursive
 from force_bdss.core.workflow import Workflow
 from force_bdss.core.input_slot_info import InputSlotInfo
 

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -11,7 +11,7 @@ from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
 from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
-    pop_recursive
+    pop_recursive, pop_dunder_recursive
 from force_bdss.core.workflow import Workflow
 from force_bdss.core.input_slot_info import InputSlotInfo
 
@@ -112,3 +112,17 @@ class TestWorkflowWriter(unittest.TestCase):
 
         test_result_dictionary = pop_recursive(test_dictionary, 'K3')
         self.assertEqual(test_result_dictionary, result_dictionary)
+
+    def test_dunder_recursive(self):
+        test_dict = {
+            '__traits_version__': '4.6.0',
+            'some_important_data':
+                {'__traits_version__': '4.6.0', 'value': 10},
+            '_some_private_data':
+                {'__instance_traits__': ['yes', 'some']},
+            '___':
+                {'__': 'a', 'foo': 'bar'}
+        }
+        expected = {'some_important_data': {'value': 10},
+                    '_some_private_data': {}}
+        self.assertEqual(pop_dunder_recursive(test_dict), expected)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -119,8 +119,14 @@ class TestWorkflowWriter(unittest.TestCase):
             '_some_private_data':
                 {'__instance_traits__': ['yes', 'some']},
             '___':
-                {'__': 'a', 'foo': 'bar'}
+                {'__': 'a', 'foo': 'bar'},
+            'list_of_dicts': [
+                {'__bad_key__': 'bad', 'good_key': 'good'},
+                {'also_good_key': 'good'}]
         }
         expected = {'some_important_data': {'value': 10},
-                    '_some_private_data': {}}
+                    '_some_private_data': {},
+                    'list_of_dicts': [{'good_key': 'good'},
+                                      {'also_good_key': 'good'}]
+                    }
         self.assertEqual(pop_dunder_recursive(test_dict), expected)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -94,7 +94,6 @@ class TestWorkflowWriter(unittest.TestCase):
         exec_layer = wf.execution_layers[0]
         exec_layer.data_sources[0].input_slot_info = [InputSlotInfo()]
         slotdata = exec_layer.data_sources[0].input_slot_info[0].__getstate__()
-        self.assertTrue("__traits_version__" in slotdata)
         # Calls traits_to_dict for each data source
         datastore_list = wfwriter._execution_layer_data(exec_layer)
         new_slotdata = datastore_list[0]['model_data']['input_slot_info']

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -10,8 +10,7 @@ from force_bdss.io.workflow_reader import WorkflowReader
 from force_bdss.tests.dummy_classes.factory_registry_plugin import \
     DummyFactoryRegistryPlugin
 
-from force_bdss.io.workflow_writer import WorkflowWriter, traits_to_dict,\
-    pop_recursive, pop_dunder_recursive
+from force_bdss.io.workflow_writer import WorkflowWriter, pop_recursive, pop_dunder_recursive
 from force_bdss.core.workflow import Workflow
 from force_bdss.core.input_slot_info import InputSlotInfo
 
@@ -85,7 +84,7 @@ class TestWorkflowWriter(unittest.TestCase):
         mock_traits = mock.Mock()
         mock_traits.__getstate__ = mock.Mock(return_value={"foo": "bar"})
 
-        self.assertEqual(traits_to_dict(mock_traits), {"foo": "bar"})
+        self.assertEqual(mock_traits.__getstate__(), {"foo": "bar"})
 
     def test_traits_to_dict(self):
 
@@ -93,7 +92,6 @@ class TestWorkflowWriter(unittest.TestCase):
         wf = self._create_workflow()
         exec_layer = wf.execution_layers[0]
         exec_layer.data_sources[0].input_slot_info = [InputSlotInfo()]
-        slotdata = exec_layer.data_sources[0].input_slot_info[0].__getstate__()
         # Calls traits_to_dict for each data source
         datastore_list = wfwriter._execution_layer_data(exec_layer)
         new_slotdata = datastore_list[0]['model_data']['input_slot_info']

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -93,9 +93,6 @@ def traits_to_dict(traits_obj):
     traits version."""
 
     state = traits_obj.__getstate__()
-
-    state = pop_recursive(state, '__traits_version__')
-
     return state
 
 
@@ -117,5 +114,34 @@ def pop_recursive(dictionary, remove_key):
             for element in value:
                 if isinstance(element, dict):
                     pop_recursive(element, remove_key)
+
+    return dictionary
+
+
+def pop_dunder_recursive(dictionary):
+    """ Recursively removes all dunder keys from a nested dictionary. """
+    try:
+        found = False
+        for key in dictionary:
+            if key.startswith('__') and key.endswith('__'):
+                dictionary.pop(key)
+                found = True
+                break
+        if found:
+            pop_dunder_recursive(dictionary)
+
+    except KeyError:
+        pass
+
+    for key, value in dictionary.items():
+        # If remove_key is in the dict, remove it
+        if isinstance(value, dict):
+            pop_dunder_recursive(value)
+        # If we have a non-dict iterable which contains a dict,
+        # call pop.(remove_key) from that as well
+        elif isinstance(value, (tuple, list)):
+            for element in value:
+                if isinstance(element, dict):
+                    pop_dunder_recursive(element)
 
     return dictionary

--- a/force_bdss/local_traits.py
+++ b/force_bdss/local_traits.py
@@ -3,7 +3,7 @@ from traits.api import Regex, String, BaseInt
 #: Used for variable names, but allow also empty string as it's the default
 #: case and it will be present if the workflow is saved before actually
 #: specifying the value.
-Identifier = Regex(regex="(^[^\d\W]\w*\Z|^\Z)")
+Identifier = Regex(regex=r"(^[^\d\W]\w*\Z|^\Z)")
 
 #: Identifies a CUBA type with its key. At the moment a String with
 #: no validation, but will come later.

--- a/force_bdss/tests/test_core_evaluation_driver.py
+++ b/force_bdss/tests/test_core_evaluation_driver.py
@@ -88,8 +88,7 @@ class TestCoreEvaluationDriver(unittest.TestCase):
                     " An entry of type <.* 'str'> was instead found"
                     " in position 0."
                     " Fix the DataSource.run\(\) method to"
-                    " return the appropriate entity."
-                    ):
+                    " return the appropriate entity."):
                 driver.application_started()
 
     def test_error_for_missing_ds_output_names(self):


### PR DESCRIPTION
- Bumped the Python version of this repo and the plugins/wfmanager to Python 3.6
- Bumped envisage version to 4.7, which brings Traits 5.0.0.
- Redefined `__getstate__()` for relevant base types such that dunder keys are removed, circumventing the issues of serialisation of data stored under `__instance_traits__` in Traits 5.0.0.