### PR TITLE
MAINT: using tempfile instead of persistent `tmp.json` in tests

### DIFF
--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import tempfile
 
 from force_bdss.core.execution_layer import ExecutionLayer
 from force_bdss.core.kpi_specification import KPISpecification
@@ -46,7 +47,7 @@ class TestWorkflowWriter(unittest.TestCase):
         wfwriter = WorkflowWriter()
         workflow = self.sample_workflow()
 
-        filename = "tmp.json"
+        filename = tempfile.mktemp()
         wfwriter.write(workflow, filename)
         with open(filename) as f:
             result = json.load(f)
@@ -60,7 +61,7 @@ class TestWorkflowWriter(unittest.TestCase):
         wfwriter = WorkflowWriter()
         workflow = self.sample_workflow()
 
-        filename = "tmp.json"
+        filename = tempfile.mktemp()
         wfwriter.write(workflow, filename)
 
         wfreader = WorkflowReader(self.registry)
@@ -84,7 +85,7 @@ class TestWorkflowWriter(unittest.TestCase):
         workflow = Workflow()
         wfwriter = WorkflowWriter()
 
-        filename = "tmp.json"
+        filename = tempfile.mktemp()
         wfwriter.write(workflow, filename)
 
         wfreader = WorkflowReader(self.registry)

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -47,7 +47,8 @@ class TestWorkflowWriter(unittest.TestCase):
         wfwriter = WorkflowWriter()
         workflow = self.sample_workflow()
 
-        filename = tempfile.mktemp()
+        tmp_file = tempfile.NamedTemporaryFile()
+        filename = tmp_file.name
         wfwriter.write(workflow, filename)
         with open(filename) as f:
             result = json.load(f)
@@ -61,7 +62,8 @@ class TestWorkflowWriter(unittest.TestCase):
         wfwriter = WorkflowWriter()
         workflow = self.sample_workflow()
 
-        filename = tempfile.mktemp()
+        tmp_file = tempfile.NamedTemporaryFile()
+        filename = tmp_file.name
         wfwriter.write(workflow, filename)
 
         wfreader = WorkflowReader(self.registry)
@@ -85,7 +87,8 @@ class TestWorkflowWriter(unittest.TestCase):
         workflow = Workflow()
         wfwriter = WorkflowWriter()
 
-        filename = tempfile.mktemp()
+        tmp_file = tempfile.NamedTemporaryFile()
+        filename = tmp_file.name
         wfwriter.write(workflow, filename)
 
         wfreader = WorkflowReader(self.registry)


### PR DESCRIPTION
### Summary

This small PR uses `tempfile` module to create temporary workflow json files for tests, instead of a creating an annoyingly persistent `tmp.json` in the project folder.

### Done

- Use `tempfile` in tests and removed `tmp.json` from project folder. 