### PR TITLE
WIP: DEV: Including EMMO package

### DIFF
--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -1,6 +1,8 @@
 import unittest
 import testfixtures
 
+from emmo.ontology import Ontology
+
 from traits.testing.api import UnittestTools
 
 from force_bdss.core.execution_layer import ExecutionLayer
@@ -33,6 +35,25 @@ class TestWorkflow(unittest.TestCase, UnittestTools):
     def setUp(self):
         self.registry = ProbeFactoryRegistry()
         self.plugin = self.registry.plugin
+
+    def test_ontology(self):
+        mco_factory = ProbeMCOFactory(self.plugin)
+        mco_model = mco_factory.create_model()
+        parameter_factory = mco_factory.parameter_factories[0]
+
+        mco_model.parameters = [
+            parameter_factory.create_model({"name": "in1"}),
+        ]
+        mco_model.kpis = [KPISpecification(name="out1")]
+
+        workflow = Workflow(
+            mco_model=mco_model,
+            execution_layers=[
+                ExecutionLayer()
+            ],
+        )
+
+        self.assertIsInstance(workflow.ontology, Ontology)
 
     def test_multilayer_execution(self):
         # The multilayer peforms the following execution

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -1,5 +1,8 @@
 import logging
 
+from emmo import get_ontology
+from owlready2 import Ontology
+
 from traits.api import HasStrictTraits, Instance, List
 
 from force_bdss.core.execution_layer import ExecutionLayer
@@ -37,6 +40,18 @@ class Workflow(HasStrictTraits):
 
     #: Contains information about the listeners to be setup
     notification_listeners = List(BaseNotificationListenerModel)
+
+    #: Ontology for DataValue types
+    ontology = Instance(Ontology)
+
+    def _ontology_default(self):
+
+        # NOTE: This functionality requires a local installation of JDK
+        ontology = get_ontology("http://emmo.info/emmo.owl#")
+        ontology.load()
+        ontology.sync_reasoner('Pellet')
+
+        return ontology
 
     def execute(self, data_values):
         """Executes the given workflow using the list of data values.


### PR DESCRIPTION
This PR experiments with including the European Materials Modelling Ontology [EMMO](https://github.com/emmo-repo) package in the BDSS.

Considering that the ontology is an instance, rather than a library, we much decide where to contain this object as a reference during run time. Initially we have experimented with allocating it as a attribute of the `Workflow`, since each `DataValue` object is expected to have a `type` attribute corresponding to a ontology class. A method should then be constructed to map each `DataValue.type` attribute to an existing `Ontology.<class>` object.

This may be combined with similar methods that have been constructed to identify `Variable` objects from corresponding `DataValue` instances.

## Change log

- Dependencies are updated in the CI for `EMMO` to be installed through `pip`
- New `ontology` attribute on `Workflow` class

## To Do

- Construct method to map ontology classes to `DataValue` types