### PR TITLE
Renamed the Workflow.mco to Workflow.mco_model

### DIFF
--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -23,7 +23,7 @@ class EvaluateOperation(HasStrictTraits):
 
     def run(self):
         """ Evaluate the workflow. """
-        mco_model = self.workflow.mco
+        mco_model = self.workflow.mco_model
         if mco_model is None:
             log.info("No MCO defined. Nothing to do. Exiting.")
             return

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -1,14 +1,19 @@
 import logging
 
 from traits.api import (
-    DelegatesTo, HasStrictTraits, Instance, List, on_trait_change, provides
+    DelegatesTo,
+    HasStrictTraits,
+    Instance,
+    List,
+    on_trait_change,
+    provides,
 )
 
 from force_bdss.mco.i_evaluator import IEvaluator
 from force_bdss.app.workflow_evaluator import WorkflowEvaluator
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.notification_listeners.base_notification_listener import (
-    BaseNotificationListener
+    BaseNotificationListener,
 )
 from .i_operation import IOperation
 from .workflow_file import WorkflowFile
@@ -28,7 +33,7 @@ class OptimizeOperation(HasStrictTraits):
     workflow_file = Instance(WorkflowFile)
 
     #: The workflow instance.
-    workflow = DelegatesTo('workflow_file')
+    workflow = DelegatesTo("workflow_file")
 
     #: The mco instance.
     mco = Instance(BaseMCO)
@@ -41,17 +46,14 @@ class OptimizeOperation(HasStrictTraits):
 
     def _solver_default(self):
         return WorkflowEvaluator(
-            workflow=self.workflow,
-            workflow_filepath=self.workflow_file.path,
+            workflow=self.workflow, workflow_filepath=self.workflow_file.path
         )
 
     def run(self):
         """ Create and run the optimizer. """
         self.workflow_file.verify()
         if len(self.workflow_file.errors) != 0:
-            log.error(
-                "Unable to execute workflow due to verification errors:"
-            )
+            log.error("Unable to execute workflow due to verification errors:")
             for error in self.workflow_file.errors:
                 log.error(error.local_error)
             raise RuntimeError("Workflow file has errors.")
@@ -62,13 +64,12 @@ class OptimizeOperation(HasStrictTraits):
         try:
             self.mco.run(self.solver)
         except Exception:
-            log.exception((
-                "Method run() of MCO with id '{}' from plugin '{}' "
-                "raised exception. This might indicate a "
-                "programming error in the plugin.").format(
-                    self.mco.factory.id,
-                    self.mco.factory.plugin_id
-                )
+            log.exception(
+                (
+                    "Method run() of MCO with id '{}' from plugin '{}' "
+                    "raised exception. This might indicate a "
+                    "programming error in the plugin."
+                ).format(self.mco.factory.id, self.mco.factory.plugin_id)
             )
             raise
         finally:
@@ -77,18 +78,17 @@ class OptimizeOperation(HasStrictTraits):
 
     def create_mco(self):
         """ Create the MCO from the model's factory. """
-        mco_factory = self.workflow.mco.factory
+        mco_factory = self.workflow.mco_model.factory
         try:
             self.mco = mco_factory.create_optimizer()
         except Exception:
-            log.exception((
-                "Unable to instantiate optimizer for mco '{}' in "
-                "plugin '{}'. An exception was raised. "
-                "This might indicate a programming error in the "
-                "plugin.").format(
-                    mco_factory.id,
-                    mco_factory.plugin_id
-                )
+            log.exception(
+                (
+                    "Unable to instantiate optimizer for mco '{}' in "
+                    "plugin '{}'. An exception was raised. "
+                    "This might indicate a programming error in the "
+                    "plugin."
+                ).format(mco_factory.id, mco_factory.plugin_id)
             )
             raise
 
@@ -99,24 +99,24 @@ class OptimizeOperation(HasStrictTraits):
         self.mco = None
 
     def _deliver_start_event(self):
-        self._deliver_event(self.workflow.mco.create_start_event())
+        self._deliver_event(self.workflow.mco_model.create_start_event())
 
     def _deliver_finish_event(self):
-        self._deliver_event(self.workflow.mco.create_finish_event())
+        self._deliver_event(self.workflow.mco_model.create_finish_event())
 
-    @on_trait_change('mco:event')
+    @on_trait_change("mco:event")
     def _deliver_event(self, event):
         """ Delivers an event to the listeners """
         for listener in self.listeners[:]:
             try:
                 listener.deliver(event)
             except Exception:
-                log.exception((
-                    "Exception while delivering to listener "
-                    "'{}' in plugin '{}'. The listener will be dropped and "
-                    "computation will continue.").format(
-                        listener.factory.id,
-                        listener.factory.plugin_id
+                log.exception(
+                    (
+                        f"Exception while delivering to listener "
+                        f"'{listener.factory.id}' in plugin "
+                        f"'{listener.factory.plugin_id}'. The listener will "
+                        f"be dropped and computation will continue."
                     )
                 )
                 self._finalize_listener(listener)
@@ -130,12 +130,11 @@ class OptimizeOperation(HasStrictTraits):
         try:
             listener.finalize()
         except Exception:
-            log.exception((
-                "Exception while finalizing listener '{}'"
-                " in plugin '{}'.").format(
-                    listener.factory.id,
-                    listener.factory.plugin_id
-                )
+            log.exception(
+                (
+                    "Exception while finalizing listener '{}'"
+                    " in plugin '{}'."
+                ).format(listener.factory.id, listener.factory.plugin_id)
             )
 
     def _initialize_listeners(self):
@@ -146,12 +145,12 @@ class OptimizeOperation(HasStrictTraits):
             try:
                 listener = factory.create_listener()
             except Exception:
-                log.exception((
-                    "Failed to create listener with id '{}' in plugin '{}'. "
-                    "This may indicate a programming error in the "
-                    "plugin.").format(
-                        factory.id,
-                        factory.plugin_id
+                log.exception(
+                    (
+                        f"Failed to create listener with id '{factory.id}' "
+                        f"in plugin '{factory.plugin_id}'. "
+                        "This may indicate a programming error in the "
+                        "plugin."
                     )
                 )
                 raise
@@ -159,12 +158,11 @@ class OptimizeOperation(HasStrictTraits):
             try:
                 listener.initialize(nl_model)
             except Exception:
-                log.exception((
-                    "Failed to initialize listener with id '{}' in "
-                    "plugin '{}'. The listener will be dropped.").format(
-                        factory.id,
-                        factory.plugin_id
-                    )
+                log.exception(
+                    (
+                        "Failed to initialize listener with id '{}' in "
+                        "plugin '{}'. The listener will be dropped."
+                    ).format(factory.id, factory.plugin_id)
                 )
                 continue
 

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -66,7 +66,7 @@ class TestEvaluateOperation(TestCase):
 
     def test_run_missing_mco(self):
         # Test for missing MCO
-        self.operation.workflow.mco = None
+        self.operation.workflow.mco_model = None
         with testfixtures.LogCapture() as capture:
             self.operation.run()
             capture.check(
@@ -97,7 +97,7 @@ class TestEvaluateOperation(TestCase):
     def test_error_for_non_matching_mco_parameters(self):
         # Test for missing MCO parameter
         factory = self.registry.mco_factories[0]
-        self.operation.workflow.mco = factory.create_model()
+        self.operation.workflow.mco_model = factory.create_model()
 
         with testfixtures.LogCapture():
             with self.assertRaisesRegex(

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -53,7 +53,7 @@ class TestOptimizeOperation(TestCase):
 
     def test_run_missing_mco(self):
         # Test for missing MCO
-        self.operation.workflow.mco = None
+        self.operation.workflow.mco_model = None
         with testfixtures.LogCapture() as capture:
             with self.assertRaisesRegex(
                     RuntimeError,

--- a/force_bdss/app/tests/test_workflow_evaluator.py
+++ b/force_bdss/app/tests/test_workflow_evaluator.py
@@ -1,39 +1,34 @@
 from unittest import TestCase
 
 from force_bdss.tests import fixtures
-from force_bdss.tests.probe_classes.workflow_file import (
-    ProbeWorkflowFile
-)
+from force_bdss.tests.probe_classes.workflow_file import ProbeWorkflowFile
 
 from force_bdss.core.workflow import Workflow
 from force_bdss.app.workflow_evaluator import WorkflowEvaluator
 
 
 class TestWorkflowEvaluator(TestCase):
-
     def setUp(self):
         file_path = "test_probe.json"
-        workflow_file = ProbeWorkflowFile(
-            path=fixtures.get("test_probe.json")
-        )
+        workflow_file = ProbeWorkflowFile(path=fixtures.get("test_probe.json"))
         workflow_file.read()
         self.evaluator = WorkflowEvaluator(
-            workflow=workflow_file.workflow,
-            workflow_filepath=file_path
+            workflow=workflow_file.workflow, workflow_filepath=file_path
         )
 
     def test_empty_init(self):
 
         evaluator = WorkflowEvaluator()
         self.assertIsNone(evaluator.workflow)
-        self.assertEqual('', evaluator.workflow_filepath)
+        self.assertEqual("", evaluator.workflow_filepath)
 
     def test_init(self):
 
         self.assertIsInstance(self.evaluator.workflow, Workflow)
         self.assertEqual("test_probe.json", self.evaluator.workflow_filepath)
-        self.assertEqual(self.evaluator.workflow.mco,
-                         self.evaluator.mco_model)
+        self.assertEqual(
+            self.evaluator.workflow.mco_model, self.evaluator.mco_model
+        )
 
     def test__internal_evaluate(self):
 

--- a/force_bdss/app/workflow_evaluator.py
+++ b/force_bdss/app/workflow_evaluator.py
@@ -1,8 +1,11 @@
 import logging
 
 from traits.api import (
-    HasStrictTraits, Instance, Unicode, provides,
-    DelegatesTo
+    HasStrictTraits,
+    Instance,
+    Unicode,
+    provides,
+    DelegatesTo,
 )
 
 from force_bdss.core.data_value import DataValue
@@ -22,7 +25,7 @@ class WorkflowEvaluator(HasStrictTraits):
     workflow = Instance(Workflow)
 
     #: A reference to the mco model of the workflow instance.
-    mco_model = DelegatesTo('workflow', prefix='mco')
+    mco_model = DelegatesTo("workflow", prefix="mco_model")
 
     #: The path to the workflow file.
     workflow_filepath = Unicode()
@@ -32,11 +35,11 @@ class WorkflowEvaluator(HasStrictTraits):
         running on the internal process"""
 
         data_values = [
-            DataValue(type=parameter.type,
-                      name=parameter.name,
-                      value=value)
+            DataValue(type=parameter.type, name=parameter.name, value=value)
             for parameter, value in zip(
-                self.mco_model.parameters, parameter_values)]
+                self.mco_model.parameters, parameter_values
+            )
+        ]
 
         kpi_results = self.workflow.execute(data_values)
 

--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -27,58 +27,58 @@ class TestVerifier(unittest.TestCase):
 
     def test_no_mco_parameters(self):
         wf = self.workflow
-        wf.mco = self.plugin.mco_factories[0].create_model()
+        wf.mco_model = self.plugin.mco_factories[0].create_model()
 
         errors = verify_workflow(wf)
         self.assertEqual(len(errors), 3)
-        self.assertEqual(errors[0].subject, wf.mco)
+        self.assertEqual(errors[0].subject, wf.mco_model)
         self.assertIn("no defined parameters", errors[0].local_error)
 
     def test_no_mco_kpis(self):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
-        wf.mco = mco_factory.create_model()
+        wf.mco_model = mco_factory.create_model()
 
         errors = verify_workflow(wf)
         self.assertEqual(len(errors), 3)
-        self.assertEqual(errors[0].subject, wf.mco)
+        self.assertEqual(errors[0].subject, wf.mco_model)
         self.assertIn("no defined KPIs", errors[1].local_error)
 
     def test_empty_parameter_options(self):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
-        wf.mco = mco_factory.create_model()
+        wf.mco_model = mco_factory.create_model()
         parameter_factory = mco_factory.parameter_factories[0]
-        wf.mco.parameters.append(parameter_factory.create_model())
+        wf.mco_model.parameters.append(parameter_factory.create_model())
 
         errors = verify_workflow(wf)
         self.assertEqual(len(errors), 4)
-        self.assertEqual(errors[1].subject, wf.mco.parameters[0])
+        self.assertEqual(errors[1].subject, wf.mco_model.parameters[0])
         self.assertIn("MCO parameter is not named", errors[1].local_error)
-        self.assertEqual(errors[1].subject, wf.mco.parameters[0])
+        self.assertEqual(errors[1].subject, wf.mco_model.parameters[0])
         self.assertIn("MCO parameter has no type set", errors[2].local_error)
 
     def test_empty_kpi_options(self):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
-        wf.mco = mco_factory.create_model()
+        wf.mco_model = mco_factory.create_model()
         kpi = KPISpecification(name='')
-        wf.mco.kpis.append(kpi)
+        wf.mco_model.kpis.append(kpi)
 
         errors = verify_workflow(wf)
         self.assertEqual(len(errors), 3)
-        self.assertEqual(errors[1].subject, wf.mco.kpis[0])
+        self.assertEqual(errors[1].subject, wf.mco_model.kpis[0])
         self.assertIn("KPI is not named", errors[1].local_error)
 
     def test_empty_execution_layer(self):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
-        wf.mco = mco_factory.create_model()
+        wf.mco_model = mco_factory.create_model()
         parameter_factory = mco_factory.parameter_factories[0]
-        wf.mco.parameters.append(parameter_factory.create_model())
-        wf.mco.parameters[0].name = "name"
-        wf.mco.parameters[0].type = "type"
-        wf.mco.kpis.append(KPISpecification(name='name'))
+        wf.mco_model.parameters.append(parameter_factory.create_model())
+        wf.mco_model.parameters[0].name = "name"
+        wf.mco_model.parameters[0].type = "type"
+        wf.mco_model.kpis.append(KPISpecification(name='name'))
 
         layer = ExecutionLayer()
         wf.execution_layers.append(layer)
@@ -90,12 +90,12 @@ class TestVerifier(unittest.TestCase):
     def test_data_sources(self):
         wf = self.workflow
         mco_factory = self.plugin.mco_factories[0]
-        wf.mco = mco_factory.create_model()
+        wf.mco_model = mco_factory.create_model()
         parameter_factory = mco_factory.parameter_factories[0]
-        wf.mco.parameters.append(parameter_factory.create_model())
-        wf.mco.parameters[0].name = "name"
-        wf.mco.parameters[0].type = "type"
-        wf.mco.kpis.append(KPISpecification(name='name'))
+        wf.mco_model.parameters.append(parameter_factory.create_model())
+        wf.mco_model.parameters[0].name = "name"
+        wf.mco_model.parameters[0].type = "type"
+        wf.mco_model.kpis.append(KPISpecification(name='name'))
 
         layer = ExecutionLayer()
         wf.execution_layers.append(layer)

--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -34,21 +34,6 @@ class TestWorkflow(unittest.TestCase, UnittestTools):
         self.registry = ProbeFactoryRegistry()
         self.plugin = self.registry.plugin
 
-    def test_public_mco_model(self):
-        mco_factory = ProbeMCOFactory(self.plugin)
-        mco_model = mco_factory.create_model()
-        wf = Workflow(mco_model=mco_model, execution_layers=[])
-
-        with testfixtures.LogCapture() as capture:
-            self.assertIs(wf.mco_model, wf._mco_model)
-            capture.check()
-
-        with testfixtures.LogCapture() as capture:
-            with self.assertTraitChanges(wf, "_mco_model"):
-                new_model = mco_factory.create_model()
-                wf.mco_model = new_model
-                capture.check()
-
     def test_multilayer_execution(self):
         # The multilayer peforms the following execution
         # layer 0: in1 + in2   | in3 + in4

--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -8,15 +8,13 @@ from force_bdss.tests.probe_classes.data_source import ProbeDataSourceFactory
 
 from force_bdss.core.input_slot_info import InputSlotInfo
 from force_bdss.core.data_value import DataValue
-from force_bdss.tests.probe_classes.factory_registry import \
-    ProbeFactoryRegistry
-from force_bdss.tests.probe_classes.mco import (
-    ProbeMCOFactory
+from force_bdss.tests.probe_classes.factory_registry import (
+    ProbeFactoryRegistry,
 )
+from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
 
 
 class TestWorkflow(unittest.TestCase):
-
     def setUp(self):
         self.registry = ProbeFactoryRegistry()
         self.plugin = self.registry.plugin
@@ -38,7 +36,7 @@ class TestWorkflow(unittest.TestCase):
             DataValue(value=10, name="in1"),
             DataValue(value=15, name="in2"),
             DataValue(value=3, name="in3"),
-            DataValue(value=7, name="in4")
+            DataValue(value=7, name="in4"),
         ]
 
         def adder(model, parameters):
@@ -51,7 +49,8 @@ class TestWorkflow(unittest.TestCase):
             self.plugin,
             input_slots_size=2,
             output_slots_size=1,
-            run_function=adder)
+            run_function=adder,
+        )
 
         def multiplier(model, parameters):
             first = parameters[0].value
@@ -62,83 +61,72 @@ class TestWorkflow(unittest.TestCase):
             self.plugin,
             input_slots_size=2,
             output_slots_size=1,
-            run_function=multiplier)
+            run_function=multiplier,
+        )
 
         mco_factory = ProbeMCOFactory(self.plugin)
         mco_model = mco_factory.create_model()
         parameter_factory = mco_factory.parameter_factories[0]
 
         mco_model.parameters = [
-            parameter_factory.create_model({'name': "in1"}),
-            parameter_factory.create_model({'name': "in2"}),
-            parameter_factory.create_model({'name': "in3"}),
-            parameter_factory.create_model({'name': "in4"})
+            parameter_factory.create_model({"name": "in1"}),
+            parameter_factory.create_model({"name": "in2"}),
+            parameter_factory.create_model({"name": "in3"}),
+            parameter_factory.create_model({"name": "in4"}),
         ]
-        mco_model.kpis = [
-            KPISpecification(name="out1")
-        ]
+        mco_model.kpis = [KPISpecification(name="out1")]
 
         wf = Workflow(
-            mco=mco_model,
+            mco_model=mco_model,
             execution_layers=[
                 ExecutionLayer(),
                 ExecutionLayer(),
                 ExecutionLayer(),
-                ExecutionLayer()
-            ]
+                ExecutionLayer(),
+            ],
         )
         # Layer 0
         model = adder_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="in1"),
-            InputSlotInfo(name="in2")
+            InputSlotInfo(name="in2"),
         ]
-        model.output_slot_info = [
-            OutputSlotInfo(name="res1")
-        ]
+        model.output_slot_info = [OutputSlotInfo(name="res1")]
         wf.execution_layers[0].data_sources.append(model)
 
         model = adder_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="in3"),
-            InputSlotInfo(name="in4")
+            InputSlotInfo(name="in4"),
         ]
-        model.output_slot_info = [
-            OutputSlotInfo(name="res2")
-        ]
+        model.output_slot_info = [OutputSlotInfo(name="res2")]
         wf.execution_layers[0].data_sources.append(model)
 
         # layer 1
         model = adder_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="res1"),
-            InputSlotInfo(name="res2")
+            InputSlotInfo(name="res2"),
         ]
-        model.output_slot_info = [
-            OutputSlotInfo(name="res3")
-        ]
+        model.output_slot_info = [OutputSlotInfo(name="res3")]
         wf.execution_layers[1].data_sources.append(model)
 
         # layer 2
         model = multiplier_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="res3"),
-            InputSlotInfo(name="res1")
+            InputSlotInfo(name="res1"),
         ]
-        model.output_slot_info = [
-            OutputSlotInfo(name="res4")
-        ]
+        model.output_slot_info = [OutputSlotInfo(name="res4")]
         wf.execution_layers[2].data_sources.append(model)
 
         # layer 3
         model = multiplier_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="res4"),
-            InputSlotInfo(name="res2")
+            InputSlotInfo(name="res2"),
         ]
-        model.output_slot_info = [
-            OutputSlotInfo(name="out1")
-        ]
+        model.output_slot_info = [OutputSlotInfo(name="out1")]
         wf.execution_layers[3].data_sources.append(model)
 
         kpi_results = wf.execute(data_values)
@@ -153,7 +141,7 @@ class TestWorkflow(unittest.TestCase):
         # keep input DataValues constant
         data_values = [
             DataValue(value=99, name="in1"),
-            DataValue(value=1, name="in2")
+            DataValue(value=1, name="in2"),
         ]
 
         # dummy addition DataSource(a, b) that also returns its inputs
@@ -164,14 +152,15 @@ class TestWorkflow(unittest.TestCase):
             return [
                 DataValue(value=first),
                 DataValue(value=second),
-                DataValue(value=(first + second))
+                DataValue(value=(first + second)),
             ]
 
         adder_factory = ProbeDataSourceFactory(
             self.plugin,
             input_slots_size=2,
             output_slots_size=3,
-            run_function=adder)
+            run_function=adder,
+        )
 
         mco_factory = ProbeMCOFactory(self.plugin)
         parameter_factory = mco_factory.parameter_factories[0]
@@ -181,56 +170,50 @@ class TestWorkflow(unittest.TestCase):
         model = adder_factory.create_model()
         model.input_slot_info = [
             InputSlotInfo(name="in1"),
-            InputSlotInfo(name="in2")
+            InputSlotInfo(name="in2"),
         ]
         model.output_slot_info = [
             OutputSlotInfo(name="out1"),
             OutputSlotInfo(name="out2"),
-            OutputSlotInfo(name="out3")
+            OutputSlotInfo(name="out3"),
         ]
 
         # test Parameter and KPI spec that follows DataSource slots
         # exactly
         mco_model.parameters = [
-            parameter_factory.create_model({'name': "in1"}),
-            parameter_factory.create_model({'name': "in2"})
+            parameter_factory.create_model({"name": "in1"}),
+            parameter_factory.create_model({"name": "in2"}),
         ]
         mco_model.kpis = [
             KPISpecification(name="out1"),
             KPISpecification(name="out2"),
-            KPISpecification(name="out3")
+            KPISpecification(name="out3"),
         ]
         # need to make a new workflow for each KPISpecification
-        wf = Workflow(
-            mco=mco_model,
-            execution_layers=[
-                ExecutionLayer()
-            ]
-        )
+        wf = Workflow(mco_model=mco_model, execution_layers=[ExecutionLayer()])
         wf.execution_layers[0].data_sources.append(model)
         kpi_results = wf.execute(data_values)
         self.assertEqual(len(kpi_results), 3)
         self.assertEqual(kpi_results[0].value, 99)
         self.assertEqual(kpi_results[1].value, 1)
         self.assertEqual(kpi_results[2].value, 100)
-        self.assertEqual(kpi_results[0].name, 'out1')
-        self.assertEqual(kpi_results[1].name, 'out2')
-        self.assertEqual(kpi_results[2].name, 'out3')
+        self.assertEqual(kpi_results[0].name, "out1")
+        self.assertEqual(kpi_results[1].name, "out2")
+        self.assertEqual(kpi_results[2].name, "out3")
 
         # now test all possible combinations of KPISpecification, including
         # those with KPIs repeated, and empty KPI specification
         import itertools
-        out_options = [('out1', 99), ('out2', 1), ('out3', 100)]
+
+        out_options = [("out1", 99), ("out2", 1), ("out3", 100)]
         for num_outputs in range(len(out_options) + 2, 0, -1):
             for spec in itertools.permutations(out_options, r=num_outputs):
-                mco_model.kpis = [KPISpecification(name=opt[0])
-                                  for opt in spec]
+                mco_model.kpis = [
+                    KPISpecification(name=opt[0]) for opt in spec
+                ]
 
                 wf = Workflow(
-                    mco=mco_model,
-                    execution_layers=[
-                        ExecutionLayer()
-                    ]
+                    mco_model=mco_model, execution_layers=[ExecutionLayer()]
                 )
                 wf.execution_layers[0].data_sources.append(model)
                 kpi_results = wf.execute(data_values)

--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -34,27 +34,6 @@ class TestWorkflow(unittest.TestCase, UnittestTools):
         self.registry = ProbeFactoryRegistry()
         self.plugin = self.registry.plugin
 
-    def test_deprecated_mco_attribute(self):
-        mco_factory = ProbeMCOFactory(self.plugin)
-        mco_model = mco_factory.create_model()
-        wf = Workflow(mco_model=mco_model, execution_layers=[])
-        warning_log = (
-            "force_bdss.core.workflow",
-            "WARNING",
-            "The Workflow object format with 'mco' attribute is "
-            "now deprecated. Please use 'mco_model' attribute instead.",
-        )
-
-        with testfixtures.LogCapture() as capture:
-            self.assertIs(wf.mco_model, wf.mco)
-            capture.check(warning_log)
-
-        with self.assertTraitChanges(wf, "_mco_model"):
-            with testfixtures.LogCapture() as capture:
-                new_model = mco_factory.create_model()
-                wf.mco = new_model
-                capture.check(warning_log)
-
     def test_public_mco_model(self):
         mco_factory = ProbeMCOFactory(self.plugin)
         mco_model = mco_factory.create_model()

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -28,15 +28,13 @@ class Workflow(HasStrictTraits):
 
     #: The factory-specific MCOModel object.
     #: Can be None if no MCOModel has been specified yet.
-    _mco_model = Instance(
-        BaseMCOModel, allow_none=True  # , transient=True, visible=False
-    )
+    _mco_model = Instance(BaseMCOModel, allow_none=True)
 
     #: Deprecated MCO attribute references to the mco_model attribute.
     #: It is present to prevent possible dependencies API breaks.
-    mco = Property(depends_on="mco_model")  # , transient=True, visible=False)
+    mco = Property(depends_on="mco_model")
 
-    mco_model = Property(depends_on="mco_model")
+    mco_model = Property(depends_on="_mco_model")
 
     #: The execution layers. Execution starts from the first layer,
     #: where all data sources are executed in sequence. It then passes all
@@ -47,14 +45,23 @@ class Workflow(HasStrictTraits):
     notification_listeners = List(BaseNotificationListenerModel)
 
     def _get_mco(self):
+        """ Deprecated method getter. Redirects the call to the public
+        `self.mco_model` attribute."""
         WorkflowAttributeWarning.warn()
         return self.mco_model
 
     def _set_mco(self, mco_model):
+        """ Deprecated method setter. Redirects the call to the public
+        `self.mco_model` attribute."""
         WorkflowAttributeWarning.warn()
         self.mco_model = mco_model
 
     def _get_mco_model(self):
+        """ This is a public method to get the Workflow MCOModel attribute.
+        Direct access to `self._mco_model` for assignment is unsafe.
+        This method is safe and includes necessary verification steps prior
+        to assigning the `mco_model` to `self._mco_model`.
+        """
         return self._mco_model
 
     def _set_mco_model(self, mco_model):

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -28,11 +28,15 @@ class Workflow(HasStrictTraits):
 
     #: The factory-specific MCOModel object.
     #: Can be None if no MCOModel has been specified yet.
-    mco_model = Instance(BaseMCOModel, allow_none=True)
+    _mco_model = Instance(
+        BaseMCOModel, allow_none=True  # , transient=True, visible=False
+    )
 
     #: Deprecated MCO attribute references to the mco_model attribute.
     #: It is present to prevent possible dependencies API breaks.
-    mco = Property(depends_on="mco_model", transient=True, visible=False)
+    mco = Property(depends_on="mco_model")  # , transient=True, visible=False)
+
+    mco_model = Property(depends_on="mco_model")
 
     #: The execution layers. Execution starts from the first layer,
     #: where all data sources are executed in sequence. It then passes all
@@ -45,6 +49,21 @@ class Workflow(HasStrictTraits):
     def _get_mco(self):
         WorkflowAttributeWarning.warn()
         return self.mco_model
+
+    def _set_mco(self, mco_model):
+        WorkflowAttributeWarning.warn()
+        self.mco_model = mco_model
+
+    def _get_mco_model(self):
+        return self._mco_model
+
+    def _set_mco_model(self, mco_model):
+        """ This is a public method to set the Workflow MCOModel attribute.
+        Direct access to `self._mco_model` for assignment is unsafe.
+        This method is safe and includes necessary verification steps prior
+        to assigning the `mco_model` to `self._mco_model`.
+        """
+        self._mco_model = mco_model
 
     def execute(self, data_values):
         """Executes the given workflow using the list of data values.

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -1,6 +1,6 @@
 import logging
 
-from traits.api import HasStrictTraits, Instance, List, Property
+from traits.api import HasStrictTraits, Instance, List
 
 from force_bdss.core.execution_layer import ExecutionLayer
 from force_bdss.core.verifier import VerifierError
@@ -26,13 +26,9 @@ class WorkflowAttributeWarning:
 class Workflow(HasStrictTraits):
     """Model object that represents the Workflow as a whole"""
 
-    #: The Workflow provate MCOModel object.
+    #: The Workflow MCOModel object.
     #: Can be None if no MCOModel has been specified yet.
-    _mco_model = Instance(BaseMCOModel, allow_none=True)
-
-    #: The Workflow public MCOModel property.
-    #: Implement getter and setter methods for data verification.
-    mco_model = Property(depends_on="_mco_model")
+    mco_model = Instance(BaseMCOModel, allow_none=True)
 
     #: The execution layers. Execution starts from the first layer,
     #: where all data sources are executed in sequence. It then passes all
@@ -41,22 +37,6 @@ class Workflow(HasStrictTraits):
 
     #: Contains information about the listeners to be setup
     notification_listeners = List(BaseNotificationListenerModel)
-
-    def _get_mco_model(self):
-        """ This is a public method to get the Workflow MCOModel attribute.
-        Direct access to `self._mco_model` for assignment is unsafe.
-        This method is safe and includes necessary verification steps prior
-        to assigning the `mco_model` to `self._mco_model`.
-        """
-        return self._mco_model
-
-    def _set_mco_model(self, mco_model):
-        """ This is a public method to set the Workflow MCOModel attribute.
-        Direct access to `self._mco_model` for assignment is unsafe.
-        This method is safe and includes necessary verification steps prior
-        to assigning the `mco_model` to `self._mco_model`.
-        """
-        self._mco_model = mco_model
 
     def execute(self, data_values):
         """Executes the given workflow using the list of data values.

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -14,9 +14,9 @@ log = logging.getLogger(__name__)
 
 class Workflow(HasStrictTraits):
     """Model object that represents the Workflow as a whole"""
-    #: Contains the factory-specific MCO Model object.
-    #: Can be None if no MCO has been specified yet.
-    mco = Instance(BaseMCOModel, allow_none=True)
+    #: The factory-specific MCOModel object.
+    #: Can be None if no MCOModel has been specified yet.
+    mco_model = Instance(BaseMCOModel, allow_none=True)
 
     #: The execution layers. Execution starts from the first layer,
     #: where all data sources are executed in sequence. It then passes all
@@ -40,7 +40,7 @@ class Workflow(HasStrictTraits):
         kpis : list of DataValues
             The DataValues containing the KPI results.
         """
-        available_data_values = self.mco.bind_parameters(data_values)
+        available_data_values = self.mco_model.bind_parameters(data_values)
 
         for index, layer in enumerate(self.execution_layers):
             log.info("Computing data layer {}".format(index))
@@ -48,7 +48,7 @@ class Workflow(HasStrictTraits):
             available_data_values += ds_results
 
         log.info("Aggregating KPI data")
-        kpi_results = self.mco.bind_kpis(available_data_values)
+        kpi_results = self.mco_model.bind_kpis(available_data_values)
 
         return kpi_results
 
@@ -67,7 +67,7 @@ class Workflow(HasStrictTraits):
         """
         errors = []
 
-        if not self.mco:
+        if not self.mco_model:
             errors.append(
                 VerifierError(
                     subject=self,
@@ -75,7 +75,7 @@ class Workflow(HasStrictTraits):
                 )
             )
         else:
-            errors += self.mco.verify()
+            errors += self.mco_model.verify()
 
         if not self.execution_layers:
             errors.append(

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -26,14 +26,12 @@ class WorkflowAttributeWarning:
 class Workflow(HasStrictTraits):
     """Model object that represents the Workflow as a whole"""
 
-    #: The factory-specific MCOModel object.
+    #: The Workflow provate MCOModel object.
     #: Can be None if no MCOModel has been specified yet.
     _mco_model = Instance(BaseMCOModel, allow_none=True)
 
-    #: Deprecated MCO attribute references to the mco_model attribute.
-    #: It is present to prevent possible dependencies API breaks.
-    mco = Property(depends_on="mco_model")
-
+    #: The Workflow public MCOModel property.
+    #: Implement getter and setter methods for data verification.
     mco_model = Property(depends_on="_mco_model")
 
     #: The execution layers. Execution starts from the first layer,
@@ -43,18 +41,6 @@ class Workflow(HasStrictTraits):
 
     #: Contains information about the listeners to be setup
     notification_listeners = List(BaseNotificationListenerModel)
-
-    def _get_mco(self):
-        """ Deprecated method getter. Redirects the call to the public
-        `self.mco_model` attribute."""
-        WorkflowAttributeWarning.warn()
-        return self.mco_model
-
-    def _set_mco(self, mco_model):
-        """ Deprecated method setter. Redirects the call to the public
-        `self.mco_model` attribute."""
-        WorkflowAttributeWarning.warn()
-        self.mco_model = mco_model
 
     def _get_mco_model(self):
         """ This is a public method to get the Workflow MCOModel attribute.

--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -12,7 +12,7 @@ from force_bdss.io.workflow_reader import (
     InvalidFileException,
     MissingPluginException,
     ModelInstantiationFailedException,
-    deprecated_wf_format
+    deprecated_wf_format,
 )
 from force_bdss.tests.dummy_classes.factory_registry import (
     DummyFactoryRegistry,
@@ -228,15 +228,21 @@ class TestDeprecationWrapper(unittest.TestCase):
         mco_model_dict = {"mco_model": 1}
         mixed_dict = {"mco": 1, "mco_model": 1}
         with testfixtures.LogCapture() as capture:
-            self.assertDictEqual(decorated_method(None, mco_dict), mco_model_dict)
+            self.assertDictEqual(
+                decorated_method(None, mco_dict), mco_model_dict
+            )
             capture.check(expected_log)
 
         with testfixtures.LogCapture() as capture:
-            self.assertDictEqual(decorated_method(None, mco_model_dict), mco_model_dict)
+            self.assertDictEqual(
+                decorated_method(None, mco_model_dict), mco_model_dict
+            )
             capture.check()
 
         with testfixtures.LogCapture() as capture:
-            self.assertDictEqual(decorated_method(None, mixed_dict), mixed_dict)
+            self.assertDictEqual(
+                decorated_method(None, mixed_dict), mixed_dict
+            )
             capture.check()
 
 

--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -1,14 +1,18 @@
 import json
 import unittest
 from io import StringIO
+import logging
 
 import testfixtures
 
 from force_bdss.core.workflow import Workflow
 from force_bdss.io.workflow_reader import (
     WorkflowReader,
-    InvalidVersionException, InvalidFileException, MissingPluginException,
+    InvalidVersionException,
+    InvalidFileException,
+    MissingPluginException,
     ModelInstantiationFailedException,
+    deprecated_wf_format
 )
 from force_bdss.tests.dummy_classes.factory_registry import (
     DummyFactoryRegistry,
@@ -16,6 +20,8 @@ from force_bdss.tests.dummy_classes.factory_registry import (
 from force_bdss.tests.probe_classes.factory_registry import (
     ProbeFactoryRegistry,
 )
+
+log = logging.getLogger(__name__)
 
 
 class TestWorkflowReader(unittest.TestCase):
@@ -28,72 +34,64 @@ class TestWorkflowReader(unittest.TestCase):
             "workflow": {
                 "mco_model": {
                     "id": "force.bdss.enthought.plugin.test.v0"
-                          ".factory.dummy_mco",
+                    ".factory.dummy_mco",
                     "model_data": {
                         "parameters": [
                             {
                                 "id": "force.bdss.enthought.plugin.test.v0"
-                                      ".factory.dummy_mco.parameter"
-                                      ".dummy_mco_parameter",
-                                "model_data": {}
+                                ".factory.dummy_mco.parameter"
+                                ".dummy_mco_parameter",
+                                "model_data": {},
                             }
                         ],
-                        "kpis": []
+                        "kpis": [],
                     },
                 },
                 "execution_layers": [
-                    [{
-                        "id": "force.bdss.enthought.plugin.test.v0"
-                              ".factory.dummy_data_source",
-                        "model_data": {
-                            "input_slot_info": [],
-                            "output_slot_info": [],
+                    [
+                        {
+                            "id": "force.bdss.enthought.plugin.test.v0"
+                            ".factory.dummy_data_source",
+                            "model_data": {
+                                "input_slot_info": [],
+                                "output_slot_info": [],
+                            },
                         }
-                    }],
+                    ]
                 ],
                 "notification_listeners": [
                     {
                         "id": "force.bdss.enthought.plugin.test.v0"
-                              ".factory.dummy_notification_listener",
-                        "model_data": {}
-                    },
-                ]
-            }
+                        ".factory.dummy_notification_listener",
+                        "model_data": {},
+                    }
+                ],
+            },
         }
 
     def test_initialization(self):
-        self.assertEqual(self.wfreader.factory_registry,
-                         self.registry)
+        self.assertEqual(self.wfreader.factory_registry, self.registry)
 
-        workflow = self.wfreader.read(
-            _as_json_stringio(self.working_data)
-        )
+        workflow = self.wfreader.read(_as_json_stringio(self.working_data))
 
         self.assertIsInstance(workflow, Workflow)
 
     def test_invalid_version(self):
-        data = {
-            "version": "2",
-            "workflow": {}
-        }
+        data = {"version": "2", "workflow": {}}
 
         with testfixtures.LogCapture():
             with self.assertRaises(InvalidVersionException):
                 self.wfreader.read(_as_json_stringio(data))
 
     def test_absent_version(self):
-        data = {
-        }
+        data = {}
 
         with testfixtures.LogCapture():
             with self.assertRaises(InvalidFileException):
                 self.wfreader.read(_as_json_stringio(data))
 
     def test_missing_key(self):
-        data = {
-            "version": "1",
-            "workflow": {}
-        }
+        data = {"version": "1", "workflow": {}}
 
         with testfixtures.LogCapture():
             with self.assertRaises(InvalidFileException):
@@ -108,27 +106,41 @@ class TestWorkflowReader(unittest.TestCase):
 
     def test_missing_plugin_mco_parameter(self):
         data = self.working_data
-        data["workflow"]["mco_model"]["model_data"]["parameters"][0]["id"] = \
-            "missing_parameter"
+        data["workflow"]["mco_model"]["model_data"]["parameters"][0][
+            "id"
+        ] = "missing_parameter"
 
         with self.assertRaises(MissingPluginException):
             self.wfreader.read(_as_json_stringio(data))
 
     def test_missing_plugin_notification_listener(self):
         data = self.working_data
-        data["workflow"]["notification_listeners"][0]["id"] = \
-            "missing_nl"
+        data["workflow"]["notification_listeners"][0]["id"] = "missing_nl"
 
         with self.assertRaises(MissingPluginException):
             self.wfreader.read(_as_json_stringio(data))
 
     def test_missing_plugin_data_source(self):
         data = self.working_data
-        data["workflow"]["execution_layers"][0][0]["id"] = \
-            "missing_ds"
+        data["workflow"]["execution_layers"][0][0]["id"] = "missing_ds"
 
         with self.assertRaises(MissingPluginException):
             self.wfreader.read(_as_json_stringio(data))
+
+    def test_deprecated_wf_format_wrapper(self):
+        self.working_data["workflow"]["mco"] = self.working_data[
+            "workflow"
+        ].pop("mco_model")
+
+        with testfixtures.LogCapture() as capture:
+            self.wfreader._extract_mco(self.working_data["workflow"])
+            expected_log = (
+                "force_bdss.core.workflow",
+                "WARNING",
+                "The Workflow object format with 'mco' attribute is "
+                "now deprecated. Please use 'mco_model' attribute instead.",
+            )
+            capture.check(expected_log)
 
 
 class TestModelCreationFailure(unittest.TestCase):
@@ -141,60 +153,55 @@ class TestModelCreationFailure(unittest.TestCase):
             "workflow": {
                 "mco_model": {
                     "id": "force.bdss.enthought.plugin.test.v0"
-                          ".factory.probe_mco",
+                    ".factory.probe_mco",
                     "model_data": {
                         "parameters": [
                             {
                                 "id": "force.bdss.enthought.plugin.test.v0"
-                                      ".factory.probe_mco.parameter"
-                                      ".probe_mco_parameter",
-                                "model_data": {}
+                                ".factory.probe_mco.parameter"
+                                ".probe_mco_parameter",
+                                "model_data": {},
                             }
                         ],
-                        "kpis": [
-                        ]
+                        "kpis": [],
                     },
                 },
                 "execution_layers": [
-                    [{
-                        "id": "force.bdss.enthought.plugin.test.v0"
-                              ".factory.probe_data_source",
-                        "model_data": {
-                            "input_slot_info": [],
-                            "output_slot_info": [],
+                    [
+                        {
+                            "id": "force.bdss.enthought.plugin.test.v0"
+                            ".factory.probe_data_source",
+                            "model_data": {
+                                "input_slot_info": [],
+                                "output_slot_info": [],
+                            },
                         }
-                    }],
+                    ]
                 ],
                 "notification_listeners": [
                     {
                         "id": "force.bdss.enthought.plugin.test.v0"
-                              ".factory.probe_notification_listener",
-                        "model_data": {}
-                    },
-                ]
-            }
+                        ".factory.probe_notification_listener",
+                        "model_data": {},
+                    }
+                ],
+            },
         }
 
     def test_basic_probe_loading(self):
-        self.wfreader.read(
-            _as_json_stringio(self.working_data)
-        )
+        self.wfreader.read(_as_json_stringio(self.working_data))
 
     def test_data_source_model_throws(self):
         self.registry.data_source_factories[0].raises_on_create_model = True
         with testfixtures.LogCapture():
             with self.assertRaises(ModelInstantiationFailedException):
-                self.wfreader.read(
-                    _as_json_stringio(self.working_data)
-                )
+                self.wfreader.read(_as_json_stringio(self.working_data))
 
     def test_mco_model_throws(self):
         self.registry.mco_factories[0].raises_on_create_model = True
         with testfixtures.LogCapture():
             with self.assertRaises(ModelInstantiationFailedException):
-                self.wfreader.read(
-                    _as_json_stringio(self.working_data)
-                )
+                self.wfreader.read(_as_json_stringio(self.working_data))
 
     def test_notification_listener_throws(self):
         factory = self.registry.notification_listener_factories[0]
@@ -202,9 +209,35 @@ class TestModelCreationFailure(unittest.TestCase):
 
         with testfixtures.LogCapture():
             with self.assertRaises(ModelInstantiationFailedException):
-                self.wfreader.read(
-                    _as_json_stringio(self.working_data)
-                )
+                self.wfreader.read(_as_json_stringio(self.working_data))
+
+
+class TestDeprecationWrapper(unittest.TestCase):
+    def test_wrapper(self):
+        @deprecated_wf_format
+        def decorated_method(self_reference, data_dict):
+            return data_dict
+
+        expected_log = (
+            "force_bdss.core.workflow",
+            "WARNING",
+            "The Workflow object format with 'mco' attribute is "
+            "now deprecated. Please use 'mco_model' attribute instead.",
+        )
+        mco_dict = {"mco": 1}
+        mco_model_dict = {"mco_model": 1}
+        mixed_dict = {"mco": 1, "mco_model": 1}
+        with testfixtures.LogCapture() as capture:
+            self.assertDictEqual(decorated_method(None, mco_dict), mco_model_dict)
+            capture.check(expected_log)
+
+        with testfixtures.LogCapture() as capture:
+            self.assertDictEqual(decorated_method(None, mco_model_dict), mco_model_dict)
+            capture.check()
+
+        with testfixtures.LogCapture() as capture:
+            self.assertDictEqual(decorated_method(None, mixed_dict), mixed_dict)
+            capture.check()
 
 
 def _as_json_stringio(data):

--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -26,7 +26,7 @@ class TestWorkflowReader(unittest.TestCase):
         self.working_data = {
             "version": "1",
             "workflow": {
-                "mco": {
+                "mco_model": {
                     "id": "force.bdss.enthought.plugin.test.v0"
                           ".factory.dummy_mco",
                     "model_data": {
@@ -101,14 +101,14 @@ class TestWorkflowReader(unittest.TestCase):
 
     def test_missing_plugin_mco(self):
         data = self.working_data
-        data["workflow"]["mco"]["id"] = "missing_mco"
+        data["workflow"]["mco_model"]["id"] = "missing_mco"
 
         with self.assertRaises(MissingPluginException):
             self.wfreader.read(_as_json_stringio(data))
 
     def test_missing_plugin_mco_parameter(self):
         data = self.working_data
-        data["workflow"]["mco"]["model_data"]["parameters"][0]["id"] = \
+        data["workflow"]["mco_model"]["model_data"]["parameters"][0]["id"] = \
             "missing_parameter"
 
         with self.assertRaises(MissingPluginException):
@@ -139,7 +139,7 @@ class TestModelCreationFailure(unittest.TestCase):
         self.working_data = {
             "version": "1",
             "workflow": {
-                "mco": {
+                "mco_model": {
                     "id": "force.bdss.enthought.plugin.test.v0"
                           ".factory.probe_mco",
                     "model_data": {

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -32,7 +32,7 @@ class TestWorkflowWriter(unittest.TestCase):
         result = json.loads(fp.getvalue())
         self.assertIn("version", result)
         self.assertIn("workflow", result)
-        self.assertIn("mco", result["workflow"])
+        self.assertIn("mco_model", result["workflow"])
         self.assertIn("execution_layers", result["workflow"])
 
     def test_write_and_read(self):
@@ -43,8 +43,8 @@ class TestWorkflowWriter(unittest.TestCase):
         fp.seek(0)
         wfreader = WorkflowReader(self.registry)
         wf_result = wfreader.read(fp)
-        self.assertEqual(wf_result.mco.factory.id,
-                         wf.mco.factory.id)
+        self.assertEqual(wf_result.mco_model.factory.id,
+                         wf.mco_model.factory.id)
         self.assertEqual(len(wf_result.execution_layers), 2)
         self.assertEqual(
             len(wf_result.execution_layers[0].data_sources), 2)
@@ -54,11 +54,11 @@ class TestWorkflowWriter(unittest.TestCase):
     def _create_workflow(self):
         wf = Workflow()
 
-        wf.mco = self.mco_factory.create_model()
-        wf.mco.parameters = [
+        wf.mco_model = self.mco_factory.create_model()
+        wf.mco_model.parameters = [
             self.mco_parameter_factory.create_model()
         ]
-        wf.mco.kpis = [
+        wf.mco_model.kpis = [
             KPISpecification()
         ]
         wf.execution_layers = [
@@ -80,7 +80,7 @@ class TestWorkflowWriter(unittest.TestCase):
         fp.seek(0)
         wfreader = WorkflowReader(self.registry)
         wf_result = wfreader.read(fp)
-        self.assertIsNone(wf_result.mco)
+        self.assertIsNone(wf_result.mco_model)
 
     def test_traits_to_dict_no_version(self):
         mock_traits = mock.Mock()

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -137,7 +137,7 @@ class WorkflowReader(HasStrictTraits):
         """
         wf = Workflow()
 
-        wf.mco = self._extract_mco(wf_data)
+        wf.mco_model = self._extract_mco(wf_data)
         wf.execution_layers[:] = self._extract_execution_layers(wf_data)
         wf.notification_listeners[:] = (
             self._extract_notification_listeners(wf_data)
@@ -160,7 +160,7 @@ class WorkflowReader(HasStrictTraits):
         """
         registry = self.factory_registry
 
-        mco_data = wf_data.get("mco")
+        mco_data = wf_data.get("mco_model")
         if mco_data is None:
             # The file was saved without setting an MCO.
             # The file is valid, we simply can't run any optimization yet.
@@ -175,7 +175,7 @@ class WorkflowReader(HasStrictTraits):
                 "The plugin responsible for the missing "
                 "key '{}' may be missing or broken.".format(mco_id)
             )
-        model_data = wf_data["mco"]["model_data"]
+        model_data = wf_data["mco_model"]["model_data"]
         model_data["parameters"] = self._extract_mco_parameters(
             mco_id,
             model_data["parameters"])

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -30,7 +30,7 @@ class WorkflowWriter(HasStrictTraits):
 
     def _workflow_data(self, workflow):
         workflow_data = {
-            "mco": self._mco_data(workflow.mco),
+            "mco_model": self._mco_data(workflow.mco_model),
             "execution_layers": [
                 self._execution_layer_data(el)
                 for el in workflow.execution_layers],

--- a/force_bdss/tests/fixtures/test_dummy.json
+++ b/force_bdss/tests/fixtures/test_dummy.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.enthought.plugin.test.v0.factory.dummy_mco",
             "model_data": {
                 "parameters": [

--- a/force_bdss/tests/fixtures/test_empty.json
+++ b/force_bdss/tests/fixtures/test_empty.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
   "workflow": {
-    "mco": null,
+    "mco_model": null,
     "execution_layers": [
     ],
     "notification_listeners": [

--- a/force_bdss/tests/fixtures/test_null.json
+++ b/force_bdss/tests/fixtures/test_null.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
   "workflow": {
-    "mco": {
+    "mco_model": {
       "id": "force.bdss.enthought.plugin.test.v0.factory.probe_mco",
       "model_data": {
         "parameters" : [

--- a/force_bdss/tests/fixtures/test_probe.json
+++ b/force_bdss/tests/fixtures/test_probe.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.enthought.plugin.test.v0.factory.probe_mco",
             "model_data": {
                 "parameters": [


### PR DESCRIPTION
This PR approaches #246 

### Summary

The attribute `mco` of the `Workflow` class refers to the `Instance(BaseMCOModel)`. There are such entities as `BaseMCO` alongside the `BaseMCOModel`, and therefore this naming is misleading. We approach to resolve this inconsistency.

### Done

- We rename the attribute to `Workflow.mco_model`, and change all implicit and explicit references to `mco` to `mco_model`.

### Compatibility

This change doesn't breaks the backwards compatibility for workflow json files but throws a deprecation warning. We suggest that all workflow json file `workflow["mco"]` elements must be renamed to `workflow["mco_model"]`. In addition, the `force-wfmanager` requests to `Workflow.mco` should be changed to `Workflow.mco_model`.