### PR TITLE
Enc/refactor io slots

### DIFF
--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -297,10 +297,10 @@ class TestOptimizeOperation(TestCase):
                  'The MCO has no defined KPIs'),
                 ('force_bdss.app.optimize_operation',
                  'ERROR',
-                 'Input slot is not named'),
+                 'An Input Slot variable has an undefined name'),
                 ('force_bdss.app.optimize_operation',
                  'ERROR',
                  'All output variables have undefined names.'),
                 ('force_bdss.app.optimize_operation',
                  'ERROR',
-                 'An output variable has an undefined name'))
+                 'An Output Slot variable has an undefined name'))

--- a/force_bdss/core/base_slot_info.py
+++ b/force_bdss/core/base_slot_info.py
@@ -23,35 +23,22 @@ class BaseSlotInfo(HasStrictTraits):
     #: A textual description of the slot
     description = Unicode("No description")
 
-    #: Slot Info title
-    _title = ""
-
-    #: Slot state verification severity
-    _verification_severity = "error"
-
     def __getstate__(self):
         return pop_dunder_recursive(super().__getstate__())
 
-    def verify(self):
-        """ BaseSlotInfo may require a non-empty name trait to be used in a
-        later execution layer. However, not all outputs are required to be
-        used in later stages.
-
-        Parameters:
-        title: str
-            Title of the SlotInfo ("Input", "Output")
-        severity: str
-            Severity of the verification error
+    def _verify_name(self, slot_title="", verification_severity="error"):
+        """ Verifies that the `name` trait of the SlotInfo object is defined,
+        as it may be required for a later execution layer.
         """
 
         errors = []
         if not self.name:
             error = VerifierError(
                 subject=self,
-                severity=self._verification_severity,
+                severity=verification_severity,
                 trait_name="name",
                 global_error="An {} variable has an undefined name".format(
-                    self._title
+                    slot_title
                 ),
             )
             errors.append(error)

--- a/force_bdss/core/base_slot_info.py
+++ b/force_bdss/core/base_slot_info.py
@@ -2,6 +2,7 @@ from traits.api import HasStrictTraits, Unicode
 
 from force_bdss.io.workflow_writer import pop_dunder_recursive
 from force_bdss.local_traits import Identifier, CUBAType
+from force_bdss.core.verifier import VerifierError
 
 
 class BaseSlotInfo(HasStrictTraits):
@@ -22,5 +23,37 @@ class BaseSlotInfo(HasStrictTraits):
     #: A textual description of the slot
     description = Unicode("No description")
 
+    #: Slot Info title
+    _title = ""
+
+    #: Slot state verification severity
+    _verification_severity = "error"
+
     def __getstate__(self):
         return pop_dunder_recursive(super().__getstate__())
+
+    def verify(self):
+        """ BaseSlotInfo may require a non-empty name trait to be used in a
+        later execution layer. However, not all outputs are required to be
+        used in later stages.
+
+        Parameters:
+        title: str
+            Title of the SlotInfo ("Input", "Output")
+        severity: str
+            Severity of the verification error
+        """
+
+        errors = []
+        if not self.name:
+            error = VerifierError(
+                subject=self,
+                severity=self._verification_severity,
+                trait_name="name",
+                global_error="An {} variable has an undefined name".format(
+                    self._title
+                ),
+            )
+            errors.append(error)
+
+        return errors

--- a/force_bdss/core/base_slot_info.py
+++ b/force_bdss/core/base_slot_info.py
@@ -29,6 +29,13 @@ class BaseSlotInfo(HasStrictTraits):
     def _verify_name(self, slot_title="", verification_severity="error"):
         """ Verifies that the `name` trait of the SlotInfo object is defined,
         as it may be required for a later execution layer.
