### PR TITLE
BUG: creating ListedMCOParameter via UI

### DIFF
--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from traits.api import List, Unicode, Property, Float, ReadOnly, Int, Either
+from traits.api import List, Unicode, Property, Float, ReadOnly, Int
 from traitsui.api import ListEditor
 
 from .base_mco_parameter import BaseMCOParameter
@@ -89,7 +89,7 @@ class ListedMCOParameter(BaseMCOParameter):
     """ Listed MCO parameter that has discrete numerical values."""
 
     #: Discrete set of available numerical values
-    levels = List(Either(Int, Float), value=[0.0])
+    levels = List(Float, value=[0.0])
 
     sample_values = Property(depends_on="levels", visible=False)
 


### PR DESCRIPTION
This PR approaches #254 

We fix the bug that appears in workflow manager, when a new `ListedMCOParameter` is created. Apparently, there is a undocumented behaviour of the `List(Either())` trait.

Now, instead of using `Either(Int, Float)` we use just `Float`. This does not affect any logic of the BDSS or plugins, and fixes the `ListedMCOParameter` instantiation via the workflow manager UI.