### PR TITLE
Dev: Workflow event types

### DIFF
--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -91,10 +91,10 @@ class OptimizeOperation(HasStrictTraits):
         self.mco = None
 
     def _deliver_start_event(self):
-        self._deliver_event(self.workflow.mco_model.create_start_event())
+        self.workflow.mco_model.notify_start_event()
 
     def _deliver_finish_event(self):
-        self._deliver_event(self.workflow.mco_model.create_finish_event())
+        self.workflow.mco_model.notify_finish_event()
 
     @on_trait_change("workflow_file:workflow:event,mco:event")
     def _deliver_event(self, event):

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -238,7 +238,7 @@ class TestOptimizeOperation(TestCase):
         self.operation.workflow.mco_model.notify_new_point(
             [DataValue(value=1), DataValue(value=2)],
             [DataValue(value=3), DataValue(value=4)],
-            [0.5, 0.5])
+            weights=[0.5, 0.5])
         self.assertIsInstance(
             listener.deliver_call_args[0][0],
             MCOProgressEvent)
@@ -271,7 +271,7 @@ class TestOptimizeOperation(TestCase):
             self.operation.mco.notify_new_point(
                 [DataValue(value=2), DataValue(value=3)],
                 [DataValue(value=4), DataValue(value=5)],
-                [1.5, 1.5])
+                weights=[1.5, 1.5])
             self.assertIsInstance(
                 listener.deliver_call_args[0][0],
                 MCOProgressEvent)

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -5,12 +5,13 @@ import testfixtures
 from force_bdss.app.optimize_operation import OptimizeOperation
 from force_bdss.core.data_value import DataValue
 from force_bdss.core_driver_events import (
-    MCOStartEvent, MCOFinishEvent, MCOProgressEvent)
+    MCOStartEvent,
+    MCOFinishEvent,
+    MCOProgressEvent,
+)
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.tests import fixtures
-from force_bdss.tests.probe_classes.workflow_file import (
-    ProbeWorkflowFile
-)
+from force_bdss.tests.probe_classes.workflow_file import ProbeWorkflowFile
 
 
 def raise_exception(*args, **kwargs):
@@ -18,16 +19,13 @@ def raise_exception(*args, **kwargs):
 
 
 class TestOptimizeOperation(TestCase):
-
     def setUp(self):
         self.operation = OptimizeOperation()
         self.operation.workflow_file = ProbeWorkflowFile(
             path=fixtures.get("test_probe.json")
         )
         self.operation.workflow_file.read()
-        self.registry = (
-            self.operation.workflow_file.reader.factory_registry
-        )
+        self.registry = self.operation.workflow_file.reader.factory_registry
 
     def test__init__(self):
 
@@ -56,16 +54,20 @@ class TestOptimizeOperation(TestCase):
         self.operation.workflow.mco_model = None
         with testfixtures.LogCapture() as capture:
             with self.assertRaisesRegex(
-                    RuntimeError,
-                    "Workflow file has errors"):
+                RuntimeError, "Workflow file has errors"
+            ):
                 self.operation.run()
             capture.check(
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Unable to execute workflow due to verification errors:'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Workflow has no MCO'),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Unable to execute workflow due to verification errors:",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Workflow has no MCO",
+                ),
             )
 
     def test__initialize_listeners(self):
@@ -84,14 +86,17 @@ class TestOptimizeOperation(TestCase):
             with self.assertRaises(Exception):
                 self.operation._initialize_listeners()
             capture.check(
-                ("force_bdss.app.optimize_operation",
-                 "ERROR",
-                 "Failed to create listener with id "
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_notification_listener' in plugin "
-                 "'force.bdss.enthought.plugin.test.v0'. "
-                 "This may indicate a programming error in the "
-                 "plugin."))
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Failed to create listener with id "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_notification_listener' in plugin "
+                    "'force.bdss.enthought.plugin.test.v0'. "
+                    "This may indicate a programming error in the "
+                    "plugin.",
+                )
+            )
 
         # Test for error on initialization of listener, we
         # only expect a log message
@@ -101,13 +106,16 @@ class TestOptimizeOperation(TestCase):
         with testfixtures.LogCapture() as capture:
             self.operation._initialize_listeners()
             capture.check(
-                ("force_bdss.app.optimize_operation",
-                 "ERROR",
-                 "Failed to initialize listener with id "
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_notification_listener' in plugin "
-                 "'force.bdss.enthought.plugin.test.v0'. "
-                 "The listener will be dropped."))
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Failed to initialize listener with id "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_notification_listener' in plugin "
+                    "'force.bdss.enthought.plugin.test.v0'. "
+                    "The listener will be dropped.",
+                )
+            )
 
     def test__finalize_listeners(self):
 
