### PR TITLE
BUG: fixed FixedMCOParameter UI setup bug. Changed the type to Any

### DIFF
--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from traits.api import List, Unicode, Property, Float, ReadOnly, Int, Either
+from traits.api import List, Unicode, Property, Float, Any, Int, Either
 from traitsui.api import ListEditor
 
 from .base_mco_parameter import BaseMCOParameter
@@ -12,7 +12,7 @@ class FixedMCOParameter(BaseMCOParameter):
     must be specified before use: the value is <undefined> by default."""
 
     #: Fixed parameter value
-    value = ReadOnly
+    value = Any
 
     sample_values = Property(depends_on="value", visible=False)
 

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -1,7 +1,5 @@
 from unittest import TestCase, mock
 
-from traits.api import TraitError
-
 from force_bdss.mco.base_mco_factory import BaseMCOFactory
 from force_bdss.mco.parameters.mco_parameters import (
     FixedMCOParameter,
@@ -31,8 +29,8 @@ class TestFixedMCOParameter(TestCase):
 
     def test_sample_values(self):
         self.assertEqual([1], self.parameter.sample_values)
-        with self.assertRaises(TraitError):
-            self.parameter.value = 1
+        self.parameter.value = "something different"
+        self.assertEqual(["something different"], self.parameter.sample_values)
 
     def test_factory(self):
         self.assertEqual("fixed", self.factory.get_identifier())


### PR DESCRIPTION
This PR fixed #252 

We change the type of `FixedMCOParameter.value` attribute to `Any` instead of `ReadOnly`. This fixes the UI bug which didn't allow the user to set the parameter value to anything longer than 1 character.

Further suggestion would be to introduce a control attribute to make `FixedMCOParameter.value` read-only whenever it might be necessary.