### PR TITLE
Implementing generic MCOparameter types

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -27,6 +27,7 @@ ADDITIONAL_CORE_DEPS = [
     "numpy==1.15.4-2"
 ]
 
+
 @click.group()
 def cli():
     pass

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -23,6 +23,9 @@ PIP_DEPS = [
     "stevedore==1.30.1"
 ]
 
+ADDITIONAL_CORE_DEPS = [
+    "numpy==1.15.4-2"
+]
 
 @click.group()
 def cli():
@@ -50,7 +53,7 @@ def build_env(python_version):
 
     check_call([
         "edm", "install", "-e", env_name,
-        "--yes"] + CORE_DEPS + DEV_DEPS + DOCS_DEPS)
+        "--yes"] + CORE_DEPS + DEV_DEPS + DOCS_DEPS + ADDITIONAL_CORE_DEPS)
 
     if len(PIP_DEPS):
         check_call([

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -138,7 +138,7 @@ class CategoricalMCOParameterFactory(BaseMCOParameterFactory):
 
     #: A name that will appear in the UI to identify this parameter.
     def get_name(self):
-        return "Categorical Parameter"
+        return "Categorical"
 
     #: Definition of the associated model class.
     def get_model_class(self):

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -61,7 +61,9 @@ class RangedMCOParameter(BaseMCOParameter):
     )
 
     def _get_sample_values(self):
-        return np.linspace(self.lower_bound, self.upper_bound, self.n_samples)
+        return list(
+            np.linspace(self.lower_bound, self.upper_bound, self.n_samples)
+        )
 
 
 class RangedMCOParameterFactory(BaseMCOParameterFactory):

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,0 +1,147 @@
+import numpy as np
+
+from traits.api import List, Unicode, Property, Float, ReadOnly, Int, Either
+from traitsui.api import ListEditor
+
+from .base_mco_parameter import BaseMCOParameter
+from .base_mco_parameter_factory import BaseMCOParameterFactory
+
+
+class FixedMCOParameter(BaseMCOParameter):
+    """ Fixed MCO parameter for (dummy) constant-valued data. The value
+    must be specified before use: the value is <undefined> by default."""
+
+    #: Fixed parameter value
+    value = ReadOnly
+
+    sample_values = Property(depends_on="value", visible=False)
+
+    def _get_sample_values(self):
+        return [self.value]
+
+
+class FixedMCOParameterFactory(BaseMCOParameterFactory):
+    """ Fixed Parameter factory"""
+
+    #: This identifier must be unique for your parameter.
+    #: Once again you are fully responsible for its uniqueness within the scope
+    #: of the MCO it belongs to. You can have the same identifier if and only
+    #: if they belong to different MCOs.
+    #: Again, you are free to choose a uuid if you so prefer.
+    def get_identifier(self):
+        return "fixed"
+
+    #: A name that will appear in the UI to identify this parameter.
+    def get_name(self):
+        return "Fixed"
+
+    #: Definition of the associated model class.
+    def get_model_class(self):
+        return FixedMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        return "A parameter with a fixed ReadOnly value."
+
+
+class RangedMCOParameter(BaseMCOParameter):
+    """ Numerical MCO parameter that continuously ranges between
+    lower and upper floating point values."""
+
+    #: Lower bound for parameter values range
+    lower_bound = Float(0.1)
+
+    #: Upper bound for parameter values range
+    upper_bound = Float(100.0)
+
+    n_samples = Int(5)
+
+    sample_values = Property(
+        depends_on="lower_bound,upper_bound,n_samples", visible=False
+    )
+
+    def _get_sample_values(self):
+        return np.linspace(self.lower_bound, self.upper_bound, self.n_samples)
+
+
+class RangedMCOParameterFactory(BaseMCOParameterFactory):
+    """ Ranged Parameter factory"""
+
+    def get_identifier(self):
+        return "ranged"
+
+    #: A name that will appear in the UI to identify this parameter.
+    def get_name(self):
+        return "Ranged"
+
+    #: Definition of the associated model class.
+    def get_model_class(self):
+        return RangedMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        return "A parameter with a ranged level in floating point values."
+
+
+class ListedMCOParameter(BaseMCOParameter):
+    """ Listed MCO parameter that has discrete numerical values."""
+
+    #: Discrete set of available numerical values
+    levels = List(Either(Int, Float), value=[0.0])
+
+    sample_values = Property(depends_on="levels", visible=False)
+
+    def _get_sample_values(self):
+        return sorted(self.levels)
+
+
+class ListedMCOParameterFactory(BaseMCOParameterFactory):
+    """ Listed Parameter factory"""
+
+    def get_identifier(self):
+        return "listed"
+
+    #: A name that will appear in the UI to identify this parameter.
+    def get_name(self):
+        return "Listed"
+
+    #: Definition of the associated model class.
+    def get_model_class(self):
+        return ListedMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        return (
+            "A parameter with a listed set of levels"
+            " in floating point values."
+        )
+
+
+class CategoricalMCOParameter(BaseMCOParameter):
+    """ Categorical MCO Parameter implements unordered, discrete valued,
+    categorical data. Available categorical values are strings. """
+
+    categories = List(Unicode, editor=ListEditor())
+    sample_values = Property(depends_on="categories", visible=False)
+
+    def _get_sample_values(self):
+        return self.categories
+
+
+class CategoricalMCOParameterFactory(BaseMCOParameterFactory):
+    """ The CategoricalMCOParameter factory"""
+
+    def get_identifier(self):
+        return "category"
+
+    #: A name that will appear in the UI to identify this parameter.
+    def get_name(self):
+        return "Categorical Parameter"
+
+    #: Definition of the associated model class.
+    def get_model_class(self):
+        return CategoricalMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        return "A Categorical parameter defining unordered discrete objects."

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -1,0 +1,103 @@
+from unittest import TestCase, mock
+
+from traits.api import TraitError
+
+from force_bdss.mco.parameters.mco_parameters import (
+    FixedMCOParameter,
+    FixedMCOParameterFactory,
+    RangedMCOParameter,
+    RangedMCOParameterFactory,
+    ListedMCOParameter,
+    ListedMCOParameterFactory,
+    CategoricalMCOParameter,
+    CategoricalMCOParameterFactory,
+)
+
+
+class TestFixedMCOParameter(TestCase):
+    def setUp(self):
+        self.parameter = FixedMCOParameter(
+            mock.Mock(spec=FixedMCOParameterFactory), value=1
+        )
+
+    def test_level(self):
+        self.assertEqual(1, self.parameter.value)
+
+    def test_sample_values(self):
+        self.assertEqual([1], self.parameter.sample_values)
+        with self.assertRaises(TraitError):
+            self.parameter.value = 1
+
+
+class TestRangedMCOParameter(TestCase):
+    def setUp(self):
+        self.parameter = RangedMCOParameter(
+            mock.Mock(spec=RangedMCOParameterFactory)
+        )
+
+    def test_default(self):
+        self.assertEqual(0.1, self.parameter.lower_bound)
+        self.assertEqual(100.0, self.parameter.upper_bound)
+        self.assertEqual(5, self.parameter.n_samples)
+
+    def test_sample_values(self):
+        for expected, actual in zip(
+            [0.1, 25.075, 50.05, 75.025, 100.0],
+            list(self.parameter.sample_values),
+        ):
+            self.assertAlmostEqual(expected, actual)
+        self.parameter.lower_bound = 90.0
+        for expected, actual in zip(
+            [90.0, 92.5, 95.0, 97.5, 100.0], list(self.parameter.sample_values)
+        ):
+            self.assertAlmostEqual(expected, actual)
+        self.parameter.n_samples = 3
+        for expected, actual in zip(
+            [90.0, 95.0, 100.0], list(self.parameter.sample_values)
+        ):
+            self.assertAlmostEqual(expected, actual)
+
+
+class TestListedMCOParameter(TestCase):
+    def setUp(self):
+        self.parameter = ListedMCOParameter(
+            mock.Mock(spec=ListedMCOParameterFactory)
+        )
+        self.filled_parameter = ListedMCOParameter(
+            mock.Mock(spec=ListedMCOParameterFactory), levels=[4, 0.0, 2]
+        )
+
+    def test_init(self):
+        self.assertListEqual([0.0], self.parameter.levels)
+        self.assertListEqual([4, 0.0, 2], self.filled_parameter.levels)
+
+    def test_sample_values(self):
+        self.assertListEqual([0.0], self.parameter.sample_values)
+        self.parameter.levels = [1, 2, 3]
+        self.assertListEqual([1, 2, 3], self.parameter.sample_values)
+
+        self.assertListEqual([0.0, 2, 4], self.filled_parameter.sample_values)
+
+
+class TestCategoricalMCOParameter(TestCase):
+    def setUp(self):
+        self.default_categories = ["chemical1", "chemical2"]
+        self.parameter = CategoricalMCOParameter(
+            mock.Mock(spec=CategoricalMCOParameterFactory),
+            categories=self.default_categories,
+        )
+
+    def test_default(self):
+        self.assertListEqual(
+            self.default_categories, self.parameter.categories
+        )
+
+    def test_sample_values(self):
+        self.assertListEqual(
+            self.default_categories, self.parameter.sample_values
+        )
+        self.parameter.categories.append("new_chemical")
+        self.assertListEqual(
+            self.default_categories + ["new_chemical"],
+            self.parameter.sample_values,
+        )

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -2,6 +2,7 @@ from unittest import TestCase, mock
 
 from traits.api import TraitError
 
+from force_bdss.mco.base_mco_factory import BaseMCOFactory
 from force_bdss.mco.parameters.mco_parameters import (
     FixedMCOParameter,
     FixedMCOParameterFactory,
@@ -16,9 +17,14 @@ from force_bdss.mco.parameters.mco_parameters import (
 
 class TestFixedMCOParameter(TestCase):
     def setUp(self):
-        self.parameter = FixedMCOParameter(
-            mock.Mock(spec=FixedMCOParameterFactory), value=1
+        self.mco_factory = mock.Mock(
+            spec=BaseMCOFactory,
+            plugin_id="pid",
+            plugin_name="Plugin",
+            id="mcoid",
         )
+        self.factory = FixedMCOParameterFactory(self.mco_factory)
+        self.parameter = FixedMCOParameter(self.factory, value=1)
 
     def test_level(self):
         self.assertEqual(1, self.parameter.value)
@@ -28,12 +34,25 @@ class TestFixedMCOParameter(TestCase):
         with self.assertRaises(TraitError):
             self.parameter.value = 1
 
+    def test_factory(self):
+        self.assertEqual("fixed", self.factory.get_identifier())
+        self.assertEqual("Fixed", self.factory.get_name())
+        self.assertEqual(
+            "A parameter with a fixed ReadOnly value.",
+            self.factory.get_description(),
+        )
+
 
 class TestRangedMCOParameter(TestCase):
     def setUp(self):
-        self.parameter = RangedMCOParameter(
-            mock.Mock(spec=RangedMCOParameterFactory)
+        self.mco_factory = mock.Mock(
+            spec=BaseMCOFactory,
+            plugin_id="pid",
+            plugin_name="Plugin",
+            id="mcoid",
         )
+        self.factory = RangedMCOParameterFactory(self.mco_factory)
+        self.parameter = RangedMCOParameter(self.factory)
 
     def test_default(self):
         self.assertEqual(0.1, self.parameter.lower_bound)
@@ -57,14 +76,27 @@ class TestRangedMCOParameter(TestCase):
         ):
             self.assertAlmostEqual(expected, actual)
 
+    def test_factory(self):
+        self.assertEqual("ranged", self.factory.get_identifier())
+        self.assertEqual("Ranged", self.factory.get_name())
+        self.assertEqual(
+            "A parameter with a ranged level in floating point values.",
+            self.factory.get_description(),
+        )
+
 
 class TestListedMCOParameter(TestCase):
     def setUp(self):
-        self.parameter = ListedMCOParameter(
-            mock.Mock(spec=ListedMCOParameterFactory)
+        self.mco_factory = mock.Mock(
+            spec=BaseMCOFactory,
+            plugin_id="pid",
+            plugin_name="Plugin",
+            id="mcoid",
         )
+        self.factory = ListedMCOParameterFactory(self.mco_factory)
+        self.parameter = ListedMCOParameter(self.factory)
         self.filled_parameter = ListedMCOParameter(
-            mock.Mock(spec=ListedMCOParameterFactory), levels=[4, 0.0, 2]
+            self.factory, levels=[4, 0.0, 2]
         )
 
     def test_init(self):
@@ -78,13 +110,28 @@ class TestListedMCOParameter(TestCase):
 
         self.assertListEqual([0.0, 2, 4], self.filled_parameter.sample_values)
 
+    def test_factory(self):
+        self.assertEqual("listed", self.factory.get_identifier())
+        self.assertEqual("Listed", self.factory.get_name())
+        self.assertEqual(
+            "A parameter with a listed set of levels"
+            " in floating point values.",
+            self.factory.get_description(),
+        )
+
 
 class TestCategoricalMCOParameter(TestCase):
     def setUp(self):
+        self.mco_factory = mock.Mock(
+            spec=BaseMCOFactory,
+            plugin_id="pid",
+            plugin_name="Plugin",
+            id="mcoid",
+        )
+        self.factory = CategoricalMCOParameterFactory(self.mco_factory)
         self.default_categories = ["chemical1", "chemical2"]
         self.parameter = CategoricalMCOParameter(
-            mock.Mock(spec=CategoricalMCOParameterFactory),
-            categories=self.default_categories,
+            self.factory, categories=self.default_categories
         )
 
     def test_default(self):
@@ -100,4 +147,12 @@ class TestCategoricalMCOParameter(TestCase):
         self.assertListEqual(
             self.default_categories + ["new_chemical"],
             self.parameter.sample_values,
+        )
+
+    def test_factory(self):
+        self.assertEqual("category", self.factory.get_identifier())
+        self.assertEqual("Categorical", self.factory.get_name())
+        self.assertEqual(
+            "A Categorical parameter defining unordered discrete objects.",
+            self.factory.get_description(),
         )


### PR DESCRIPTION
This PR approaches #240 

We introduce extension to `BaseMCOParameter`: 4 more specific (though still generic) types for `MCOParameter`s:

- `FixedMCOParameter`: constant-valued dummy parameter
- `RangedMCOParameter`: Numerical MCO parameter that continuously ranges between lower and upper floating point values
- `ListedMCOParameter`: Listed MCO parameter that has discrete numerical values
- `CategoricalMCOParameter`: implements unordered, discrete valued, categorical data. Available categorical values are strings

The purpose of the PR is to move these objects from separate example plugins into core, and maintain them as a part of `force-bdss`.

We also include necessary tests.