@@ -130,12 +138,15 @@ class TestOptimizeOperation(TestCase):
         with testfixtures.LogCapture() as capture:
             self.operation._finalize_listeners()
             capture.check(
-                ("force_bdss.app.optimize_operation",
-                 "ERROR",
-                 "Exception while finalizing listener "
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_notification_listener' in plugin "
-                 "'force.bdss.enthought.plugin.test.v0'."))
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Exception while finalizing listener "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_notification_listener' in plugin "
+                    "'force.bdss.enthought.plugin.test.v0'.",
+                )
+            )
 
         self.assertEqual(0, len(self.operation.listeners))
         self.assertTrue(listener.finalize_called)
@@ -148,17 +159,11 @@ class TestOptimizeOperation(TestCase):
         # Deliver a start event
         self.operation._deliver_start_event()
         self.assertTrue(listener.deliver_called)
-        self.assertIsInstance(
-            listener.deliver_call_args[0][0],
-            MCOStartEvent
-        )
+        self.assertIsInstance(listener.deliver_call_args[0][0], MCOStartEvent)
 
         # Deliver a finish event
         self.operation._deliver_finish_event()
-        self.assertIsInstance(
-            listener.deliver_call_args[0][0],
-            MCOFinishEvent
-        )
+        self.assertIsInstance(listener.deliver_call_args[0][0], MCOFinishEvent)
 
         # Now initialise a set of listeners that will raise an
         # exception when delivered to test error handling
@@ -172,14 +177,17 @@ class TestOptimizeOperation(TestCase):
             self.operation._deliver_start_event()
             self.assertTrue(listener.deliver_called)
             capture.check(
-                ("force_bdss.app.optimize_operation",
-                 "ERROR",
-                 "Exception while delivering to listener "
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_notification_listener' in plugin "
-                 "'force.bdss.enthought.plugin.test.v0'. "
-                 "The listener will be dropped and computation "
-                 "will continue."))
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Exception while delivering to listener "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_notification_listener' in plugin "
+                    "'force.bdss.enthought.plugin.test.v0'. "
+                    "The listener will be dropped and computation "
+                    "will continue.",
+                )
+            )
 
     def test_create_mco(self):
 
@@ -197,18 +205,19 @@ class TestOptimizeOperation(TestCase):
             with self.assertRaises(Exception):
                 self.operation.create_mco()
             capture.check(
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Unable to instantiate optimizer for mco '
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_mco' in plugin "
-                 "'force.bdss.enthought.plugin.test.v0'. "
-                 "An exception was raised. This might "
-                 'indicate a programming error in the plugin.')
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Unable to instantiate optimizer for mco "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_mco' in plugin "
+                    "'force.bdss.enthought.plugin.test.v0'. "
+                    "An exception was raised. This might "
+                    "indicate a programming error in the plugin.",
+                )
             )
 
     def test_mco_run_exception(self):
-
         def run_func(*args, **kwargs):
             raise Exception("run_func")
 
@@ -221,27 +230,43 @@ class TestOptimizeOperation(TestCase):
             with self.assertRaises(Exception):
                 self.operation.run()
             capture.check(
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Method run() of MCO with id '
-                 "'force.bdss.enthought.plugin.test.v0"
-                 ".factory.probe_mco' from plugin "
-                 "'force.bdss.enthought.plugin.test.v0'"
-                 " raised exception. This might indicate "
-                 'a programming error in the plugin.')
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Method run() of MCO with id "
+                    "'force.bdss.enthought.plugin.test.v0"
+                    ".factory.probe_mco' from plugin "
+                    "'force.bdss.enthought.plugin.test.v0'"
+                    " raised exception. This might indicate "
+                    "a programming error in the plugin.",
+                )
             )
 
     def test_progress_event_handling(self):
 
         self.operation.mco = self.operation.create_mco()
         listener = self.operation.listeners[0]
