### PR TITLE
Upgrade dependencies

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -5,8 +5,8 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 CORE_DEPS = [
-    "envisage==4.7.1-1",
-    "click==6.7-1",
+    "envisage==4.7.2-1",
+    "click==7.0-1",
 ]
 
 DOCS_DEPS = [
@@ -14,13 +14,13 @@ DOCS_DEPS = [
 ]
 
 DEV_DEPS = [
-    "flake8==3.3.0-2",
+    "flake8==3.7.7-1",
     "coverage==4.3.4-1",
     "testfixtures==4.10.0-1",
 ]
 
 PIP_DEPS = [
-    "stevedore==1.24.0"
+    "stevedore==1.30.1"
 ]
 
 

--- a/force_bdss/tests/test_core_evaluation_driver.py
+++ b/force_bdss/tests/test_core_evaluation_driver.py
@@ -55,9 +55,9 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         with testfixtures.LogCapture():
             with self.assertRaisesRegex(
                     RuntimeError,
-                    "The number of data values \(2 values\)"
-                    " returned by 'test_data_source' does not match"
-                    " the number of output slots"):
+                    r"The number of data values \(2 values\)"
+                    r" returned by 'test_data_source' does not match"
+                    r" the number of output slots"):
                 driver.application_started()
 
     def test_error_for_incorrect_return_type(self):
@@ -69,9 +69,9 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         with testfixtures.LogCapture():
             with self.assertRaisesRegex(
                     RuntimeError,
-                    "The run method of data source test_data_source must"
-                    " return a list. It returned instead <.* 'str'>. Fix"
-                    " the run\(\) method to return the appropriate entity."):
+                    r"The run method of data source test_data_source must"
+                    r" return a list. It returned instead <.* 'str'>. Fix"
+                    r" the run\(\) method to return the appropriate entity."):
                 driver.application_started()
 
     def test_error_for_incorrect_data_value_entries(self):
@@ -83,12 +83,12 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         with testfixtures.LogCapture():
             with self.assertRaisesRegex(
                     RuntimeError,
-                    "The result list returned by DataSource test_data_source"
-                    " contains an entry that is not a DataValue."
-                    " An entry of type <.* 'str'> was instead found"
-                    " in position 0."
-                    " Fix the DataSource.run\(\) method to"
-                    " return the appropriate entity."):
+                    r"The result list returned by DataSource test_data_source"
+                    r" contains an entry that is not a DataValue."
+                    r" An entry of type <.* 'str'> was instead found"
+                    r" in position 0."
+                    r" Fix the DataSource.run\(\) method to"
+                    r" return the appropriate entity."):
                 driver.application_started()
 
     def test_error_for_missing_ds_output_names(self):
@@ -105,9 +105,9 @@ class TestCoreEvaluationDriver(unittest.TestCase):
         with testfixtures.LogCapture():
             with self.assertRaisesRegex(
                     RuntimeError,
-                    "The number of data values \(2 values\)"
-                    " returned by 'test_data_source' does not match"
-                    " the number of user-defined names"):
+                    r"The number of data values \(2 values\)"
+                    r" returned by 'test_data_source' does not match"
+                    r" the number of user-defined names"):
                 driver.application_started()
 
     def test_mco_communicator_broken(self):


### PR DESCRIPTION
Upgrading all dependencies to the latest served by EDM/PyPI. 

Flake8 becomes a bit more restrictive.

This doesn't seem to cause test failures down the line (`force-wfmanager` and `force-bdss-plugin-enthought-example`), except some flake8 errors, fixing in https://github.com/force-h2020/force-wfmanager/pull/286.