### PR TITLE
Fix/prfix ref data source

### DIFF
--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -160,8 +160,7 @@ class BaseDataSourceModel(BaseModel):
         object are not equal to those returned by the associated
         BaseDataSource `slots` method
         TraitSimilarityError, if the attributes on each element in the
-        List(BaseSlotInfo) instances do not pass a
-        `merge_trait_with_check` call
+        List(BaseSlotInfo) instances do not pass a `merge_trait_with_check`
         """
 
         # Get InputSlotInfo / OutputSlotInfo lists that are returned
@@ -204,8 +203,7 @@ class BaseDataSourceModel(BaseModel):
                     # both values differ and are not set at their defaults
                     merge_trait_with_check(slot, data_source_slot, attributes)
             else:
-                # If attribute list is empty, simply assign
-                # data_source_slot_info
+                # If attribute list is empty, assign data_source_slot_info
                 setattr(self, slot_name, data_source_slot_info)
 
     # -------------------

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -1,8 +1,6 @@
 from logging import getLogger
 
-from traits.api import (
-    Instance, List, Event, on_trait_change
-)
+from traits.api import Instance, List, Event, on_trait_change
 
 from force_bdss.core.base_model import BaseModel
 from force_bdss.core.input_slot_info import InputSlotInfo
@@ -11,10 +9,8 @@ from force_bdss.core.verifier import VerifierError
 from force_bdss.data_sources.i_data_source_factory import IDataSourceFactory
 from force_bdss.io.workflow_writer import pop_dunder_recursive
 
+from .data_source_utilities import merge_trait_with_check
 
-from .data_source_utilities import (
-    merge_trait_with_check
-)
 
 logger = getLogger(__name__)
 
@@ -27,6 +23,7 @@ class BaseDataSourceModel(BaseModel):
     In your factory definition, your factory-specific model must reimplement
     this class.
     """
+
     #: A reference to the creating factory, so that we can
     #: retrieve it as the originating factory.
     factory = Instance(IDataSourceFactory, visible=False, transient=True)
@@ -100,8 +97,7 @@ class BaseDataSourceModel(BaseModel):
             logger.exception(
                 "Unable to create data source from factory {}, plugin "
                 "{}. This might indicate a  programming error".format(
-                    self.factory.id,
-                    self.factory.plugin_id
+                    self.factory.id, self.factory.plugin_id
                 )
             )
             raise
@@ -113,8 +109,7 @@ class BaseDataSourceModel(BaseModel):
                 "Unable to retrieve slot information from data source"
                 " created by factory {}, plugin {}. This might "
                 "indicate a programming error.".format(
-                    self.factory.id,
-                    self.factory.plugin_id
+                    self.factory.id, self.factory.plugin_id
                 )
             )
             raise
@@ -137,19 +132,19 @@ class BaseDataSourceModel(BaseModel):
         input_slots, output_slots = self._data_source_slots()
 
         input_slot_info = [
-            InputSlotInfo(type=slot.type,
-                          description=slot.description)
+            InputSlotInfo(type=slot.type, description=slot.description)
             for slot in input_slots
         ]
 
         output_slot_info = [
-            OutputSlotInfo(type=slot.type,
-                           description=slot.description)
+            OutputSlotInfo(type=slot.type, description=slot.description)
             for slot in output_slots
         ]
 
-        for element in zip(["input_slot_info", "output_slot_info"],
-                           [input_slot_info, output_slot_info]):
+        for element in zip(
+            ["input_slot_info", "output_slot_info"],
+            [input_slot_info, output_slot_info],
+        ):
             yield element
 
     def _assign_slot_info(self):
@@ -171,11 +166,11 @@ class BaseDataSourceModel(BaseModel):
 
         # Get InputSlotInfo / OutputSlotInfo lists that are returned
         # from the associated BaseDataSource subclass
