### PR TITLE
Base CSV Writer for MCO Events

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -109,7 +109,7 @@ def flake8(python_version):
     returncode = edm_run(env_name, ["flake8", "."])
     if returncode:
         raise click.ClickException(
-            f"Flake8 exited with exit status {returncode}"
+            "Flake8 exited with exit status {}".format(returncode)
         )
 
 

--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -48,3 +48,5 @@ from .ui_hooks.base_ui_hooks_factory import BaseUIHooksFactory  # noqa
 from .ui_hooks.base_ui_hooks_manager import BaseUIHooksManager  # noqa
 
 from .local_traits import Identifier, PositiveInt  # noqa
+
+from .io.base_csv_writer import BaseCSVWriterFactory  # noqa

--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -49,4 +49,4 @@ from .ui_hooks.base_ui_hooks_manager import BaseUIHooksManager  # noqa
 
 from .local_traits import Identifier, PositiveInt  # noqa
 
-from .io.base_csv_writer import BaseCSVWriterFactory  # noqa
+from .io.base_csv_writer import BaseCSVWriterFactory, BaseCSVWriterModel, BaseCSVWriter  # noqa

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -6,7 +6,6 @@ from traits.api import (
 
 from force_bdss.mco.i_evaluator import IEvaluator
 from force_bdss.app.workflow_evaluator import WorkflowEvaluator
-from force_bdss.core_driver_events import MCOFinishEvent, MCOStartEvent
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.notification_listeners.base_notification_listener import (
     BaseNotificationListener
@@ -58,7 +57,6 @@ class OptimizeOperation(HasStrictTraits):
             raise RuntimeError("Workflow file has errors.")
 
         self.create_mco()
-
         self._deliver_start_event()
 
         try:
@@ -101,14 +99,10 @@ class OptimizeOperation(HasStrictTraits):
         self.mco = None
 
     def _deliver_start_event(self):
-        mco_model = self.workflow.mco
-        self._deliver_event(MCOStartEvent(
-            parameter_names=list(p.name for p in mco_model.parameters),
-            kpi_names=list(kpi.name for kpi in mco_model.kpis)
-        ))
+        self._deliver_event(self.workflow.mco.create_start_event())
 
     def _deliver_finish_event(self):
-        self._deliver_event(MCOFinishEvent())
+        self._deliver_event(self.workflow.mco.create_finish_event())
 
     @on_trait_change('mco:event')
     def _deliver_event(self, event):

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -46,6 +46,17 @@ class MCOStartEvent(BaseDriverEvent):
         """ Provides serialized form of MCOStartEvent for further data storage
         (e.g. in csv format) or processing.
 
+
+        Usage example:
+        For a custom MCOStartEvent subclass, this method can be overloaded.
+        An example of a custom `serialize` method would be:
+        >>> class CustomMCOStartEvent(MCOStartEvent):
+        >>>     weights = List(Float())
+        >>>     def serialize(self):
+        >>>         custom_data = [f"{name}_weight" for name in self.kpi_names]
+        >>>         return super().serialize() + custom_data
+        >>>
+
         Returns:
             List(Unicode): event parameters names and kpi names
         """
@@ -81,6 +92,15 @@ class MCOProgressEvent(BaseDriverEvent):
 
         Warning: `weights` attribute is NOT serialized here. We expect it to be
         refactored to custom MCOProgressEvent class.
+
+        Usage example:
+        For a custom MCOProgressEvent subclass, this method can be overloaded.
+        An example of a custom `serialize` method would be:
+        >>> class CustomMCOProgressEvent(MCOProgressEvent):
+        >>>     weights = List(Float())
+        >>>     def serialize(self):
+        >>>         return super().serialize() + self.weights
+        >>>
 
         Returns:
             List(Datavalue.value): values of the event optimal points and kpis

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -25,8 +25,9 @@ class BaseDriverEvent(HasStrictTraits):
     """ Base event for the MCO driver."""
 
     def __getstate__(self):
-        """ Returns state dictionary of the object. For a nested dict, the The zero level items and
-        the first level items """
+        """ Returns state dictionary of the object. For a nested dict,
+        __getstate__ is applied to zero level items and first level items.
+        """
         state = pop_dunder_recursive(super().__getstate__())
         state = nested_getstate(state)
         return state

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -32,6 +32,15 @@ class MCOStartEvent(BaseDriverEvent):
     #: The names associated to the KPIs
     kpi_names = List(Unicode())
 
+    def serialize(self):
+        """ Provides serialized form of MCOStartEvent for further data storage
+        (e.g. in csv format) or processing.
+
+        Returns:
+            List(Unicode): event parameters names and kpi names
+        """
+        return self.parameter_names + self.kpi_names
+
 
 class MCOFinishEvent(BaseDriverEvent):
     """ The MCO driver should emit this event when the evaluation ends."""
@@ -51,3 +60,20 @@ class MCOProgressEvent(BaseDriverEvent):
 
     #: The weights assigned to the KPIs
     weights = List(Float())
+
+    def serialize(self):
+        """ Provides serialized form of MCOProgressEvent for further data storage
+        (e.g. in csv format) or processing.
+
+        Note: this code duplicates the MCOProgressEvent handler in
+        `force_wfmanager.wfmanager_setup_task._server_event_mainthread`
+        Can we refactor this?
+
+        Warning: `weights` attribute is NOT serialized here. We expect it to be
+        refactored to custom MCOProgressEvent class.
+
+        Returns:
+            List(Datavalue.value): values of the event optimal points and kpis
+        """
+        event_datavalues = self.optimal_point + self.optimal_kpis
+        return [entry.value for entry in event_datavalues]

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -30,20 +30,21 @@ class BaseCSVWriter(BaseNotificationListener):
         return []
 
     def parse_progress_event(self, event):
-        """ Basic implementation of event to row parser.
+        """ Basic implementation of MCOProgressEvent event to row parser.
+        Extracts .value attributes from `optimal_point` and `optimal_kpi`
 
         Note: this code duplicates the MCOProgressEvent handler in
         `force_wfmanager.wfmanager_setup_task._server_event_mainthread`
         Can we refactor this?
         """
-        row = [dv.value for dv in event.optimal_point]
-        row.extend([dv.value for dv in event.optimal_kpis])
-        return row
+        event_datavalues = event.optimal_point + event.optimal_kpis
+        return [entry.value for entry in event_datavalues]
 
     def parse_start_event(self, event):
-        header = list(event.parameter_names)
-        header.extend(list(event.kpi_names))
-        return header
+        """ Basic implementation of MCOStartEvent event to row parser.
+        Merges the parameters' and kpis' names
+        """
+        return event.parameter_names + event.kpi_names
 
     def write_to_file(self, data, *, mode):
         with open(self.model.path, mode) as f:

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -66,8 +66,8 @@ class BaseCSVWriter(BaseNotificationListener):
             # file, therefore the current row is finished and no additional
             # data will be accepted after this event.
             progress_data = self.parse_progress_event(event)
-            for i, column_name in enumerate(self.header):
-                self.row_data[column_name] = progress_data[i]
+            for column, value in zip(self.header, progress_data):
+                self.row_data[column] = value
             self.write_to_file(
                 [self.row_data[el] for el in self.header], mode="a"
             )

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -68,7 +68,9 @@ class BaseCSVWriter(BaseNotificationListener):
             progress_data = self.parse_progress_event(event)
             for i, column_name in enumerate(self.header):
                 self.row_data[column_name] = progress_data[i]
-            self.write_to_file(self.row_data, mode="a")
+            self.write_to_file(
+                [self.row_data[el] for el in self.header], mode="a"
+            )
             self.row_data = self._row_data_default()
 
     def initialize(self, model):

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -22,6 +22,10 @@ class BaseCSVWriter(BaseNotificationListener):
     """ Base class of core CSVWriter functionality.
     BaseCSVWriter implements basic MCOStartEvent and MCOProgressEvent
     parsers, write_to_file method, and `row_data` structure for CSV header.
+
+    Custom implementation of the existing MCOEvent parsers should consider
+    overloading only the `parse_event` adapter methods, and leave the
+    `deliver` method as it is.
     """
 
     # A reference to the associated CSVWriterModel

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -30,23 +30,16 @@ class BaseCSVWriter(BaseNotificationListener):
         return dict.fromkeys(self.header)
 
     def parse_progress_event(self, event):
-        """ Basic implementation of MCOProgressEvent event to row parser.
-        Extracts .value attributes from `optimal_point` and `optimal_kpi`
+        """ Adapter to extract serialized data from the MCOProgressEvent event.
         The MCOProgressEvent event data **MUST BE ordered** in the same way
         as the MCOStartEvent data.
-
-        Note: this code duplicates the MCOProgressEvent handler in
-        `force_wfmanager.wfmanager_setup_task._server_event_mainthread`
-        Can we refactor this?
         """
-        event_datavalues = event.optimal_point + event.optimal_kpis
-        return [entry.value for entry in event_datavalues]
+        return event.serialize()
 
     def parse_start_event(self, event):
-        """ Basic implementation of MCOStartEvent event to row parser.
-        Merges the parameters' and kpis' names
+        """ Adapter to extract data from the MCOStartEvent event.
         """
-        return event.parameter_names + event.kpi_names
+        return event.serialize()
 
     def write_to_file(self, data, *, mode):
         with open(self.model.path, mode) as f:

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -12,10 +12,17 @@ from force_bdss.api import (
 
 
 class BaseCSVWriterModel(BaseNotificationListenerModel):
+    """ Base Model class for CSV writer."""
+
+    #: CSV file path for data storage and output
     path = Unicode("output.csv")
 
 
 class BaseCSVWriter(BaseNotificationListener):
+    """ Base class of core CSVWriter functionality.
+    BaseCSVWriter implements basic MCOStartEvent and MCOProgressEvent
+    parsers, write_to_file method, and `row_data` structure for CSV header.
+    """
 
     # A reference to the associated CSVWriterModel
     model = Instance(BaseCSVWriterModel)

--- a/force_bdss/io/base_csv_writer.py
+++ b/force_bdss/io/base_csv_writer.py
@@ -1,0 +1,64 @@
+import csv
+
+from traits.api import Unicode, Instance
+
+from force_bdss.api import (
+    BaseNotificationListenerFactory,
+    BaseNotificationListenerModel,
+    BaseNotificationListener,
+    MCOProgressEvent,
+    MCOStartEvent,
+)
+
+
+class BaseCSVWriterModel(BaseNotificationListenerModel):
+    path = Unicode("output.csv")
+
+
+class BaseCSVWriter(BaseNotificationListener):
+    model = Instance(BaseCSVWriterModel)
+
+    def parse_progress_event(self, event):
+        """ Basic implementation of event to row parser.
+
+        Note: this code duplicates the MCOProgressEvent handler in
+        `force_wfmanager.wfmanager_setup_task._server_event_mainthread`
+        Can we refactor this?
+        """
+        row = ["%.10f" % dv.value for dv in event.optimal_point]
+        row.extend([dv.value for dv in event.optimal_kpis])
+        return row
+
+    def parse_start_event(self, event):
+        value_names = list(event.parameter_names)
+        value_names.extend(list(event.kpi_names))
+        return value_names
+
+    def write_to_file(self, data, *, mode):
+        with open(self.model.path, mode) as f:
+            writer = csv.writer(f)
+            writer.writerow(data)
+
+    def deliver(self, event):
+        if isinstance(event, MCOStartEvent):
+            self.write_to_file(self.parse_start_event(event), mode="w")
+        elif isinstance(event, MCOProgressEvent):
+            self.write_to_file(self.parse_progress_event(event), mode="a")
+
+    def initialize(self, model):
+        """ Assign `model` to the writer."""
+        self.model = model
+
+
+class BaseCSVWriterFactory(BaseNotificationListenerFactory):
+    def get_identifier(self):
+        return "base_csv_writer"
+
+    def get_name(self):
+        return "Base CSV Writer"
+
+    def get_model_class(self):
+        return BaseCSVWriterModel
+
+    def get_listener_class(self):
+        return BaseCSVWriter

--- a/force_bdss/io/tests/test_base_csv_writer.py
+++ b/force_bdss/io/tests/test_base_csv_writer.py
@@ -1,0 +1,88 @@
+from unittest import TestCase, mock
+
+from traits.testing.unittest_tools import UnittestTools
+
+from force_bdss.api import (
+    BaseCSVWriterFactory,
+    BaseCSVWriter,
+    BaseCSVWriterModel,
+    DataValue,
+    MCOStartEvent,
+    MCOProgressEvent,
+)
+
+_CSVWRITER_OPEN = "force_bdss.io.base_csv_writer.open"
+
+
+class TestCSVWriter(TestCase, UnittestTools):
+    def setUp(self):
+        self.plugin = {"id": "id", "name": "name"}
+        self.factory = BaseCSVWriterFactory(plugin=self.plugin)
+        self.notification_listener = self.factory.create_listener()
+        self.model = self.factory.create_model()
+
+        self.notification_listener.initialize(self.model)
+
+        self.parameters = [
+            DataValue(name="p1", value=1.0),
+            DataValue(name="p2", value=5.0),
+        ]
+        self.kpis = [
+            DataValue(name="kpi1", value=5.7),
+            DataValue(name="kpi2", value=10),
+        ]
+
+    def test_factory(self):
+        self.assertEqual("base_csv_writer", self.factory.get_identifier())
+        self.assertEqual("Base CSV Writer", self.factory.get_name())
+        self.assertIs(self.factory.listener_class, BaseCSVWriter)
+        self.assertIs(self.factory.model_class, BaseCSVWriterModel)
+
+    def test_model(self):
+        self.assertEqual("output.csv", self.model.path)
+
+    def test_writer(self):
+        self.assertEqual(self.model, self.notification_listener.model)
+
+        new_model = self.factory.create_model()
+        self.notification_listener.initialize(new_model)
+        self.assertEqual(new_model, self.notification_listener.model)
+        self.assertEqual([], self.notification_listener.row_data)
+        self.assertEqual([], self.notification_listener.header)
+
+    def test_deliver_start_event(self):
+
+        mock_open = mock.mock_open()
+
+        with mock.patch(_CSVWRITER_OPEN, mock_open, create=True):
+            event = MCOStartEvent(
+                parameter_names=[p.name for p in self.parameters],
+                kpi_names=[k.name for k in self.kpis],
+            )
+            self.assertListEqual(
+                ["p1", "p2", "kpi1", "kpi2"],
+                self.notification_listener.parse_start_event(event),
+            )
+
+            self.notification_listener.deliver(event)
+            self.assertListEqual(
+                ["p1", "p2", "kpi1", "kpi2"], self.notification_listener.header
+            )
+
+            mock_open.assert_called_once()
+
+    def test_deliver_progress_event(self):
+        mock_open = mock.mock_open()
+
+        with mock.patch(_CSVWRITER_OPEN, mock_open, create=True):
+            event = MCOProgressEvent(
+                optimal_point=self.parameters, optimal_kpis=self.kpis
+            )
+            self.assertListEqual(
+                [1.0, 5.0, 5.7, 10],
+                self.notification_listener.parse_progress_event(event),
+            )
+            self.notification_listener.deliver(event)
+            self.assertListEqual([], self.notification_listener.row_data)
+
+            mock_open.assert_called_once()

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -1,43 +1,67 @@
 import unittest
 
 from force_bdss.core.data_value import DataValue
-from force_bdss.core_driver_events import MCOProgressEvent
+from force_bdss.core_driver_events import (
+    MCOProgressEvent,
+    MCOStartEvent,
+    MCOFinishEvent,
+    BaseDriverEvent
+)
 
 
 class TestCoreDriverEvents(unittest.TestCase):
-    def test_getstate_for_progress_event(self):
-        ev = MCOProgressEvent()
-        ev.optimal_kpis = [DataValue(value=10)]
-        ev.optimal_point = [DataValue(value=12), DataValue(value=13)]
-        ev.weights = [1.0]
+    def test_getstate_progress_event(self):
+        ev = MCOProgressEvent(
+            optimal_kpis=[DataValue(value=10)],
+            optimal_point=[DataValue(value=12), DataValue(value=13)],
+            weights=[1.0],
+        )
 
-        self.maxDiff = 1000
         self.assertEqual(
             ev.__getstate__(),
             {
-                'optimal_kpis': [
+                "optimal_kpis": [
                     {
-                        'accuracy': None,
-                        'name': '',
-                        'quality': 'AVERAGE',
-                        'type': '',
-                        'value': 10
-                    }],
-                'optimal_point': [
-                   {
-                       'accuracy': None,
-                       'name': '',
-                       'quality': 'AVERAGE',
-                       'type': '',
-                       'value': 12},
-                   {
-                       'accuracy': None,
-                       'name': '',
-                       'quality': 'AVERAGE',
-                       'type': '',
-                       'value': 13
-                   }
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 10,
+                    }
                 ],
-                'weights': [1.0]
-            }
+                "optimal_point": [
+                    {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 12,
+                    },
+                    {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 13,
+                    },
+                ],
+                "weights": [1.0],
+            },
         )
+
+    def test_getstate_start_event(self):
+        event = MCOStartEvent(
+            parameter_names=["p1", "p2"], kpi_names=["k1", "k2", "k3"]
+        )
+        self.assertDictEqual(
+            event.__getstate__(),
+            {"parameter_names": ["p1", "p2"], "kpi_names": ["k1", "k2", "k3"]},
+        )
+
+    def test_getstate_finish_event(self):
+        event = MCOFinishEvent()
+        self.assertFalse(event.__getstate__())
+
+    def test_getstate_base_event(self):
+        event = BaseDriverEvent()
+        self.assertFalse(event.__getstate__())

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -87,3 +87,18 @@ class TestCoreDriverEvents(unittest.TestCase):
                 },
             },
         )
+
+    def test_serialize_start_event(self):
+        event = MCOStartEvent(
+            parameter_names=["p1", "p2"], kpi_names=["k1", "k2", "k3"]
+        )
+        self.assertListEqual(event.serialize(), ["p1", "p2", "k1", "k2", "k3"])
+
+    def test_serialize_progress_event(self):
+        event = MCOProgressEvent(
+            optimal_kpis=[DataValue(value=10)],
+            optimal_point=[DataValue(value=12), DataValue(value=13)],
+            weights=[1.0],
+        )
+
+        self.assertListEqual(event.serialize(), [12, 13, 10])

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -1,12 +1,19 @@
 import unittest
 
+from traits.api import Instance, Int
+
 from force_bdss.core.data_value import DataValue
 from force_bdss.core_driver_events import (
     MCOProgressEvent,
     MCOStartEvent,
     MCOFinishEvent,
-    BaseDriverEvent
+    BaseDriverEvent,
 )
+
+
+class DummyEvent(BaseDriverEvent):
+    stateless_data = Int(1)
+    stateful_data = Instance(DataValue)
 
 
 class TestCoreDriverEvents(unittest.TestCase):
@@ -65,3 +72,18 @@ class TestCoreDriverEvents(unittest.TestCase):
     def test_getstate_base_event(self):
         event = BaseDriverEvent()
         self.assertFalse(event.__getstate__())
+
+        event = DummyEvent(stateful_data=DataValue(value=1))
+        self.assertDictEqual(
+            event.__getstate__(),
+            {
+                "stateless_data": 1,
+                "stateful_data": {
+                    "accuracy": None,
+                    "name": "",
+                    "quality": "AVERAGE",
+                    "type": "",
+                    "value": 1,
+                },
+            },
+        )


### PR DESCRIPTION
This PR approaches [this issue](https://github.com/force-h2020/force-bdss-plugin-itwm-example/issues/60) and attempts to generalise the `CSVWriter` functionality

### Summary

`CSVWriter` is a notification listener that logs the MCO data during runtime, in `.csv` format.

### Done
- Refactored `BaseDriverEvent.__getstate__`: now, any `trait` and `List(trait)` objects will be automatically parsed by the base class using `nested_getstate` method. **This breaks backwards compatibility**: child classes no longer need to implement `__getstate__` for simple traits and lists of traits.
- Created methods to generate `MCOStartEvent` and `MCOFinishEvent` instances on the `BaseMCOModel` class. These methods are then referred to in `OptimizeOperation._deliver_start_event` and `OptimizeOperation._deliver_finish_event`, allowing MCO-specific driver events to be contributed by the `BaseMCOModel`.
- Implemented `BaseCSVWriter`. The `deliver` method parses incoming `event: Union(MCOStartEvent, MCOProgressEvent)` object and creates header / row data. This data is then written to file. If a specific header / row format is required, we suggest that the user implements their own `parse_start_event` and `parse_progress_event`, or extends them with additional logic.
- Developed dict-style design for `row_data`. Now, when a header is created with `MCOStartEvent`, a new `row_data` dictionary is instantiated, with no data. Data coming from `MCOProgressEvent` is assigned to `row_data` entries such that the first data value from the event corresponds to the first header value, and so on. This means that the `MCOProgressEvent` will fill out the first available `header` slots.

### Possible ToDos

- (see #247) Now the `MCOModel` is responsible for creating (custom) `MCOStart` and `MCOFinish` events. It seems reasonable to
-- Implement `MCOModel.create_progress_event` method which handles the optimal points / optimal KPIs broadcasting, and
-- Refactor the `BaseMCO.notify_new_point` and `BaseMCO.notify` to `BaseMCOModel`. Then it would be much easier to broadcast the progress events since the model is responsible for their initialisation.