### PR TITLE
Bundle based environment building

### DIFF
--- a/ci/bundle/force-py36-osx-x86_64.json
+++ b/ci/bundle/force-py36-osx-x86_64.json
@@ -1,0 +1,411 @@
+{
+    "mark": [
+        {
+            "name": "alabaster",
+            "state": "auto"
+        },
+        {
+            "name": "appdirs",
+            "state": "auto"
+        },
+        {
+            "name": "apptools",
+            "state": "auto"
+        },
+        {
+            "name": "babel",
+            "state": "auto"
+        },
+        {
+            "name": "certifi",
+            "state": "auto"
+        },
+        {
+            "name": "chardet",
+            "state": "auto"
+        },
+        {
+            "name": "click",
+            "state": "manual"
+        },
+        {
+            "name": "configobj",
+            "state": "auto"
+        },
+        {
+            "name": "configparser",
+            "state": "auto"
+        },
+        {
+            "name": "coverage",
+            "state": "manual"
+        },
+        {
+            "name": "distribute_remove",
+            "state": "auto"
+        },
+        {
+            "name": "docutils",
+            "state": "auto"
+        },
+        {
+            "name": "entrypoints",
+            "state": "auto"
+        },
+        {
+            "name": "envisage",
+            "state": "manual"
+        },
+        {
+            "name": "flake8",
+            "state": "manual"
+        },
+        {
+            "name": "idna",
+            "state": "auto"
+        },
+        {
+            "name": "imagesize",
+            "state": "auto"
+        },
+        {
+            "name": "jinja2",
+            "state": "auto"
+        },
+        {
+            "name": "markupsafe",
+            "state": "auto"
+        },
+        {
+            "name": "mccabe",
+            "state": "auto"
+        },
+        {
+            "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pycodestyle",
+            "state": "auto"
+        },
+        {
+            "name": "pyface",
+            "state": "auto"
+        },
+        {
+            "name": "pyflakes",
+            "state": "auto"
+        },
+        {
+            "name": "pygments",
+            "state": "auto"
+        },
+        {
+            "name": "pyparsing",
+            "state": "auto"
+        },
+        {
+            "name": "pytz",
+            "state": "auto"
+        },
+        {
+            "name": "requests",
+            "state": "auto"
+        },
+        {
+            "name": "setuptools",
+            "state": "auto"
+        },
+        {
+            "name": "six",
+            "state": "auto"
+        },
+        {
+            "name": "snowballstemmer",
+            "state": "auto"
+        },
+        {
+            "name": "sphinx",
+            "state": "manual"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "state": "auto"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "state": "auto"
+        },
+        {
+            "name": "testfixtures",
+            "state": "manual"
+        },
+        {
+            "name": "traits",
+            "state": "auto"
+        },
+        {
+            "name": "traitsui",
+            "state": "auto"
+        },
+        {
+            "name": "urllib3",
+            "state": "auto"
+        }
+    ],
+    "metadata_version": "2.0",
+    "modifiers": {
+        "allow_any": [],
+        "allow_newer": [],
+        "allow_older": []
+    },
+    "repositories": {
+        "packages": [
+            "enthought/commercial",
+            "enthought/free",
+            "enthought/platform",
+            "shell/geoduck"
+        ],
+        "runtimes": [
+            "enthought/free"
+        ]
+    },
+    "requirements": [
+        {
+            "name": "alabaster",
+            "repository": "enthought/free",
+            "sha256": "8fe687bd9ae74b93f4a79648758a559358da5ebf84bc7eea43523f9de1625b64",
+            "version": "0.7.10-1"
+        },
+        {
+            "name": "appdirs",
+            "repository": "enthought/free",
+            "sha256": "d742ad6fd4241eb6288707eef468f4786463efd7e6660b6abf18789a323341b1",
+            "version": "1.4.3-1"
+        },
+        {
+            "name": "apptools",
+            "repository": "enthought/free",
+            "sha256": "82389f4d34e57f869d5e5548f481612b473dd50347fc06fb716bcad347991cfe",
+            "version": "4.4.0-14"
+        },
+        {
+            "name": "babel",
+            "repository": "enthought/free",
+            "sha256": "54afd72db4e5ee6d64617b9dfe265645966768b1728ae0625ff37b6f49a5b785",
+            "version": "2.6.0-1"
+        },
+        {
+            "name": "certifi",
+            "repository": "enthought/free",
+            "sha256": "f21ccb29d2034b7e2d54f9ef0018f4827caf8db2584398e59726c325fe3396b8",
+            "version": "2018.11.29-1"
+        },
+        {
+            "name": "chardet",
+            "repository": "enthought/free",
+            "sha256": "5c95ad850f9f0db5a6946b0c4d9ae89866b2ad050d5ce79163e0369f9596b742",
+            "version": "3.0.4-1"
+        },
+        {
+            "name": "click",
+            "repository": "enthought/free",
+            "sha256": "b61f24ef84336c0f67afc2c84cd7eb2c11a3fab9e71f1b81427b2279cf631592",
+            "version": "7.0-1"
+        },
+        {
+            "name": "configobj",
+            "repository": "enthought/free",
+            "sha256": "4462f77435994d3a963a9a084691cc712747f327ad7bcce092ba00550fa790cd",
+            "version": "5.0.6-3"
+        },
+        {
+            "name": "configparser",
+            "repository": "enthought/free",
+            "sha256": "bd1c7fc64791ba2b634e9eb72b36143b7b6923e9ab48c251f2ac578cec0ca59a",
+            "version": "3.5.0-1"
+        },
+        {
+            "name": "coverage",
+            "repository": "enthought/free",
+            "sha256": "f3b70c52931477d132aee42600bd1cefa65ca67251706af1f760fbc4fdc6043b",
+            "version": "4.3.4-1"
+        },
+        {
+            "name": "distribute_remove",
+            "repository": "enthought/free",
+            "sha256": "96721226786e9ac5a1e09d9ff78e57a843e2a4345d8ee93e8d0a3c70578302f7",
+            "version": "1.0.0-4"
+        },
+        {
+            "name": "docutils",
+            "repository": "enthought/free",
+            "sha256": "a8ae6984ebf3927c3942388b2df7220a87173c88bd90ef35b6e8abfec162cdbf",
+            "version": "0.13.1-1"
+        },
+        {
+            "name": "entrypoints",
+            "repository": "enthought/free",
+            "sha256": "44ed105e82ca6eeae7a5a040ffce346fd51c3527d153ca0711b0bb7419c29c6c",
+            "version": "0.3-1"
+        },
+        {
+            "name": "envisage",
+            "repository": "enthought/free",
+            "sha256": "6a42a7e49aba843acf9b5323811c92b24e45c1bfbe090f5865f0de9af24e24db",
+            "version": "4.7.2-1"
+        },
+        {
+            "name": "flake8",
+            "repository": "enthought/free",
+            "sha256": "56aa528197c428cb6495430ad5fa5793aa3129255d3387a496f4e69dd20b279e",
+            "version": "3.7.7-1"
+        },
+        {
+            "name": "idna",
+            "repository": "enthought/free",
+            "sha256": "9f1b3b8dca4b2d596816b7f4312f286b7ea9df1e56e0e16cb768f265b3c1a180",
+            "version": "2.5-1"
+        },
+        {
+            "name": "imagesize",
+            "repository": "enthought/free",
+            "sha256": "4e171447b12511d3fa4e0872613b1e27a74f613c45097b514651c04e22e17a7b",
+            "version": "0.7.1-1"
+        },
+        {
+            "name": "jinja2",
+            "repository": "enthought/free",
+            "sha256": "424c782b0c8b0dd1fe2441724702116cee919234fe6c6cca0696b4ea0bdf9803",
+            "version": "2.10.1-1"
+        },
+        {
+            "name": "markupsafe",
+            "repository": "enthought/free",
+            "sha256": "26b5a2c0c018400b9ded49a4d49a533c517a02952bc014601c62a7b19c048bf6",
+            "version": "1.1.1-1"
+        },
+        {
+            "name": "mccabe",
+            "repository": "enthought/free",
+            "sha256": "93d8c44066f61bc4664695385b1bcc2899cc33b93aac4e30f4e5593ff8738071",
+            "version": "0.6.1-1"
+        },
+        {
+            "name": "packaging",
+            "repository": "enthought/free",
+            "sha256": "7cd3127256f2bc2e0dbed2f67e68fa21671df3eca607f782309f2006049de99a",
+            "version": "16.8-3"
+        },
+        {
+            "name": "pycodestyle",
+            "repository": "enthought/free",
+            "sha256": "5ee3e700cf4ad8b4911e2ab482485f90bd5dcec3dce16cd667f9a755801c67d4",
+            "version": "2.5.0-1"
+        },
+        {
+            "name": "pyface",
+            "repository": "enthought/free",
+            "sha256": "85082cd21c16289faa2c3d516da26146ecf08ba057fda9b5f03cbb0e39914585",
+            "version": "6.1.1-1"
+        },
+        {
+            "name": "pyflakes",
+            "repository": "enthought/free",
+            "sha256": "2a8913f2e112496db4002c53b4e5a9c516829e4e27db8366edc055ab6ce6304f",
+            "version": "2.1.1-1"
+        },
+        {
+            "name": "pygments",
+            "repository": "enthought/free",
+            "sha256": "150db58d5ac1a75f93c195342feadfaac602e762f5a502e49a1076d81d29244c",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pyparsing",
+            "repository": "enthought/free",
+            "sha256": "a1b6da4dcfe747ad2a36c106191985c4d2c3a4c8ce147033c833c7c42afc0877",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pytz",
+            "repository": "enthought/free",
+            "sha256": "7cadabb52f168c6c2b30e73c6150f3100dc6f0beb6250b8a2080db6e25fd19da",
+            "version": "2018.9-1"
+        },
+        {
+            "name": "requests",
+            "repository": "enthought/free",
+            "sha256": "c2803f6a331998cb5c83c9c0a4541277cd394800e88fbdb0f1d46fa114c61d5a",
+            "version": "2.21.0-1"
+        },
+        {
+            "name": "setuptools",
+            "repository": "enthought/free",
+            "sha256": "1bc23a9cfde82b524333fb3bcc85d125ba70a431766af2dcf74ea815057cb0e7",
+            "version": "38.2.5-2"
+        },
+        {
+            "name": "six",
+            "repository": "enthought/free",
+            "sha256": "95d3c2753432aae289571c6d9ec921927729c5e50d99f69078e475dfa48a28f6",
+            "version": "1.11.0-1"
+        },
+        {
+            "name": "snowballstemmer",
+            "repository": "enthought/free",
+            "sha256": "e3de6aa7155826eaacd6f0d3d4f5a05ee0fadd1c750e641f65dfb0bfce5028a3",
+            "version": "1.2.1-1"
+        },
+        {
+            "name": "sphinx",
+            "repository": "enthought/free",
+            "sha256": "294dc9d14d968fe3ed41c1d4b2d6955d0c2b0df4b0f2fb24e5e612a03c8cefea",
+            "version": "1.8.5-3"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "repository": "enthought/free",
+            "sha256": "2b333ff36ed83e4fd4d789a3266f4b7f53b77dc2e220f9d2357028fc0da48fa7",
+            "version": "0.2.4-1"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "repository": "enthought/free",
+            "sha256": "f071f60c9a2517edf76f894e78ba201234c48bbe280c5b09ec99b3ed6b8299a4",
+            "version": "1.1.0-1"
+        },
+        {
+            "name": "testfixtures",
+            "repository": "enthought/free",
+            "sha256": "37ac75dc1c379f5d3e42305b3dafe59c3e81526c30dee70459ce7a4463035481",
+            "version": "4.10.0-1"
+        },
+        {
+            "name": "traits",
+            "repository": "enthought/free",
+            "sha256": "7eca4c9a1d98e5f3dd97fc7870071c147429112c5d9d97d021030089d7f784b9",
+            "version": "5.1.1-1"
+        },
+        {
+            "name": "traitsui",
+            "repository": "enthought/free",
+            "sha256": "45a48d95532fecfa8db56baacba520d9f0027cacbab45dafc482091f939888e9",
+            "version": "6.1.1-2"
+        },
+        {
+            "name": "urllib3",
+            "repository": "enthought/free",
+            "sha256": "12e3ea55d20bb9ea9d0df385a22235a2324c5a687447ff4d8ece16a8256859ab",
+            "version": "1.22-4"
+        }
+    ],
+    "runtime": {
+        "implementation": "cpython",
+        "platform": "osx_x86_64",
+        "platform_abi": "darwin",
+        "repository": "enthought/free",
+        "sha256": "99df7e9f78c431b67af586c6884bfad770a256510a802facc9da42e3ce6b5e74",
+        "version": "3.6.0+7"
+    }
+}