-        for attr_name, data_source_slot_info in self._slot_info_generator():
+        for slot_name, data_source_slot_info in self._slot_info_generator():
 
             # Obtain a reference to either input_slot_info or
             # output_slot_info attributes on this object
-            model_slot_info = getattr(self, attr_name)
+            model_slot_info = getattr(self, slot_name)
 
             if model_slot_info:
                 # Check that the length of the assigned attribute is the
@@ -189,7 +184,8 @@ class BaseDataSourceModel(BaseModel):
                             type(model_slot_info[0]).__name__,
                             len(model_slot_info),
                             type(self).__name__,
-                            len(data_source_slot_info))
+                            len(data_source_slot_info),
+                        )
                     )
                     logger.exception(error_msg)
                     raise ValueError(error_msg)
@@ -197,7 +193,8 @@ class BaseDataSourceModel(BaseModel):
                 # Perform a merge of all attributes between the corresponding
                 # InputSlotInfo / OutputSlotInfo elements.
                 for slot, data_source_slot in zip(
-                        model_slot_info, data_source_slot_info):
+                    model_slot_info, data_source_slot_info
+                ):
 
                     # Get all the attributes that need to be merged between
                     # instances
@@ -205,12 +202,11 @@ class BaseDataSourceModel(BaseModel):
 
                     # Merge these attributes, whilst raising an exception if
                     # both values differ and are not set at their defaults
-                    merge_trait_with_check(
-                        slot, data_source_slot, attributes)
+                    merge_trait_with_check(slot, data_source_slot, attributes)
             else:
                 # If attribute list is empty, simply assign
                 # data_source_slot_info
-                setattr(self, attr_name, data_source_slot_info)
+                setattr(self, slot_name, data_source_slot_info)
 
     # -------------------
     #   Public Methods
