### PR TITLE
WIP: DEV: Standard IO MCOCommunicator

### DIFF
--- a/force_bdss/mco/stdio_mco_communicator.py
+++ b/force_bdss/mco/stdio_mco_communicator.py
@@ -1,0 +1,54 @@
+import sys
+
+from force_bdss.api import BaseMCOCommunicator, DataValue
+
+
+class StdIOMCOCommunicator(BaseMCOCommunicator):
+    """ The StdIOMCOCommunicator is responsible for handing the communication
+    protocol between the MCO executable (for example, the dakota executable) and
+    the single point evaluation (our BDSS in --evaluate mode).
+
+    The StdIOMCOCommunicator implements the communication using stdin and stdout.
+    """
+
+    def receive_from_mco(self, model):
+        """Receives data from the MCO (e.g. dakota) by reading from
+        standard input the sequence of numbers that are this execution's
+        parameter values.
+
+        You can use fancier communication systems here if your MCO supports
+        them.
+        """
+        data = sys.stdin.read()
+        values = list(map(float, data.split()))
+        names = [p.name for p in model.parameters]
+        types = [p.type for p in model.parameters]
+
+        # The values must be given a type. The MCO may pass raw numbers
+        # with no type information. You are free to use metadata your MCO may
+        # provide, but it is not mandatory that this data is available. You
+        # can also use the model specification itself.
+        # In any case, you must return a list of DataValue objects.
+        return [
+            DataValue(type=_type, name=name, value=value)
+            for _type, name, value in zip(types, names, values)
+        ]
+
+    def send_to_mco(self, model, data_values):
+        """ Sends the data_values.values to stdout via string format. Once the
+        single point evaluation is completed, this method is used to send the
+        data back to the MCO via stdout.
+
+        Parameters
+        ----------
+        model: any
+        data_values: List[DataValue]
+            List of DataValues to send to stdout
+
+        Stdout
+        ----------
+        data: str
+            A string of DataValue.values separated by " "..
+        """
+        data = " ".join([str(dv.value) for dv in data_values])
+        sys.stdout.write(data)

--- a/force_bdss/mco/tests/test_stdio_mco_communicator.py
+++ b/force_bdss/mco/tests/test_stdio_mco_communicator.py
@@ -1,0 +1,50 @@
+from io import StringIO
+from unittest import TestCase, mock
+
+from force_bdss.api import DataValue
+from force_bdss.mco.i_mco_factory import IMCOFactory
+from force_bdss.mco.stdio_mco_communicator import StdIOMCOCommunicator
+
+
+class DummyModel:
+    pass
+
+
+class DummyParameter:
+    pass
+
+
+class TestStdIOMCOCommunicator(TestCase):
+    def setUp(self):
+        self.factory = mock.Mock(spec=IMCOFactory)
+        self.communicator = StdIOMCOCommunicator(self.factory)
+
+    def test_initialize(self):
+        self.assertIs(self.communicator.factory, self.factory)
+
+    def test_receive_from_mco(self):
+        model = DummyModel()
+        parameters = [DummyParameter(), DummyParameter(), DummyParameter()]
+        for parameter in parameters:
+            parameter.name = "name"
+            parameter.type = "type"
+        model.parameters = parameters
+
+        values = "1 2 3"
+        with mock.patch("sys.stdin.read", return_value=values):
+            output = self.communicator.receive_from_mco(model)
+        self.assertEqual(3, len(output))
+        for i, data in enumerate(output):
+            self.assertIsInstance(data, DataValue)
+            self.assertEqual("name", data.name)
+            self.assertEqual("type", data.type)
+            self.assertEqual(i + 1, data.value)
+
+    def test_send_to_mco(self):
+        parameters = [DummyParameter(), DummyParameter(), DummyParameter()]
+        for i, parameter in enumerate(parameters):
+            parameter.value = i
+
+        with mock.patch("sys.stdout", new=StringIO()) as patched_stdout:
+            self.communicator.send_to_mco(None, parameters)
+            self.assertEqual(patched_stdout.getvalue().strip(), "0 1 2")


### PR DESCRIPTION
This PR approaches #249 

We implement the `stdin`/`stdout` MCOCommunicator to the core BDSS.

The ITWM and other plugins now can import this implementation instead of copying the `MCOCommunicator` code.