### PR TITLE
Force BDSS no longer manually installs default edm packages

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -5,9 +5,6 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 CORE_DEPS = [
-    "distribute_remove==1.0.0-4",
-    "pip==18.1-1",
-    "setuptools==38.2.5-2",
     "envisage==4.7.1-1",
     "click==6.7-1",
 ]

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -7,20 +7,19 @@ PYTHON_VERSIONS = ["3.6"]
 CORE_DEPS = [
     "distribute_remove==1.0.0-4",
     "pip==18.1-1",
-    "setuptools==38.2.5-1",
+    "setuptools==38.2.5-2",
     "envisage==4.7.1-1",
     "click==6.7-1",
 ]
 
 DOCS_DEPS = [
-    "sphinx==1.5.5-5"
+    "sphinx==1.8.5-3"
 ]
 
 DEV_DEPS = [
     "flake8==3.3.0-2",
     "coverage==4.3.4-1",
     "testfixtures==4.10.0-1",
-    "mock==2.0.0-1",
 ]
 
 PIP_DEPS = [


### PR DESCRIPTION
Rather than installing setuptools, pip and distribute_remove manually, we can just use the ones supplied as the default with an edm environment (these are more recent then our manual ones anyway!).
Also we required mock as a dependency, but since we're now on python 3.6 it comes in the standard library as unittest.mock anyway