@@ -262,11 +258,12 @@ class BaseDataSourceModel(BaseModel):
             )
 
         if self.output_slot_info and not any(
-                output_slot.name for output_slot in self.output_slot_info):
+            output_slot.name for output_slot in self.output_slot_info
+        ):
             errors.append(
                 VerifierError(
                     subject=self,
-                    severity='warning',
+                    severity="warning",
                     local_error="All output variables have undefined names.",
                     global_error=(
                         "A data source model has no defined output names."

--- a/force_bdss/data_sources/data_source_utilities.py
+++ b/force_bdss/data_sources/data_source_utilities.py
@@ -94,11 +94,10 @@ def merge_trait(source, target, name):
     """ Performs a merge of trait `name` between source and target
     HasTrait objects. This is achieved by assigning the source
     attribute onto the target if it has a non-default value.
-    Otherwise, the target attribute is assigned onto the
-    source.
+    Otherwise, the target attribute is assigned onto the source.
 
-    The result is that both source and target have the
-    same value for their `name` attribute
+    The result is that both source and target have the same value
+    for their `name` attribute
 
     Parameters
     ----------

--- a/force_bdss/data_sources/data_source_utilities.py
+++ b/force_bdss/data_sources/data_source_utilities.py
@@ -7,14 +7,14 @@ class TraitSimilarityError(Exception):
     """Reports the failure of a attr_similarity_check."""
 
 
-def attr_similarity_check(object_a, object_b, name, ignore_default=False):
-    """Check whether attribute on object_a can be considered similar
-    to the same attribute on object_b.
+def have_similar_attribute(object_a, object_b, name, ignore_default=False):
+    """ Check whether `name` attribute on object_a is similar to the
+    same attribute on object_b.
 
-    This is allowed either if both attributes share the
-    same `name` value, or when ignore_default==True, then it is also
-    allowed if either attribute has not been changed from its default
-    value.
+    Attributes are called similar if:
+    - both attributes share the same `name` value, or
+    - (when ignore_default==True) either attribute has not been changed
+     from its default value.
 
     Parameters
     ----------
@@ -23,9 +23,9 @@ def attr_similarity_check(object_a, object_b, name, ignore_default=False):
     name: str
         Name of an attribute to check
     ignore_default: bool, optional, default: False
-        Whether or not to ignore the attribute on source or target
-        if it is equal to its default value. Note: this will not be
-        performed if attribute does not have a default.
+        Whether or not to ignore if the `name` attribute is equal to
+        its default value. This will not be performed if attribute
+        does not have a default.
     """
 
     attr_a = getattr(object_a, name)
@@ -35,12 +35,8 @@ def attr_similarity_check(object_a, object_b, name, ignore_default=False):
     # either object is its default value, and skip cross check if so
     if ignore_default:
         try:
-            default_check_a = (
-                attr_a == object_a.trait(name).default
-            )
-            default_check_b = (
-                attr_b == object_b.trait(name).default
-            )
+            default_check_a = attr_a == object_a.trait(name).default
+            default_check_b = attr_b == object_b.trait(name).default
             if default_check_a or default_check_b:
                 return True
         except AttributeError:
@@ -52,25 +48,24 @@ def attr_similarity_check(object_a, object_b, name, ignore_default=False):
     return attr_a == attr_b
 
 
-def attr_checker(object_a, object_b, attributes, ignore_default=False):
-    """Performs a `attr_similarity_check` between source and target
-    objects for each attribute listed in `attributes`. Returns a list
-    of attribute names that fail this check.
+def different_attributes(object_a, object_b, attributes, ignore_default=False):
+    """ Given `object_a` and `object_b`, return all attribute in `attributes`
+    that are not similar. The attribute similarity check is provided by
+    `have_similar_attribute`.
 
     Parameters
     ----------
     object_a, object_b: objects
         Object instances to perform attribute checks on
     attributes: str or list of str
-        An attribute or list of attributes used to check merge
-        eligibility of source and target objects
+        An attribute or list of attributes we compare the similarity of
     ignore_default: bool, optional, default: False
         Whether or not to ignore any attributes on source or target
         that are are equal to their default values
 
     Returns
     -------
-    failed_attr: list of str
+    failed_attr: list
         Names of attributes on source and target that fail a
         merge check
     """
@@ -87,16 +82,16 @@ def attr_checker(object_a, object_b, attributes, ignore_default=False):
 
     # Iterate through attributes list
     for attr_name in attributes:
-        if not attr_similarity_check(
-                object_a, object_b,
-                attr_name, ignore_default):
+        if not have_similar_attribute(
+            object_a, object_b, attr_name, ignore_default
+        ):
             failed_attr.append(attr_name)
 
     return failed_attr
 
 
 def merge_trait(source, target, name):
-    """Performs a merge of trait `name` between source and target
+    """ Performs a merge of trait `name` between source and target
     HasTrait objects. This is achieved by assigning the source
     attribute onto the target if it has a non-default value.
     Otherwise, the target attribute is assigned onto the
@@ -120,16 +115,14 @@ def merge_trait(source, target, name):
 
 
 def merge_trait_with_check(source, target, attributes, ignore_default=True):
-    """Performs the same function as `merge_trait` method, but with
-    some extra logic checks on default values and any selected
-    attributes supplied by `attributes` argument. These checks are
-    designed to determine whether both objects possess a similar
-    enough state to merge their attributes.
+    """ Performs `merge_trait` for attribute in `attributes`, with
+    checks on default values. These checks determine whether both `source`
+    and `target` possess a similar enough state to merge their attributes.
 
     Parameters
     ----------
     source, target: HasTraits
-        HasTraits instances to have thier attributes merged
+        HasTraits instances to have their attributes merged
     attributes: str or list of str
         An attribute or list of attributes to merge on both
         source and target objects
@@ -144,8 +137,9 @@ def merge_trait_with_check(source, target, attributes, ignore_default=True):
 
     # Obtain names of any provided attributes on both source and
     # target that fail an `attr_similarity_check`
-    failed_attr = attr_checker(source, target, attributes,
-                               ignore_default=ignore_default)
+    failed_attr = different_attributes(
+        source, target, attributes, ignore_default=ignore_default
+    )
 
     if failed_attr:
         attr_name = failed_attr[0]
@@ -156,7 +150,7 @@ def merge_trait_with_check(source, target, attributes, ignore_default=True):
             "target ({}).".format(
                 attr_name,
                 getattr(source, attr_name),
-                getattr(target, attr_name)
+                getattr(target, attr_name),
             )
         )
         logger.exception(error_msg)
@@ -164,7 +158,7 @@ def merge_trait_with_check(source, target, attributes, ignore_default=True):
 
     # Merge attributes between source and target
     if isinstance(attributes, str):
-        merge_trait(source, target, attributes)
-    else:
-        for attr in attributes:
-            merge_trait(source, target, attr)
+        attributes = [attributes]
+
+    for attr in attributes:
+        merge_trait(source, target, attr)

--- a/force_bdss/data_sources/tests/test_data_source_utilities.py
+++ b/force_bdss/data_sources/tests/test_data_source_utilities.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from traits.api import HasTraits, Int, Unicode
 
 from force_bdss.data_sources.data_source_utilities import (
-    attr_similarity_check, attr_checker, merge_trait_with_check,
+    have_similar_attribute, different_attributes, merge_trait_with_check,
     merge_trait, TraitSimilarityError
 )
 
@@ -44,36 +44,36 @@ class TestDataSourceUtilities(TestCase):
     def test_trait_similarity_check(self):
 
         self.assertFalse(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.old_trait, self.new_trait, 'an_integer'
             )
         )
         self.assertTrue(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.old_trait, self.new_trait, 'an_integer',
                 ignore_default=True
             )
         )
 
         self.assertFalse(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.new_trait, self.old_trait, 'a_string'
             )
         )
         self.assertTrue(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.new_trait, self.old_trait, 'a_string',
                 ignore_default=True
             )
         )
 
         self.assertTrue(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.old_trait, self.new_trait, '__class__'
             )
         )
         self.assertTrue(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.old_trait, self.new_trait, '__class__',
                 ignore_default=True
             )
@@ -81,32 +81,32 @@ class TestDataSourceUtilities(TestCase):
 
         another_trait = AnotherDummyTrait()
         self.assertTrue(
-            attr_similarity_check(
+            have_similar_attribute(
                 self.old_trait, another_trait, 'an_integer',
                 ignore_default=True)
         )
 
     def test_attr_checker(self):
-        failed_attr = attr_checker(
+        failed_attr = different_attributes(
             self.old_trait, self.new_trait,
             '__class__',
         )
         self.assertEqual(0, len(failed_attr))
 
-        failed_attr = attr_checker(
+        failed_attr = different_attributes(
             self.old_trait, self.new_trait,
             '__class__', ignore_default=True
         )
         self.assertEqual(0, len(failed_attr))
 
-        failed_attr = attr_checker(
+        failed_attr = different_attributes(
             self.old_trait, self.new_trait,
             ['__class__', 'an_integer', 'a_string']
         )
         self.assertEqual(2, len(failed_attr))
         self.assertListEqual(['an_integer', 'a_string'], failed_attr)
 
-        failed_attr = attr_checker(
+        failed_attr = different_attributes(
             self.old_trait, self.new_trait,
             ['__class__', 'an_integer', 'a_string'],
             ignore_default=True
@@ -114,7 +114,7 @@ class TestDataSourceUtilities(TestCase):
         self.assertEqual(0, len(failed_attr))
 
         with self.assertRaises(AttributeError):
-            attr_checker(
+            different_attributes(
                 self.old_trait, self.new_trait,
                 ['not_an_attr']
             )


### PR DESCRIPTION
This PR attempts to improve the docstrings, naming and formatting of the `base_data_source_model` and `data_source_utilities` modules in #234 . This doesn't have any functionality of design changes.

### Changes

- `attr_similarity_check ` -> `have_similar_attribute`
- `attr_checker` -> `different_attributes`