### PR TITLE
Fix Qt application instantiation

### DIFF
--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -16,13 +16,6 @@ from .core_mco_driver import CoreMCODriver
 
 log = logging.getLogger(__name__)
 
-# This is a command-line app, we don't want GUI event loops
-try:
-    ETSConfig.toolkit = 'null'
-except ValueError:
-    # already been set, so can't do anything much
-    pass
-
 
 class BDSSApplication(Application):
     """Main application for the BDSS.
@@ -41,6 +34,13 @@ class BDSSApplication(Application):
     workflow = Property()
 
     def __init__(self, evaluate, workflow_filepath):
+        # This is a command-line app, we don't want GUI event loops
+        try:
+            ETSConfig.toolkit = 'null'
+        except ValueError:
+            # already been set, so can't do anything much
+            pass
+
         self.evaluate = evaluate
         self.workflow_filepath = workflow_filepath
 

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -39,7 +39,11 @@ class BDSSApplication(Application):
             ETSConfig.toolkit = 'null'
         except ValueError:
             # already been set, so can't do anything much
-            pass
+            if ETSConfig.toolkit != 'null':
+                log.info(
+                    "ETS toolkit is set to '%s', should not override.",
+                    ETSConfig.toolkit
+                )
 
         self.evaluate = evaluate
         self.workflow_filepath = workflow_filepath

--- a/force_bdss/bdss_application.py
+++ b/force_bdss/bdss_application.py
@@ -7,6 +7,7 @@ from stevedore.exception import NoMatches
 from envisage.api import Application
 from envisage.core_plugin import CorePlugin
 from traits.api import Unicode, Bool, Property
+from traits.etsconfig.api import ETSConfig
 
 from force_bdss.ids import InternalPluginID
 from .factory_registry_plugin import FactoryRegistryPlugin
@@ -14,6 +15,13 @@ from .core_evaluation_driver import CoreEvaluationDriver
 from .core_mco_driver import CoreMCODriver
 
 log = logging.getLogger(__name__)
+
+# This is a command-line app, we don't want GUI event loops
+try:
+    ETSConfig.toolkit = 'null'
+except ValueError:
+    # already been set, so can't do anything much
+    pass
 
 
 class BDSSApplication(Application):

--- a/force_bdss/cli/force_bdss.py
+++ b/force_bdss/cli/force_bdss.py
@@ -3,10 +3,7 @@ import click
 
 from traits.api import push_exception_handler
 
-from traits.etsconfig.api import ETSConfig
-
-# This is a CLI app, so ETS toolkit should be null
-ETSConfig.toolkit = 'null'
+from force_bdss.bdss_application import BDSSApplication
 
 # Makes the application rethrow the exception so that it exits return code
 # different from zero.
@@ -21,8 +18,6 @@ push_exception_handler(reraise_exceptions=True)
                    " If unspecified, the log will be written to stdout.")
 @click.argument('workflow_filepath', type=click.Path(exists=True))
 def run(evaluate, logfile, workflow_filepath):
-    from ..bdss_application import BDSSApplication
-
     logging_config = {}
     logging_config["level"] = logging.INFO
 

--- a/force_bdss/cli/force_bdss.py
+++ b/force_bdss/cli/force_bdss.py
@@ -1,11 +1,15 @@
 import logging
 import click
 
-from ..bdss_application import BDSSApplication
+from traits.api import push_exception_handler
+
+from traits.etsconfig.api import ETSConfig
+
+# This is a CLI app, so ETS toolkit should be null
+ETSConfig.toolkit = 'null'
 
 # Makes the application rethrow the exception so that it exits return code
 # different from zero.
-from traits.api import push_exception_handler
 push_exception_handler(reraise_exceptions=True)
 
 
@@ -17,6 +21,7 @@ push_exception_handler(reraise_exceptions=True)
                    " If unspecified, the log will be written to stdout.")
 @click.argument('workflow_filepath', type=click.Path(exists=True))
 def run(evaluate, logfile, workflow_filepath):
+    from ..bdss_application import BDSSApplication
 
     logging_config = {}
     logging_config["level"] = logging.INFO

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -3,6 +3,8 @@ import warnings
 
 import testfixtures
 
+from traits.etsconfig.api import ETSConfig
+
 from force_bdss.bdss_application import (
     BDSSApplication,
     _load_failure_callback,
@@ -14,8 +16,25 @@ from force_bdss.tests import fixtures
 from unittest import mock
 
 
+def clear_toolkit():
+    # note, this won't unimport any toolkit backends
+    ETSConfig._toolkit = None
+
+
 class TestBDSSApplication(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(clear_toolkit)
+
     def test_initialization(self):
+        with testfixtures.LogCapture():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                app = BDSSApplication(False, "foo/bar")
+        self.assertFalse(app.evaluate)
+        self.assertEqual(app.workflow_filepath, "foo/bar")
+
+    def test_toolkit(self):
+        ETSConfig.toolkit = 'dummy'
         with testfixtures.LogCapture():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -32,24 +32,23 @@ class TestBDSSApplication(unittest.TestCase):
                 app = BDSSApplication(False, "foo/bar")
         self.assertFalse(app.evaluate)
         self.assertEqual(app.workflow_filepath, "foo/bar")
+        self.assertEqual(ETSConfig.toolkit, 'null')
 
     def test_toolkit(self):
         ETSConfig.toolkit = 'dummy'
         with testfixtures.LogCapture():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                app = BDSSApplication(False, "foo/bar")
-        self.assertFalse(app.evaluate)
-        self.assertEqual(app.workflow_filepath, "foo/bar")
+                BDSSApplication(False, "foo/bar")
+        self.assertEqual(ETSConfig.toolkit, 'dummy')
 
     def test_toolkit_null(self):
         ETSConfig.toolkit = 'null'
         with testfixtures.LogCapture():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                app = BDSSApplication(False, "foo/bar")
-        self.assertFalse(app.evaluate)
-        self.assertEqual(app.workflow_filepath, "foo/bar")
+                BDSSApplication(False, "foo/bar")
+        self.assertEqual(ETSConfig.toolkit, 'null')
 
     def test_extension_load_failure(self):
         plugins = []

--- a/force_bdss/tests/test_bdss_application.py
+++ b/force_bdss/tests/test_bdss_application.py
@@ -42,6 +42,15 @@ class TestBDSSApplication(unittest.TestCase):
         self.assertFalse(app.evaluate)
         self.assertEqual(app.workflow_filepath, "foo/bar")
 
+    def test_toolkit_null(self):
+        ETSConfig.toolkit = 'null'
+        with testfixtures.LogCapture():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                app = BDSSApplication(False, "foo/bar")
+        self.assertFalse(app.evaluate)
+        self.assertEqual(app.workflow_filepath, "foo/bar")
+
     def test_extension_load_failure(self):
         plugins = []
         with testfixtures.LogCapture() as log:


### PR DESCRIPTION
Because we look at all plugins, we potentially do TraitsUI imports which in turn potentially select a ETS toolkit.  This forces early ETS toolkit selection to `null` in the `BDSSApplication` which should prevent the Qt application being instantiated with all the overhead that goes with that.

The result is a substantial speedup in the command-line app.