### PR TITLE
Support for custom UI in WorkflowReader

### DIFF
--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -115,6 +115,7 @@ class WorkflowReader(HasStrictTraits):
 
         try:
             wf_data = json_data["workflow"]
+            wf = self.read_dict(wf_data)
         except KeyError as e:
             msg = (
                 "Could not read file {}. "
@@ -123,7 +124,7 @@ class WorkflowReader(HasStrictTraits):
             logger.exception(msg)
             raise InvalidFileException(msg)
 
-        wf = self.read_dict(wf_data)
+
 
         return wf
 

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -124,8 +124,6 @@ class WorkflowReader(HasStrictTraits):
             logger.exception(msg)
             raise InvalidFileException(msg)
 
-
-
         return wf
 
     def read_dict(self, wf_data):

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -113,14 +113,8 @@ class WorkflowReader(HasStrictTraits):
             raise InvalidVersionException(
                 "File version {} not supported".format(json_data["version"]))
 
-        wf = Workflow()
-
         try:
             wf_data = json_data["workflow"]
-            wf.mco = self._extract_mco(wf_data)
-            wf.execution_layers[:] = self._extract_execution_layers(wf_data)
-            wf.notification_listeners[:] = \
-                self._extract_notification_listeners(wf_data)
         except KeyError as e:
             msg = (
                 "Could not read file {}. "
@@ -129,6 +123,26 @@ class WorkflowReader(HasStrictTraits):
             logger.exception(msg)
             raise InvalidFileException(msg)
 
+        wf = self.read_dict(wf_data)
+
+        return wf
+
+    def read_dict(self, wf_data):
+        """Read a dictionary containing workflow data and return a Workflow
+        object
+
+        Parameters
+        ----------
+        wf_data: Data
+            The dictionary containing the workflow data.
+        """
+        wf = Workflow()
+
+        wf.mco = self._extract_mco(wf_data)
+        wf.execution_layers[:] = self._extract_execution_layers(wf_data)
+        wf.notification_listeners[:] = (
+            self._extract_notification_listeners(wf_data)
+        )
         return wf
 
     def _extract_mco(self, wf_data):


### PR DESCRIPTION
For the custom UIs, it's helpful to be able to convert dictionaries directly into a `Workflow` object rather than it always being read from a file.