### PR TITLE
Including verification check for no defined KPIs in BaseMCOModel

### DIFF
--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -30,9 +30,19 @@ class TestVerifier(unittest.TestCase):
         wf.mco = self.plugin.mco_factories[0].create_model()
 
         errors = verify_workflow(wf)
-        self.assertEqual(len(errors), 2)
+        self.assertEqual(len(errors), 3)
         self.assertEqual(errors[0].subject, wf.mco)
         self.assertIn("no defined parameters", errors[0].local_error)
+
+    def test_no_mco_kpis(self):
+        wf = self.workflow
+        mco_factory = self.plugin.mco_factories[0]
+        wf.mco = mco_factory.create_model()
+
+        errors = verify_workflow(wf)
+        self.assertEqual(len(errors), 3)
+        self.assertEqual(errors[0].subject, wf.mco)
+        self.assertIn("no defined KPIs", errors[1].local_error)
 
     def test_empty_parameter_options(self):
         wf = self.workflow
@@ -42,11 +52,11 @@ class TestVerifier(unittest.TestCase):
         wf.mco.parameters.append(parameter_factory.create_model())
 
         errors = verify_workflow(wf)
-        self.assertEqual(len(errors), 3)
-        self.assertEqual(errors[0].subject, wf.mco.parameters[0])
-        self.assertIn("MCO parameter is not named", errors[0].local_error)
+        self.assertEqual(len(errors), 4)
         self.assertEqual(errors[1].subject, wf.mco.parameters[0])
-        self.assertIn("MCO parameter has no type set", errors[1].local_error)
+        self.assertIn("MCO parameter is not named", errors[1].local_error)
+        self.assertEqual(errors[1].subject, wf.mco.parameters[0])
+        self.assertIn("MCO parameter has no type set", errors[2].local_error)
 
     def test_empty_kpi_options(self):
         wf = self.workflow
@@ -68,6 +78,7 @@ class TestVerifier(unittest.TestCase):
         wf.mco.parameters.append(parameter_factory.create_model())
         wf.mco.parameters[0].name = "name"
         wf.mco.parameters[0].type = "type"
+        wf.mco.kpis.append(KPISpecification(name='name'))
 
         layer = ExecutionLayer()
         wf.execution_layers.append(layer)
@@ -84,6 +95,7 @@ class TestVerifier(unittest.TestCase):
         wf.mco.parameters.append(parameter_factory.create_model())
         wf.mco.parameters[0].name = "name"
         wf.mco.parameters[0].type = "type"
+        wf.mco.kpis.append(KPISpecification(name='name'))
 
         layer = ExecutionLayer()
         wf.execution_layers.append(layer)

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -48,6 +48,15 @@ class BaseMCOModel(BaseModel):
                     global_error="The MCO has no defined parameters",
                 )
             )
+
+        if not self.kpis:
+            errors.append(
+                VerifierError(
+                    subject=self,
+                    global_error="The MCO has no defined KPIs",
+                )
+            )
+
         for parameter in self.parameters:
             errors += parameter.verify()
 

--- a/force_bdss/tests/test_core_mco_driver.py
+++ b/force_bdss/tests/test_core_mco_driver.py
@@ -241,6 +241,8 @@ class TestCoreMCODriver(unittest.TestCase):
                 ('force_bdss.core_mco_driver', 'ERROR',
                  'The MCO has no defined parameters'),
                 ('force_bdss.core_mco_driver', 'ERROR',
+                 'The MCO has no defined KPIs'),
+                ('force_bdss.core_mco_driver', 'ERROR',
                  'The number of input slots is incorrect.'),
                 ('force_bdss.core_mco_driver', 'ERROR',
                  'The number of output slots is incorrect.'))


### PR DESCRIPTION
This PR completes the verification requirements for `BaseMCOModel`, listed in `<BaseMCOModel.verify>`:

    Check that the MCO model:
        - has at least one parameter
        - has at least one KPI
        - has no parameter errors
        - has no KPI errors

Specifically, the method now raises a `VerifierError` if no KPIs are defined in the MCO, replicating the condition if no parameters are present.

Supporting unit tests in `test_verifier.py` and `test_core_mco_driver.py` files have also been updated accordingly.