--- a/ci/bundle/force-py36-osx-x86_64.json
+++ b/ci/bundle/force-py36-osx-x86_64.json
@@ -85,6 +85,10 @@
             "state": "auto"
         },
         {
+            "name": "pip",
+            "state": "manual"
+        },
+        {
             "name": "pycodestyle",
             "state": "auto"
         },
@@ -296,6 +300,12 @@
             "repository": "enthought/free",
             "sha256": "7cd3127256f2bc2e0dbed2f67e68fa21671df3eca607f782309f2006049de99a",
             "version": "16.8-3"
+        },
+        {
+            "name": "pip",
+            "repository": "enthought/free",
+            "sha256": "09de499e550cfaa19c84b65a7d229a1745d106f02a36c26ceea48c9eaeaff27c",
+            "version": "18.1-1"
         },
         {
             "name": "pycodestyle",

--- a/ci/bundle/force-py36-rh6-x86_64.json
+++ b/ci/bundle/force-py36-rh6-x86_64.json
@@ -85,6 +85,10 @@
             "state": "auto"
         },
         {
+            "name": "pip",
+            "state": "manual"
+        },
+        {
             "name": "pycodestyle",
             "state": "auto"
         },
@@ -296,6 +300,12 @@
             "repository": "enthought/free",
             "sha256": "e29c32c48565d32a58358306662a44b63df5348a59d766847ec38a8b36e2016f",
             "version": "16.8-3"