-        self.operation.workflow.mco_model.notify_new_point(
-            [DataValue(value=1), DataValue(value=2)],
-            [DataValue(value=3), DataValue(value=4)],
-            weights=[0.5, 0.5])
+
+        expected_log = (
+            "force_bdss.mco.base_mco_model",
+            "WARNING",
+            "Use of the BaseMCOModel.notify_new_point method is now deprecated"
+            " and will be removed in version 0.5.0. Please replace any uses "
+            "of the BaseMCO.notify_new_point method with the "
+            "equivalent BaseMCOModel.notify_progress_event method."
+        )
+
+        with testfixtures.LogCapture() as capture:
+            self.operation.workflow.mco_model.notify_new_point(
+                [DataValue(value=1), DataValue(value=2)],
+                [DataValue(value=3), DataValue(value=4)],
+                [0.5, 0.5],
+            )
+            capture.check(expected_log)
+
         self.assertIsInstance(
-            listener.deliver_call_args[0][0],
-            MCOProgressEvent)
+            listener.deliver_call_args[0][0], MCOProgressEvent
+        )
 
         event = listener.deliver_call_args[0][0]
 
@@ -271,10 +296,11 @@ class TestOptimizeOperation(TestCase):
             self.operation.mco.notify_new_point(
                 [DataValue(value=2), DataValue(value=3)],
                 [DataValue(value=4), DataValue(value=5)],
-                weights=[1.5, 1.5])
+                weights=[1.5, 1.5],
+            )
             self.assertIsInstance(
-                listener.deliver_call_args[0][0],
-                MCOProgressEvent)
+                listener.deliver_call_args[0][0], MCOProgressEvent
+            )
 
             event = listener.deliver_call_args[0][0]
 
@@ -299,14 +325,21 @@ class TestOptimizeOperation(TestCase):
             with self.assertRaises(RuntimeError):
                 self.operation.run()
             capture.check(
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Unable to execute workflow due to verification errors:'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR', 'Workflow has no MCO'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Workflow has no execution layers')
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Unable to execute workflow due to verification errors:",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Workflow has no MCO",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Workflow has no execution layers",
+                ),
             )
 
     def test_non_valid_file(self):
@@ -321,18 +354,29 @@ class TestOptimizeOperation(TestCase):
             with self.assertRaises(RuntimeError):
                 self.operation.run()
             capture.check(
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'Unable to execute workflow due to verification errors:'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'The MCO has no defined parameters'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'The MCO has no defined KPIs'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'The number of input slots is incorrect.'),
-                ('force_bdss.app.optimize_operation',
-                 'ERROR',
-                 'The number of output slots is incorrect.'))
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "Unable to execute workflow due to verification errors:",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "The MCO has no defined parameters",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "The MCO has no defined KPIs",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "The number of input slots is incorrect.",
+                ),
+                (
+                    "force_bdss.app.optimize_operation",
+                    "ERROR",
+                    "The number of output slots is incorrect.",
+                ),
+            )

--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -388,12 +388,10 @@ class TestWorkflow(unittest.TestCase, UnittestTools):
         workflow_file.read()
         workflow = workflow_file.workflow
 
-        with self.assertTraitChanges(
-                workflow, 'event', count=1):
+        with self.assertTraitChanges(workflow, "event", count=1):
             workflow.execution_layers[0].data_sources[0].notify(
-                BaseDriverEvent())
+                BaseDriverEvent()
+            )
 
-        with self.assertTraitChanges(
-                workflow, 'event', count=1):
-            workflow.mco_model.notify(
-                BaseDriverEvent())
+        with self.assertTraitChanges(workflow, "event", count=1):
+            workflow.mco_model.notify(BaseDriverEvent())

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -7,7 +7,7 @@ from force_bdss.core.base_model import BaseModel
 from force_bdss.core_driver_events import (
     MCOStartEvent,
     MCOFinishEvent,
-    MCOProgressEvent
+    MCOProgressEvent,
 )
 from force_bdss.core.kpi_specification import KPISpecification
 from force_bdss.core.verifier import VerifierError
@@ -40,7 +40,9 @@ class BaseMCOModel(BaseModel):
     _start_event_type = Type(MCOStartEvent, visible=False, transient=True)
 
     #: Type of the MCO Start event
-    _progress_event_type = Type(MCOProgressEvent, visible=False, transient=True)
+    _progress_event_type = Type(
+        MCOProgressEvent, visible=False, transient=True
+    )
 
     #: Type of the MCO Start event
     _finish_event_type = Type(MCOFinishEvent, visible=False, transient=True)
@@ -144,16 +146,18 @@ class BaseMCOModel(BaseModel):
 
         return errors
 