+
+        Parameters
+        --------
+        slot_title: str
+            The SlotInfo title, which specifies the meta-type of the slot
+        verification_severity: str
+            The `severity` of the potential VerifierError
         """
 
         errors = []

--- a/force_bdss/core/input_slot_info.py
+++ b/force_bdss/core/input_slot_info.py
@@ -15,4 +15,5 @@ class InputSlotInfo(BaseSlotInfo):
     #: as ``name``.
     source = Enum("Environment")
 
-    _title = "Input Slot"
+    def verify(self):
+        return self._verify_name("Input Slot")

--- a/force_bdss/core/input_slot_info.py
+++ b/force_bdss/core/input_slot_info.py
@@ -1,7 +1,5 @@
 from traits.api import Enum
 
-from force_bdss.core.verifier import VerifierError
-
 from .base_slot_info import BaseSlotInfo
 
 
@@ -15,17 +13,6 @@ class InputSlotInfo(BaseSlotInfo):
     #: At the moment, only the Environment is supported: the source is the
     #: parameter in the current execution environment with the name specified
     #: as ``name``.
-    source = Enum('Environment')
+    source = Enum("Environment")
 
-    def verify(self):
-        """ Verify that the InputSlotInfo is valid. """
-        errors = []
-        if not self.name:
-            errors.append(
-                VerifierError(
-                    subject=self,
-                    local_error="Input slot is not named",
-                    global_error="An input slot is not named",
-                )
-            )
-        return errors
+    _title = "Input Slot"

--- a/force_bdss/core/output_slot_info.py
+++ b/force_bdss/core/output_slot_info.py
@@ -7,6 +7,5 @@ class OutputSlotInfo(BaseSlotInfo):
     of a data source.
     """
 
-    _verification_severity = "warning"
-
-    _title = "Output Slot"
+    def verify(self):
+        return self._verify_name("Output Slot", "warning")

--- a/force_bdss/core/output_slot_info.py
+++ b/force_bdss/core/output_slot_info.py
@@ -1,5 +1,3 @@
-from force_bdss.core.verifier import VerifierError
-
 from .base_slot_info import BaseSlotInfo
 
 
@@ -9,17 +7,6 @@ class OutputSlotInfo(BaseSlotInfo):
     of a data source.
     """
 
-    def verify(self):
-        """ OutputSlotInfo require a non-empty name to be used in a later
-        execution layer. However, not all outputs are required to be used in
-        later stages."""
-        errors = []
-        if not self.name:
-            errors.append(
-                VerifierError(
-                    severity='warning', subject=self, trait_name='name',
-                    global_error='An output variable has an undefined name'
-                )
-            )
+    _verification_severity = "warning"
 
-        return errors
+    _title = "Output Slot"

--- a/force_bdss/core/tests/test_base_slot_info.py
+++ b/force_bdss/core/tests/test_base_slot_info.py
@@ -20,3 +20,12 @@ class TestBaseSlotInfo(unittest.TestCase):
              'description': 'A description'},
             self.slot_info.__getstate__()
         )
+
+    def test__verify_name(self):
+        noname_slot_info = BaseSlotInfo(
+            name='',
+            type='VOLUME',
+            description='A description'
+        )
+        errors = noname_slot_info._verify_name()
+        self.assertEqual(1, len(errors))

--- a/force_bdss/core/tests/test_execution_layer.py
+++ b/force_bdss/core/tests/test_execution_layer.py
@@ -34,11 +34,11 @@ class TestExecutionLayer(TestCase):
         messages = [error.local_error for error in errors]
 
         self.assertEqual(6, len(messages))
-        self.assertIn('Input slot is not named',
+        self.assertIn('An Input Slot variable has an undefined name',
                       messages)
         self.assertIn('All output variables have undefined names.',
                       messages)
-        self.assertIn('An output variable has an undefined name',
+        self.assertIn('An Output Slot variable has an undefined name',
                       messages)
 
         self.layer.data_sources = []

--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -105,11 +105,11 @@ class TestVerifier(unittest.TestCase):
 
         errors = verify_workflow(wf)
         self.assertEqual(len(errors), 3)
-        self.assertIn("Input slot is not named",
+        self.assertIn("An Input Slot variable has an undefined name",
                       errors[0].local_error)
         self.assertIn("All output variables have undefined names",
                       errors[1].local_error)
-        self.assertIn("An output variable has an undefined name",
+        self.assertIn("An Output Slot variable has an undefined name",
                       errors[2].local_error)
 
         ds_model.input_slot_info[0].name = 'in'


### PR DESCRIPTION
This PR attempts to refactor the `BaseSlotInfo` class to include the verification checks shared between the actual `*SlotInfo` classes.

The `_verify_name` method is the only verification we currently do. However, if any other verifications will be needed, it can be implemented and shared across the child `SlotInfo` classes.