+        },
+        {
+            "name": "pip",
+            "repository": "enthought/free",
+            "sha256": "6503cce5fc46f9b728e35cf6a935613a9160a636596bfabd36c4a003f19d1cac",
+            "version": "18.1-1"
         },
         {
             "name": "pycodestyle",

--- a/ci/bundle/force-py36-rh6-x86_64.json
+++ b/ci/bundle/force-py36-rh6-x86_64.json
@@ -1,0 +1,411 @@
+{
+    "mark": [
+        {
+            "name": "alabaster",
+            "state": "auto"
+        },
+        {
+            "name": "appdirs",
+            "state": "auto"
+        },
+        {
+            "name": "apptools",
+            "state": "auto"
+        },
+        {
+            "name": "babel",
+            "state": "auto"
+        },
+        {
+            "name": "certifi",
+            "state": "auto"
+        },
+        {
+            "name": "chardet",
+            "state": "auto"
+        },
+        {
+            "name": "click",
+            "state": "manual"
+        },
+        {
+            "name": "configobj",
+            "state": "auto"
+        },
+        {
+            "name": "configparser",
+            "state": "auto"
+        },
+        {
+            "name": "coverage",
+            "state": "manual"
+        },
+        {
+            "name": "distribute_remove",
+            "state": "auto"
+        },
+        {
+            "name": "docutils",
+            "state": "auto"
+        },
+        {
+            "name": "entrypoints",
+            "state": "auto"
+        },
+        {
+            "name": "envisage",
+            "state": "manual"
+        },
+        {
+            "name": "flake8",
+            "state": "manual"
+        },
+        {
+            "name": "idna",
+            "state": "auto"
+        },
+        {
+            "name": "imagesize",
+            "state": "auto"
+        },
+        {
+            "name": "jinja2",
+            "state": "auto"
+        },
+        {
+            "name": "markupsafe",
+            "state": "auto"
+        },
+        {
+            "name": "mccabe",
+            "state": "auto"
+        },
+        {
+            "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pycodestyle",
+            "state": "auto"
+        },
+        {
+            "name": "pyface",
+            "state": "auto"
+        },
+        {
+            "name": "pyflakes",
+            "state": "auto"
+        },
+        {
+            "name": "pygments",
+            "state": "auto"
+        },
+        {
+            "name": "pyparsing",
+            "state": "auto"
+        },
+        {
+            "name": "pytz",
+            "state": "auto"
+        },
+        {
+            "name": "requests",
+            "state": "auto"
+        },
+        {
+            "name": "setuptools",
+            "state": "auto"
+        },
+        {
+            "name": "six",
+            "state": "auto"
+        },
+        {
+            "name": "snowballstemmer",
+            "state": "auto"
+        },
+        {
+            "name": "sphinx",
+            "state": "manual"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "state": "auto"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "state": "auto"
+        },
+        {
+            "name": "testfixtures",
+            "state": "manual"
+        },
+        {
+            "name": "traits",
+            "state": "auto"
+        },
+        {
+            "name": "traitsui",
+            "state": "auto"
+        },
+        {
+            "name": "urllib3",
+            "state": "auto"
+        }
+    ],
+    "metadata_version": "2.0",
+    "modifiers": {
+        "allow_any": [],
+        "allow_newer": [],
+        "allow_older": []
+    },
+    "repositories": {
+        "packages": [
+            "enthought/commercial",
+            "enthought/free",
+            "enthought/platform",
+            "shell/geoduck"
+        ],
+        "runtimes": [
+            "enthought/free"
+        ]
+    },
+    "requirements": [
+        {
+            "name": "alabaster",
+            "repository": "enthought/free",
+            "sha256": "266c2fe277eb5f0d9954b4840e4c3f7d8d2efa8238e14511c705fbb0502ecb62",
+            "version": "0.7.10-1"
+        },
+        {
+            "name": "appdirs",
+            "repository": "enthought/free",
+            "sha256": "82d5108b9b708dfd1853e8e747755f2c7dce71c58d3955b36fc6722422d628af",
+            "version": "1.4.3-1"
+        },
+        {
+            "name": "apptools",
+            "repository": "enthought/free",
+            "sha256": "6fcdf6d43c4818903fe4a4b01d492d93439a05919a12d9905f91ff3a87c1c31c",
+            "version": "4.4.0-14"
+        },
+        {
+            "name": "babel",
+            "repository": "enthought/free",
+            "sha256": "3ead2026cb26ca9b6dc835ff6b44d77e5844fcb3a0e8c807d7ae4973fff00cdf",
+            "version": "2.6.0-1"
+        },
+        {
+            "name": "certifi",
+            "repository": "enthought/free",
+            "sha256": "3e71d2e66e79fbbed34e78be77c56cc7939bdce51e51334aa7de8c9850c46e3f",
+            "version": "2018.11.29-1"
+        },
+        {
+            "name": "chardet",
+            "repository": "enthought/free",
+            "sha256": "f62a34ebb2119303e88c70d783e6777fb219d22bf23a0da6c7354a806d59774c",
+            "version": "3.0.4-1"
+        },
+        {
+            "name": "click",
+            "repository": "enthought/free",
+            "sha256": "c65444b98db3840adc1e24bbfddd663a7d0d46d5cd756c7e4b72727d973724d7",
+            "version": "7.0-1"
+        },
+        {
+            "name": "configobj",
+            "repository": "enthought/free",
+            "sha256": "a2969d34f7ccba9828e90f4b69c61dfd5245e102eae97e1301fbf3229d188914",
+            "version": "5.0.6-3"
+        },
+        {
+            "name": "configparser",
+            "repository": "enthought/free",
+            "sha256": "34042b8a1d6afaac9f4721356012092e57580101ac0541907ac6111d3d58c0cf",
+            "version": "3.5.0-1"
+        },
+        {
+            "name": "coverage",
+            "repository": "enthought/free",
+            "sha256": "5dc22307daad353fd8e6dd86f260f595b43032b532fd5a8cfb7a9c985396d2b9",
+            "version": "4.3.4-1"
+        },
+        {
+            "name": "distribute_remove",
+            "repository": "enthought/free",
+            "sha256": "3ccc80bc7f68050d4f1a2a9e6e0ff3b277060caf1d51db03ef552b21c849687e",
+            "version": "1.0.0-4"
+        },
+        {
+            "name": "docutils",
+            "repository": "enthought/free",
+            "sha256": "fa829d7a2f19e1d661f096e8b64a39dc626deb5244b5886b3988c7789221de33",
+            "version": "0.13.1-1"
+        },
+        {
+            "name": "entrypoints",
+            "repository": "enthought/free",
+            "sha256": "9244661a17024b3e77a4b9bc833ddfec2afab3e9e3b80683f1bc8e0a4f3ebec5",
+            "version": "0.3-1"
+        },
+        {
+            "name": "envisage",
+            "repository": "enthought/free",
+            "sha256": "9f5153562ac3eea2debc58ba81fb215a47a52a037d95d88d065f04eecc296066",
+            "version": "4.7.2-1"
+        },
+        {
+            "name": "flake8",
+            "repository": "enthought/free",
+            "sha256": "d175d2fb7da536e2287674ebbfb40dee8f4e89be51cac31a8be2b7b061d28aa6",
+            "version": "3.7.7-1"
+        },
+        {
+            "name": "idna",
+            "repository": "enthought/free",
+            "sha256": "ffaf6c2304f9aa62276adcc33c835c768dc946567d7f500995b26e2187bf5692",
+            "version": "2.5-1"
+        },
+        {
+            "name": "imagesize",
+            "repository": "enthought/free",
+            "sha256": "54b150bc0e96a9b6e471fee62ec7eeef785278da62ace41b6fc20829a16efe91",
+            "version": "0.7.1-1"
+        },
+        {
+            "name": "jinja2",
+            "repository": "enthought/free",
+            "sha256": "49be68bfe7c3e34762e44233cd2c6a25b3278f2ebe692155b51e170206a5832e",
+            "version": "2.10.1-1"
+        },
+        {
+            "name": "markupsafe",
+            "repository": "enthought/free",
+            "sha256": "a4cecf5c2b764a60ff93c25ee46d65fe208df6ac93f6247db4ec39d851c70acf",
+            "version": "1.1.1-1"
+        },
+        {
+            "name": "mccabe",
+            "repository": "enthought/free",
+            "sha256": "8da243e1fd12b88a42d9584e46921f17ca93af2053f957f28ffc4a7fe14216a7",
+            "version": "0.6.1-1"
+        },
+        {
+            "name": "packaging",
+            "repository": "enthought/free",
+            "sha256": "e29c32c48565d32a58358306662a44b63df5348a59d766847ec38a8b36e2016f",
+            "version": "16.8-3"
+        },
+        {
+            "name": "pycodestyle",
+            "repository": "enthought/free",
+            "sha256": "72aa7e7b86b37bdcb17df352c23a68065312ea1df1632e077110d88b1a4b97ca",
+            "version": "2.5.0-1"
+        },
+        {
+            "name": "pyface",
+            "repository": "enthought/free",
+            "sha256": "000a55ca8edca580b469dc948d0d4a5b9e39600bf34d9385e46d10678e569aeb",
+            "version": "6.1.1-1"
+        },
+        {
+            "name": "pyflakes",
+            "repository": "enthought/free",
+            "sha256": "f7f76558b4464675f6d800c2c6c6a483807c1615d79658c9522ed852398d26cd",
+            "version": "2.1.1-1"
+        },
+        {
+            "name": "pygments",
+            "repository": "enthought/free",
+            "sha256": "122225544301ccbd61279b6ab0c9410ddafcc911a417ed2e6a8405dc23043982",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pyparsing",
+            "repository": "enthought/free",
+            "sha256": "6fe8234a197ae9f9bb45d56c1e84c97a00a5f1570336d27ed0ab9514b178a51c",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pytz",
+            "repository": "enthought/free",
+            "sha256": "7dcece3cfd104110e0a37d6fedc2dae3973550cc69847279bfebd81aa24b7851",
+            "version": "2018.9-1"
+        },
+        {
+            "name": "requests",
+            "repository": "enthought/free",
+            "sha256": "dd4359a6e5b9a1a5589bc00dd016df4ccf429af707bec6cf77a729e241911f93",
+            "version": "2.21.0-1"
+        },
+        {
+            "name": "setuptools",
+            "repository": "enthought/free",
+            "sha256": "381be57acfe79807ecae13c84f22d2325965e3c6434217f7f4d1e3f1808de5a9",
+            "version": "38.2.5-2"
+        },
+        {
+            "name": "six",
+            "repository": "enthought/free",
+            "sha256": "8470f5ce71367d794c1c1b193e812992242cf15f6f9ee3b5569f4a46bfbc75a0",
+            "version": "1.11.0-1"
+        },
+        {
+            "name": "snowballstemmer",
+            "repository": "enthought/free",
+            "sha256": "d7ef8ecbcb021a278b746953ae2e57c2d5fa254783090748eb9dcf6a9614d639",
+            "version": "1.2.1-1"
+        },
+        {
+            "name": "sphinx",
+            "repository": "enthought/free",
+            "sha256": "ec838052a6f8b4db7129e63542957ca9d1d87b6480f73a208e9d32c643cabb5c",
+            "version": "1.8.5-3"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "repository": "enthought/free",
+            "sha256": "f000a38fc51b52465d52d3e09d7921bfb580a7a9bd63ab5cba1f785158de512b",
+            "version": "0.2.4-1"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "repository": "enthought/free",
+            "sha256": "fbcd6e093381dea5bccb8cec09b4db1e1a651968634208578b14d5da19618515",
+            "version": "1.1.0-1"
+        },
+        {
+            "name": "testfixtures",
+            "repository": "enthought/free",
+            "sha256": "e58c346a255838bd5c55af9442be3c7cbd110d701e0ddf16bffc0e9e0df3bdb1",
+            "version": "4.10.0-1"
+        },
+        {
+            "name": "traits",
+            "repository": "enthought/free",
+            "sha256": "86b823d5fb2eae1f12491bf448856d84182cb814806eefcb8e9fb5a1ad7b4e6a",
+            "version": "5.1.1-1"
+        },
+        {
+            "name": "traitsui",
+            "repository": "enthought/free",
+            "sha256": "e508a72200c0196d504b7b9c0af26bedaac9d32734528d5dd0fc4a6ee26dd7e6",
+            "version": "6.1.1-2"
+        },
+        {
+            "name": "urllib3",
+            "repository": "enthought/free",
+            "sha256": "2e1f8fa610dcfe2b9016a4ba9fafb5ee44a052bf41860ff91626a9991f26df93",
+            "version": "1.22-4"
+        }
+    ],
+    "runtime": {
+        "implementation": "cpython",
+        "platform": "rh6_x86_64",
+        "platform_abi": "gnu",
+        "repository": "enthought/free",
+        "sha256": "8f4bd731f23f1e6711a6f65b88e8b1e208ac7941348b599a2420efd320fd2a04",
+        "version": "3.6.0+7"
+    }
+}

--- a/ci/bundle/force-py36-win-x86_64.json
+++ b/ci/bundle/force-py36-win-x86_64.json
@@ -89,6 +89,10 @@
             "state": "auto"
         },
         {
+            "name": "pip",
+            "state": "manual"
+        },
+        {
             "name": "pycodestyle",
             "state": "auto"
         },