-    def create_start_event(self):
+    def notify_start_event(self):
         """ Creates base event indicating the start of the MCO."""
-        return self._start_event_type(
-            parameter_names=list(p.name for p in self.parameters),
-            kpi_names=list(kpi.name for kpi in self.kpis),
+        self.notify(
+            self._start_event_type(
+                parameter_names=list(p.name for p in self.parameters),
+                kpi_names=list(kpi.name for kpi in self.kpis),
+            )
         )
 
-    def create_finish_event(self):
+    def notify_finish_event(self):
         """ Creates base event indicating the finished MCO."""
-        return self._finish_event_type()
+        self.notify(self._finish_event_type())
 
     def notify_new_point(self, optimal_point, optimal_kpis, weights):
         """Notify the discovery of a new optimal point.
@@ -172,11 +176,13 @@ class BaseMCOModel(BaseModel):
             A list of weight values from 0.0 to 1.0 that have been assigned
             for this point to each KPI.
         """
-        self.notify(self._progress_event_type(
-            optimal_point=optimal_point,
-            optimal_kpis=optimal_kpis,
-            weights=weights,
-        ))
+        self.notify(
+            self._progress_event_type(
+                optimal_point=optimal_point,
+                optimal_kpis=optimal_kpis,
+                weights=weights,
+            )
+        )
 
     @classmethod
     def from_json(cls, factory, json_data):

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -159,7 +159,7 @@ class BaseMCOModel(BaseModel):
         """ Creates base event indicating the finished MCO."""
         self.notify(self._finish_event_type())
 
-    def notify_new_point(self, optimal_point, optimal_kpis, weights):
+    def notify_new_point(self, optimal_point, optimal_kpis, **kwargs):
         """Notify the discovery of a new optimal point.
 
         Parameters
@@ -172,15 +172,13 @@ class BaseMCOModel(BaseModel):
             A list of DataValue objects describing the KPI values resulting
             from the optimal_point values above.
 
-        weights: List(Float())
-            A list of weight values from 0.0 to 1.0 that have been assigned
-            for this point to each KPI.
+        kwargs: Additional data relevant to the MCOProgressEvent
         """
         self.notify(
             self._progress_event_type(
                 optimal_point=optimal_point,
                 optimal_kpis=optimal_kpis,
-                weights=weights,
+                **kwargs,
             )
         )
 

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 import logging
 
-from traits.api import Instance, List
+from traits.api import Instance, List, Type
 
 from force_bdss.core.base_model import BaseModel
 from force_bdss.core_driver_events import (
@@ -35,6 +35,15 @@ class BaseMCOModel(BaseModel):
 
     #: A list of KPI specification objects and their objective.
     kpis = List(KPISpecification, visible=False)
+
+    #: Type of the MCO Start event
+    _start_event_type = Type(MCOStartEvent, visible=False, transient=True)
+
+    #: Type of the MCO Start event
+    _progress_event_type = Type(MCOProgressEvent, visible=False, transient=True)
+
+    #: Type of the MCO Start event
+    _finish_event_type = Type(MCOFinishEvent, visible=False, transient=True)
 
     def bind_parameters(self, data_values):
         """ Bind and filter values from the MCO to the model parameters.
@@ -137,14 +146,14 @@ class BaseMCOModel(BaseModel):
 
     def create_start_event(self):
         """ Creates base event indicating the start of the MCO."""
-        return MCOStartEvent(
+        return self._start_event_type(
             parameter_names=list(p.name for p in self.parameters),
             kpi_names=list(kpi.name for kpi in self.kpis),
         )
 
     def create_finish_event(self):
         """ Creates base event indicating the finished MCO."""
-        return MCOFinishEvent()
+        return self._finish_event_type()
 
     def notify_new_point(self, optimal_point, optimal_kpis, weights):
         """Notify the discovery of a new optimal point.
@@ -163,7 +172,7 @@ class BaseMCOModel(BaseModel):
             A list of weight values from 0.0 to 1.0 that have been assigned
             for this point to each KPI.
         """
-        self.notify(MCOProgressEvent(
+        self.notify(self._progress_event_type(
             optimal_point=optimal_point,
             optimal_kpis=optimal_kpis,
             weights=weights,

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import logging
+import warnings
 
 from traits.api import Instance, List, Type
 
@@ -16,6 +17,21 @@ from .i_mco_factory import IMCOFactory
 
 
 log = logging.getLogger(__name__)
+
+
+class NotifyMCOProgressWarning:
+
+    warning_message = (
+        "Use of the BaseMCOModel.notify_new_point method is now deprecated"
+        " and will be removed in version 0.5.0. Please replace any uses "
+        "of the BaseMCO.notify_new_point method with the "
+        "equivalent BaseMCOModel.notify_progress_event method."
+    )
+
+    @classmethod
+    def warn(cls):
+        log.warning(cls.warning_message)
+        warnings.warn(cls.warning_message, DeprecationWarning)
 
 
 class BaseMCOModel(BaseModel):
@@ -159,7 +175,33 @@ class BaseMCOModel(BaseModel):
         """ Creates base event indicating the finished MCO."""
         self.notify(self._finish_event_type())
 
-    def notify_new_point(self, optimal_point, optimal_kpis, **kwargs):
+    def notify_new_point(self, optimal_point, optimal_kpis, weights):
+        """Notify the discovery of a new optimal point.
+
+        Parameters
+        ----------
+        optimal_point: List(Instance(DataValue))
+            A list of DataValue objects describing the point in parameter
+            space that produces an optimised result.
+
+        optimal_kpis: List(Instance(DataValue))
+            A list of DataValue objects describing the KPI values resulting
+            from the optimal_point values above.
+
+        weights: List(Float)
+             A list of weight values from 0.0 to 1.0 that have been assigned
+             for this point to each KPI.
+        """
+        NotifyMCOProgressWarning.warn()
+        self.notify(
+            self._progress_event_type(
+                optimal_point=optimal_point,
+                optimal_kpis=optimal_kpis,
+                weights=weights,
+            )
+        )
+
+    def notify_progress_event(self, optimal_point, optimal_kpis, **kwargs):
         """Notify the discovery of a new optimal point.
 
         Parameters

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -79,7 +79,7 @@ class TestBaseMCOModel(unittest.TestCase, UnittestTools):
 
         with self.assertTraitChanges(workflow, "event", count=1):
             with self.assertTraitChanges(workflow.mco_model, "event", count=1):
-                workflow.mco_model.notify_new_point(
+                workflow.mco_model.notify_progress_event(
                     [DataValue(value=2), DataValue(value=3)],
                     [DataValue(value=4), DataValue(value=5)],
                     weights=[1.5, 1.5],

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -82,5 +82,5 @@ class TestBaseMCOModel(unittest.TestCase, UnittestTools):
                 workflow.mco_model.notify_new_point(
                     [DataValue(value=2), DataValue(value=3)],
                     [DataValue(value=4), DataValue(value=5)],
-                    [1.5, 1.5],
+                    weights=[1.5, 1.5],
                 )

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -1,7 +1,10 @@
 import unittest
+import testfixtures
+import warnings
 
 from traits.testing.api import UnittestTools
 
+from force_bdss.mco.base_mco_model import NotifyMCOProgressWarning
 from force_bdss.core.data_value import DataValue
 from force_bdss.tests.dummy_classes.factory_registry import (
     DummyFactoryRegistry,
@@ -84,3 +87,27 @@ class TestBaseMCOModel(unittest.TestCase, UnittestTools):
                     [DataValue(value=4), DataValue(value=5)],
                     weights=[1.5, 1.5],
                 )
+
+
+class TestNotifyMCOProgressWarning(unittest.TestCase):
+    """NOTE: this class should be removed alongside BaseMCO.event"""
+
+    def test_warn(self):
+
+        expected_message = (
+            "Use of the BaseMCOModel.notify_new_point method is now deprecated"
+            " and will be removed in version 0.5.0. Please replace any uses "
+            "of the BaseMCO.notify_new_point method with the "
+            "equivalent BaseMCOModel.notify_progress_event method."
+        )
+
+        expected_log = ("force_bdss.mco.base_mco_model", "WARNING", expected_message)
+
+        with testfixtures.LogCapture() as capture, warnings.catch_warnings(
+            record=True
+        ) as errors:
+
+            NotifyMCOProgressWarning.warn()
+
+            capture.check(expected_log)
+            self.assertEqual(expected_message, str(errors[0].message))

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -1,11 +1,16 @@
 import unittest
 
+from traits.testing.api import UnittestTools
+
+from force_bdss.core.data_value import DataValue
 from force_bdss.tests.dummy_classes.factory_registry import (
     DummyFactoryRegistry,
 )
+from force_bdss.tests.probe_classes.workflow_file import ProbeWorkflowFile
+from force_bdss.tests import fixtures
 
 
-class TestBaseMCOModel(unittest.TestCase):
+class TestBaseMCOModel(unittest.TestCase, UnittestTools):
     def setUp(self):
         factory_registry = DummyFactoryRegistry()
         self.mcomodel_factory = factory_registry.mco_factories[0]
@@ -15,8 +20,8 @@ class TestBaseMCOModel(unittest.TestCase):
             "parameters": [
                 {
                     "id": "force.bdss.enthought.plugin."
-                          "test.v0.factory.dummy_mco.parameter."
-                          "dummy_mco_parameter",
+                    "test.v0.factory.dummy_mco.parameter."
+                    "dummy_mco_parameter",
                     "model_data": {},
                 }
             ],
@@ -29,13 +34,13 @@ class TestBaseMCOModel(unittest.TestCase):
             mco_model.__getstate__(),
             {
                 "id": "force.bdss.enthought.plugin.test.v0."
-                      "factory.dummy_mco",
+                "factory.dummy_mco",
                 "model_data": {
                     "parameters": [
                         {
                             "id": "force.bdss.enthought.plugin."
-                                  "test.v0.factory.dummy_mco."
-                                  "parameter.dummy_mco_parameter",
+                            "test.v0.factory.dummy_mco."
+                            "parameter.dummy_mco_parameter",
                             "model_data": {"x": 0, "name": "", "type": ""},
                         }
                     ],
@@ -50,11 +55,32 @@ class TestBaseMCOModel(unittest.TestCase):
                 "parameters": [
                     {
                         "id": "force.bdss.enthought.plugin."
-                              "test.v0.factory.dummy_mco."
-                              "parameter.dummy_mco_parameter",
+                        "test.v0.factory.dummy_mco."
+                        "parameter.dummy_mco_parameter",
                         "model_data": {},
                     }
                 ],
                 "kpis": [],
             },
         )
+
+    def test_notify_events(self):
+        workflow_file = ProbeWorkflowFile(path=fixtures.get("test_probe.json"))
+        workflow_file.read()
+        workflow = workflow_file.workflow
+
+        with self.assertTraitChanges(workflow, "event", count=1):
+            with self.assertTraitChanges(workflow.mco_model, "event", count=1):
+                workflow.mco_model.notify_start_event()
+
+        with self.assertTraitChanges(workflow, "event", count=1):
+            with self.assertTraitChanges(workflow.mco_model, "event", count=1):
+                workflow.mco_model.notify_finish_event()
+
+        with self.assertTraitChanges(workflow, "event", count=1):
+            with self.assertTraitChanges(workflow.mco_model, "event", count=1):
+                workflow.mco_model.notify_new_point(
+                    [DataValue(value=2), DataValue(value=3)],
+                    [DataValue(value=4), DataValue(value=5)],
+                    [1.5, 1.5],
+                )

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -101,7 +101,11 @@ class TestNotifyMCOProgressWarning(unittest.TestCase):
             "equivalent BaseMCOModel.notify_progress_event method."
         )
 
-        expected_log = ("force_bdss.mco.base_mco_model", "WARNING", expected_message)
+        expected_log = (
+            "force_bdss.mco.base_mco_model",
+            "WARNING",
+            expected_message,
+        )
 
         with testfixtures.LogCapture() as capture, warnings.catch_warnings(
             record=True


### PR DESCRIPTION
This PR extends the changes introduced in #269 
This PR approaches #247, and [#333](https://github.com/force-h2020/force-wfmanager/issues/333) of the WorkflowManager

### Summary

We introduce `mco_events` types to the `BaseMCOModel` class. Now developers are able to specify custom start, progress, and finish events in the `MCOModel`: events of these types will be raised at runtime.

`notify_new_point` is not **deprecated**. Use `notify_progress_event` instead.

### Done
- Added `_start_event_type`, `_progress_event_type` and `_finish_event_type` to the `BaseMCOModel`:
```
    #: Type of the MCO Start event
    _start_event_type = Type(MCOStartEvent, visible=False, transient=True)
```
- Refactored the `create_event` methods of the `BaseMCOModel`: not these are called `notify_*_event` and immediately call `self.notify` method with an appropriate event.
- **API update**: `notify_progress_event ` now accepts `**kwargs` as the third parameter, instead of `weights`. This allows users and developers to propagate custom data to the `MCOProgessEvent`s. 
- `notify_new_point` is now deprecated.