### PR TITLE
FIX: Workflow Reader changes json data

### DIFF
--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 import unittest
 from io import StringIO
@@ -53,8 +54,12 @@ class TestWorkflowReader(unittest.TestCase):
                             "id": "force.bdss.enthought.plugin.test.v0"
                             ".factory.dummy_data_source",
                             "model_data": {
-                                "input_slot_info": [],
-                                "output_slot_info": [],
+                                "input_slot_info": [
+                                    {"name": "input_slot_name"}
+                                ],
+                                "output_slot_info": [
+                                    {"name": "output_slot_name"}
+                                ],
                             },
                         }
                     ]
@@ -142,6 +147,24 @@ class TestWorkflowReader(unittest.TestCase):
             )
             capture.check(expected_log)
 
+    def test_persistent_wfdata(self):
+        copied_data = deepcopy(self.working_data["workflow"])
+        self.wfreader._extract_mco(self.working_data["workflow"])
+        self.assertDictEqual(copied_data, self.working_data["workflow"])
+        self.wfreader._extract_mco(self.working_data["workflow"])
+
+        self.wfreader._extract_execution_layers(self.working_data["workflow"])
+        self.assertDictEqual(copied_data, self.working_data["workflow"])
+        self.wfreader._extract_execution_layers(self.working_data["workflow"])
+
+        self.wfreader._extract_notification_listeners(
+            self.working_data["workflow"]
+        )
+        self.assertDictEqual(copied_data, self.working_data["workflow"])
+        self.wfreader._extract_notification_listeners(
+            self.working_data["workflow"]
+        )
+
 
 class TestModelCreationFailure(unittest.TestCase):
     def setUp(self):
@@ -207,6 +230,13 @@ class TestModelCreationFailure(unittest.TestCase):
         factory = self.registry.notification_listener_factories[0]
         factory.raises_on_create_model = True
 
+        with testfixtures.LogCapture():
+            with self.assertRaises(ModelInstantiationFailedException):
+                self.wfreader.read(_as_json_stringio(self.working_data))
+
+    def test__extract_mco_parameters_throws(self):
+        model_data = self.working_data["workflow"]["mco_model"]["model_data"]
+        model_data["parameters"][0]["model_data"] = {"bad": "data"}
         with testfixtures.LogCapture():
             with self.assertRaises(ModelInstantiationFailedException):
                 self.wfreader.read(_as_json_stringio(self.working_data))

--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -237,9 +237,22 @@ class TestModelCreationFailure(unittest.TestCase):
     def test__extract_mco_parameters_throws(self):
         model_data = self.working_data["workflow"]["mco_model"]["model_data"]
         model_data["parameters"][0]["model_data"] = {"bad": "data"}
-        with testfixtures.LogCapture():
+        with testfixtures.LogCapture() as capture:
             with self.assertRaises(ModelInstantiationFailedException):
                 self.wfreader.read(_as_json_stringio(self.working_data))
+            capture.check(
+                (
+                    "force_bdss.io.workflow_reader",
+                    "ERROR",
+                    "Unable to create model for MCO force.bdss.enthought."
+                    "plugin.test.v0.factory.probe_mco parameter force."
+                    "bdss.enthought.plugin.test.v0.factory.probe_mco."
+                    "parameter.probe_mco_parameter : Cannot set the undefined "
+                    "'bad' attribute of a 'ProbeParameter' object. This is "
+                    "likely due to an error "
+                    "in the plugin. Check the logs for more information.",
+                )
+            )
 
 
 class TestDeprecationWrapper(unittest.TestCase):

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -307,7 +307,7 @@ class WorkflowReader(HasStrictTraits):
                 model = factory.create_model(p["model_data"])
             except Exception as e:
                 msg = (
-                    "Unable to create model for MCO {} parameter {} : {}. "
+                    "Unable to create model for MCO {} parameter {} : {} "
                     "This is likely due to an error in the plugin. "
                     "Check the logs for more information.".format(
                         mco_id, parameter_id, e


### PR DESCRIPTION
This PR approaches #258 

### Summary

The `WorkflowReader` methods `_extract_*` mutate the `wf_data` argument during deserialization of the json dictionary. If we read the json file only once, these methods can only be called once. If called more times, the dictionary values are already changed from plain strings to BDSS objects, and can't be deserialized again.

We wrap the `wf_data` passed inside the `_extract_*` methods into `deepcopy`. Then, we are safe to mutate the copy without affecting the global state of the original `wf_data` dictionary.

### Done

- Replace access to `wf_data` to `deepcopy(wf_data)` where we apply changes to the dict entries.
- Added tests to verify the original data is persistent.
- Added missing test for corrupted data.