@@ -306,6 +310,12 @@
             "repository": "enthought/free",
             "sha256": "63ac05ad91dae2fb9440bf339d0d93854f8ba16a0c4e35f507df47c74cb6af99",
             "version": "16.8-3"
+        },
+        {
+            "name": "pip",
+            "repository": "enthought/free",
+            "sha256": "6e61f1f6cdebc64939fcdca6ab778951ec543e2a7beee1fa83bfaa554f41e24d",
+            "version": "18.1-1"
         },
         {
             "name": "pycodestyle",

--- a/ci/bundle/force-py36-win-x86_64.json
+++ b/ci/bundle/force-py36-win-x86_64.json
@@ -1,0 +1,421 @@
+{
+    "mark": [
+        {
+            "name": "alabaster",
+            "state": "auto"
+        },
+        {
+            "name": "appdirs",
+            "state": "auto"
+        },
+        {
+            "name": "apptools",
+            "state": "auto"
+        },
+        {
+            "name": "babel",
+            "state": "auto"
+        },
+        {
+            "name": "certifi",
+            "state": "auto"
+        },
+        {
+            "name": "chardet",
+            "state": "auto"
+        },
+        {
+            "name": "click",
+            "state": "manual"
+        },
+        {
+            "name": "colorama",
+            "state": "auto"
+        },
+        {
+            "name": "configobj",
+            "state": "auto"
+        },
+        {
+            "name": "configparser",
+            "state": "auto"
+        },
+        {
+            "name": "coverage",
+            "state": "manual"
+        },
+        {
+            "name": "distribute_remove",
+            "state": "auto"
+        },
+        {
+            "name": "docutils",
+            "state": "auto"
+        },
+        {
+            "name": "entrypoints",
+            "state": "auto"
+        },
+        {
+            "name": "envisage",
+            "state": "manual"
+        },
+        {
+            "name": "flake8",
+            "state": "manual"
+        },
+        {
+            "name": "idna",
+            "state": "auto"
+        },
+        {
+            "name": "imagesize",
+            "state": "auto"
+        },
+        {
+            "name": "jinja2",
+            "state": "auto"
+        },
+        {
+            "name": "markupsafe",
+            "state": "auto"
+        },
+        {
+            "name": "mccabe",
+            "state": "auto"
+        },
+        {
+            "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pycodestyle",
+            "state": "auto"
+        },
+        {
+            "name": "pyface",
+            "state": "auto"
+        },
+        {
+            "name": "pyflakes",
+            "state": "auto"
+        },
+        {
+            "name": "pygments",
+            "state": "auto"
+        },
+        {
+            "name": "pyparsing",
+            "state": "auto"
+        },
+        {
+            "name": "pytz",
+            "state": "auto"
+        },
+        {
+            "name": "requests",
+            "state": "auto"
+        },
+        {
+            "name": "setuptools",
+            "state": "auto"
+        },
+        {
+            "name": "six",
+            "state": "auto"
+        },
+        {
+            "name": "snowballstemmer",
+            "state": "auto"
+        },
+        {
+            "name": "sphinx",
+            "state": "manual"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "state": "auto"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "state": "auto"
+        },
+        {
+            "name": "testfixtures",
+            "state": "manual"
+        },
+        {
+            "name": "traits",
+            "state": "auto"
+        },
+        {
+            "name": "traitsui",
+            "state": "auto"
+        },
+        {
+            "name": "urllib3",
+            "state": "auto"
+        }
+    ],
+    "metadata_version": "2.0",
+    "modifiers": {
+        "allow_any": [],
+        "allow_newer": [],
+        "allow_older": []
+    },
+    "repositories": {
+        "packages": [
+            "enthought/commercial",
+            "enthought/free",
+            "enthought/platform",
+            "shell/geoduck"
+        ],
+        "runtimes": [
+            "enthought/free"
+        ]
+    },
+    "requirements": [
+        {
+            "name": "alabaster",
+            "repository": "enthought/free",
+            "sha256": "b4c97353ca689d93195ce5de2bf7579161182cc0d1536401f88c2a1a817b5ed0",
+            "version": "0.7.10-1"
+        },
+        {
+            "name": "appdirs",
+            "repository": "enthought/free",
+            "sha256": "bfea50588488e47b2df937c02dc1d97b25d74b12786840109b7b654f40e95dfe",
+            "version": "1.4.3-1"
+        },
+        {
+            "name": "apptools",
+            "repository": "enthought/free",
+            "sha256": "7cad25ff8f3af186fb6eb043def44176a313688836bc8a00899940fd881935b2",
+            "version": "4.4.0-14"
+        },
+        {
+            "name": "babel",
+            "repository": "enthought/free",
+            "sha256": "be0a5902950fb926e36b090ecdf659bd66e0a232b935649e4d7a8ba273bac580",
+            "version": "2.6.0-1"
+        },
+        {
+            "name": "certifi",
+            "repository": "enthought/free",
+            "sha256": "97e02f25d11e2a4b10973120330f1545db1a7a9d01d95c092a30778a881de2b5",
+            "version": "2018.11.29-1"
+        },
+        {
+            "name": "chardet",
+            "repository": "enthought/free",
+            "sha256": "bad85bb649f0ac5d7e123cc4fd853726ade2fa8d2da4e2d3fa3da4651f2ae2ec",
+            "version": "3.0.4-1"
+        },
+        {
+            "name": "click",
+            "repository": "enthought/free",
+            "sha256": "7342b8984ef7029bc8b4d2500100cd795d0f1d4d0bde2c95cdcd3dd8ab5e1065",
+            "version": "7.0-1"
+        },
+        {
+            "name": "colorama",
+            "repository": "enthought/free",
+            "sha256": "9d760ea060457da0d45f167077a92fcd90989c4e737513c4edcbb8ab642812db",
+            "version": "0.3.7-1"
+        },
+        {
+            "name": "configobj",
+            "repository": "enthought/free",
+            "sha256": "f7c2d2415ca983bb4639c3a99e77fba2e67a2458772ea81b7cc37988b32ca69e",
+            "version": "5.0.6-3"
+        },
+        {
+            "name": "configparser",
+            "repository": "enthought/free",
+            "sha256": "f4876326cc07c928be3b534c5d8d68b2ba9c64e4575a785caa087e6de1c743f0",
+            "version": "3.5.0-1"
+        },
+        {
+            "name": "coverage",
+            "repository": "enthought/free",
+            "sha256": "9e9c603e70876e7c1b605fddd78096b117b0f62550f946ab07a20292178d028f",
+            "version": "4.3.4-1"
+        },
+        {
+            "name": "distribute_remove",
+            "repository": "enthought/free",
+            "sha256": "8dfa28992cebe732dc876f97b3157bfbdf16ca8e58f95e54da29d54e4ddd14b3",
+            "version": "1.0.0-4"
+        },
+        {
+            "name": "docutils",
+            "repository": "enthought/free",
+            "sha256": "4864781e7264d8a6ff15800e2a53dd23a71d0ee4819b64147fc4f2a8b22802d9",
+            "version": "0.13.1-1"
+        },
+        {
+            "name": "entrypoints",
+            "repository": "enthought/free",
+            "sha256": "bfa0ae871167e9d1162ca84b7d40732e2fe02a2de57985198911a0ec3421ee5b",
+            "version": "0.3-1"
+        },
+        {
+            "name": "envisage",
+            "repository": "enthought/free",
+            "sha256": "35fdf19eb29ad159ac8ad38196b5ce16306b0f50293a3e112c43bf9335bc80d7",
+            "version": "4.7.2-1"
+        },
+        {
+            "name": "flake8",
+            "repository": "enthought/free",
+            "sha256": "bb4734cdcea08d1690a9d0051e045cc74f814f970c3fcc0635229f9339bd83fe",
+            "version": "3.7.7-1"
+        },
+        {
+            "name": "idna",
+            "repository": "enthought/free",
+            "sha256": "c4fd6c7ffe4640fe8d7a772d2aacced43f36b01d9d2f42d1769c88d6c66645f0",
+            "version": "2.5-1"
+        },
+        {
+            "name": "imagesize",
+            "repository": "enthought/free",
+            "sha256": "e7ae4a2ca1ad60752e9b524060387904f7bdfdb6743963c9eed2d80e6fe95bb6",
+            "version": "0.7.1-1"
+        },
+        {
+            "name": "jinja2",
+            "repository": "enthought/free",
+            "sha256": "bb198c17f1f1b33c94f03e695fe61720c4f6271b98d8e7a1864b277debc3dbd9",
+            "version": "2.10.1-1"
+        },
+        {
+            "name": "markupsafe",
+            "repository": "enthought/free",
+            "sha256": "ac1450d9ae99268be4405d729b282e052274908e518a322543eb272c59ba5daf",
+            "version": "1.1.1-1"
+        },
+        {
+            "name": "mccabe",
+            "repository": "enthought/free",
+            "sha256": "5ef2bd3ad55c4da43a2a53550eed3fc64b7c0974c3d783449678346a059f8dab",
+            "version": "0.6.1-1"
+        },
+        {
+            "name": "packaging",
+            "repository": "enthought/free",
+            "sha256": "63ac05ad91dae2fb9440bf339d0d93854f8ba16a0c4e35f507df47c74cb6af99",
+            "version": "16.8-3"
+        },
+        {
+            "name": "pycodestyle",
+            "repository": "enthought/free",
+            "sha256": "04c3df901ff96d437f052ccd4dd01976ca652ab3de7ca46c858c044317e12770",
+            "version": "2.5.0-1"
+        },
+        {
+            "name": "pyface",
+            "repository": "enthought/free",
+            "sha256": "9f1e4fbc60534f962b62274a7cdf272998af114a3f1e1e80c60124cb42768ab2",
+            "version": "6.1.1-1"
+        },
+        {
+            "name": "pyflakes",
+            "repository": "enthought/free",
+            "sha256": "638569a8542048b6f40be5415c87774e4590d63d9d066a584fe7e56d62add574",
+            "version": "2.1.1-1"
+        },
+        {
+            "name": "pygments",
+            "repository": "enthought/free",
+            "sha256": "589c22af756ded210872dcee46c8dcfd59cfd852ed8ac87afb9ca0de65c0acd3",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pyparsing",
+            "repository": "enthought/free",
+            "sha256": "07ef95bc2b52e1f6595f6c783ed455b774dc0770772cd2969dc600be7e6b3c69",
+            "version": "2.2.0-1"
+        },
+        {
+            "name": "pytz",
+            "repository": "enthought/free",
+            "sha256": "eff62186d162be5a3a7774ed234fbfe9eeb6bcf4389ef1b7afa1bc6ff6260758",
+            "version": "2018.9-1"
+        },
+        {
+            "name": "requests",
+            "repository": "enthought/free",
+            "sha256": "ae68d99d50381dfb7eb45f76f236e372dba648629e5a2866be60150bff27617f",
+            "version": "2.21.0-1"
+        },
+        {
+            "name": "setuptools",
+            "repository": "enthought/free",
+            "sha256": "81832eca518f8f251102c0354e393281291c7535eee3088ab4a366c740e99681",
+            "version": "38.2.5-2"
+        },
+        {
+            "name": "six",
+            "repository": "enthought/free",
+            "sha256": "69b68c6dbeaa9ece01bbb0614ab04e50a1e307a60de9b48bc24d0346f7b805b9",
+            "version": "1.11.0-1"
+        },
+        {
+            "name": "snowballstemmer",
+            "repository": "enthought/free",
+            "sha256": "acbd2c457a49747bfa342dee74d6e862fe35839305026915c898a286c5b15899",
+            "version": "1.2.1-1"
+        },
+        {
+            "name": "sphinx",
+            "repository": "enthought/free",
+            "sha256": "505a386aab83ab6899d88c85121e4d1947f8bc3f5448ad502ded4d1913220e53",
+            "version": "1.8.5-3"
+        },
+        {
+            "name": "sphinx_rtd_theme",
+            "repository": "enthought/free",
+            "sha256": "6c568bff2b583683fd3f3c3a232ca3b3bd530a690522e62e949fc5b55f519441",
+            "version": "0.2.4-1"
+        },
+        {
+            "name": "sphinxcontrib_websupport",
+            "repository": "enthought/free",
+            "sha256": "d2fd11ff619e7e903091315b8c18a82e7f19600579b968ea6b2a5c3f8d4a30f7",
+            "version": "1.1.0-1"
+        },
+        {
+            "name": "testfixtures",
+            "repository": "enthought/free",
+            "sha256": "8ba5658e4a7cec3e306208409875a314f1114c0b5c284bc060acae17fac5c6ec",
+            "version": "4.10.0-1"
+        },
+        {
+            "name": "traits",
+            "repository": "enthought/free",
+            "sha256": "a832a303a2be6225a9ff485a6e95ea62d9bff87c4022300e024e67a5e8dbfadd",
+            "version": "5.1.1-1"
+        },
+        {
+            "name": "traitsui",
+            "repository": "enthought/free",
+            "sha256": "a8d92520248433c044de1945a5d757634eb777634f6bac1a4c1d763e0c38526f",
+            "version": "6.1.1-2"
+        },
+        {
+            "name": "urllib3",
+            "repository": "enthought/free",
+            "sha256": "fbbe97adf1667de4b3940465199ba788c0ec2195b8d2a8f02a679e67e9584d26",
+            "version": "1.22-4"
+        }
+    ],
+    "runtime": {
+        "implementation": "cpython",
+        "platform": "win_x86_64",
+        "platform_abi": "msvc2015",
+        "repository": "enthought/free",
+        "sha256": "4b91c784f2f5c9260a6117c49a51c7ca7fd703da1d7b7c475867d34f8542e892",
+        "version": "3.6.0+7"
+    }
+}


### PR DESCRIPTION
With this PR, the process for building an environment doesn't change (from the user point of view): indeed, `.travis.yml` and `docs/source/installation.rst` aren't changed.

However, now the dependencies are not specified in the `ci` code, but in bundle files, which makes the environment creation process entirely reproducible.

---

When updating the dependencies, instead of changing the `*_DEPS` constants, we run
```
ci generate-edm-bundles  # this will pick up the newest eggs
```
then, if
```
ci build-env
ci install
ci test
```
work well, we `commit` and `push` the new bundles.

If downgrades are necessary, then and only then we edit `EDM_DEPS` with version strings on selected packages, and repeat the process.