### PR TITLE
CI updates, including macOS worker and verbose tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 language: c
+sudo: false
+
+env:
+  global:
+    - EDM_FULL=1.11.0
+    - EDM_X_Y=1.11
+
 cache:
   directories:
       - "$HOME/.cache"
       - "$HOME/.ccache"
+
+matrix:
+  include:
+  - os: linux
+    env: EDM_OS="rh5_x86_64"
+    env: EDM_INSTALLER_SUFF="_linux_x86_64.sh"
+  - os: osx
+    env: EDM_OS="osx_x86_64"
+    env: EDM_INSTALLER_SUFFIX=".pkg"
+
 before_install:
     - ccache -s
     - export PATH=/usr/lib/ccache:${PATH}
-    - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
-    - export PATH=${HOME}/edm/bin:${PATH}
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.5 -y click setuptools
     - edm run -- python -m ci build-env
 script:
@@ -19,4 +39,4 @@ after_success:
     - edm run -- python -m ci coverage
     - edm run -- pip install codecov
     - edm run -- codecov
-    - bash <(curl -s https://codecov.io/bash)
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 sudo: false
 
 env:
@@ -23,7 +23,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
-    - edm install --version 3.5 -y click setuptools
+    - edm install --version 3.6 -y click setuptools
     - edm run -- python -m ci build-env
 script:
     - edm run -- python -m ci install
@@ -31,7 +31,7 @@ script:
     - edm run -- python -m ci test
     - edm run -- python -m ci docs
 after_success:
-    - edm run -- python -m ci coverage
-    - edm run -- pip install codecov
-    - edm run -- codecov
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- python -m ci coverage; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- pip install codecov; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- codecov; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,16 @@ env:
     - EDM_FULL=1.11.0
     - EDM_X_Y=1.11
 
-cache:
-  directories:
-      - "$HOME/.cache"
-      - "$HOME/.ccache"
-
 matrix:
   include:
   - os: linux
     env: EDM_OS="rh5_x86_64"
-    env: EDM_INSTALLER_SUFF="_linux_x86_64.sh"
+    env: EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
   - os: osx
     env: EDM_OS="osx_x86_64"
     env: EDM_INSTALLER_SUFFIX=".pkg"
 
 before_install:
-    - ccache -s
-    - export PATH=/usr/lib/ccache:${PATH}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,18 @@ sudo: false
 env:
   global:
     - EDM_FULL=1.11.0
-    - EDM_X_Y=1.11
+      EDM_X_Y=1.11
 
 matrix:
   include:
   - os: linux
-    env: EDM_OS="rh5_x86_64"
-    env: EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
+    env: 
+      - EDM_OS="rh5_x86_64"
+        EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
   - os: osx
-    env: EDM_OS="osx_x86_64"
-    env: EDM_INSTALLER_SUFFIX=".pkg"
+    env:
+      - EDM_OS="osx_x86_64"
+        EDM_INSTALLER_SUFFIX=".pkg"
 
 before_install:
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -69,13 +69,19 @@ def install(python_version):
 
 @cli.command(help="Run the tests")
 @python_version_option
-def test(python_version):
+@click.option(
+    "--verbose/--quiet", default=True,
+    help="Run tests in verbose mode? [default: --verbose]",
+)
+def test(python_version, verbose):
     env_name = get_env_name(python_version)
 
-    check_call([
-        "edm", "run", "-e", env_name, "--", "python", "-m", "unittest",
-        "discover"
-    ])
+    verbosity_args = ["--verbose"] if verbose else []
+
+    check_call(
+        ["edm", "run", "-e", env_name, "--", "python", "-m", "unittest",
+         "discover"] + verbosity_args
+    )
 
 
 @cli.command(help="Run flake")


### PR DESCRIPTION
This PR:
- adds a macOS Travis CI job
- uses EDM 1.11.0 in CI
- uses a Python 3.6 bootstrap environment (was 3.5)

Also:
- makes the tests verbose

I'm not sure why `language: c` and `ccache` were used (probably boilerplate?), but I removed them in favor of `language: generic`.

Codecov is run only once (on Linux) since it would be redundant otherwise.