### PR TITLE
Docs: instructions for contributing data_views in the Plugin Development chapter

### DIFF
--- a/doc/source/plugin_development.rst
+++ b/doc/source/plugin_development.rst
@@ -248,6 +248,10 @@ them discoverable by a GUI application (wfmanager) through the
         of its subclasses.
         """
 
+Note that this method doesn't exist in ``force_bdss.api.BaseExtensionPlugin``
+and there is no need to override it, unless you want to provide custom data
+views.
+
 Make sure to import the module containing the data view class from inside
 ``get_data_views``: this ensures that running BDSS without a GUI application
 doesn't import the graphical stack. For instance::

--- a/doc/source/plugin_development.rst
+++ b/doc/source/plugin_development.rst
@@ -6,7 +6,8 @@ provided as a separate python package that makes available some new classes.
 Force BDSS will find these classes from the plugin at startup.
 
 A single Plugin can provide one or more of the following entities:
-MCO, DataSources, NotificationListeners, UIHooks.
+MCO, DataSources, NotificationListeners, UIHooks. It can optionally
+provide data_views to be used by the wfmanager GUI.
 
 An example plugin implementation is available at:
 
@@ -233,3 +234,24 @@ of the UI. It has no model. The factory must inherit from
 to return a class inheriting from ``BaseUIHooksManager``. This class has
 specific methods to be reimplemented to perform operations before and after
 some UI operations.
+
+Data views
+^^^^^^^^^^
+
+A plugin can also define one or more custom visualization classes, and make
+them discoverable by a GUI application (wfmanager) through the
+``get_data_views`` method of the plugin class::
+
+    def get_data_views(self):
+        """ Returns a list of classes, which must inherit from
+        `force_wfmanager.ui.review.data_view.BaseDataView` or from one
+        of its subclasses.
+        """
+
+Make sure to import the module containing the data view class from inside
+``get_data_views``: this ensures that running BDSS without a GUI application
+doesn't import the graphical stack. For instance::
+
+    def get_data_views(self):
+        from .example_data_views import ExampleCustomPlot
+        return [ExampleCustomPlot]


### PR DESCRIPTION
In order to advertise the feature being added in wfmanager (https://github.com/force-h2020/force-wfmanager/pull/276).

It doesn't reflect anything that is present in this codebase, but this repo holds the documentation for writing plugins so it seemed like a good place to put it.