### PR TITLE
MAINT: Port BaseDriverEvent (de)serialization from wfmanager

### DIFF
--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -39,6 +39,13 @@ class BaseDriverEvent(HasStrictTraits):
         return state
 
     def dumps_json(self):
+        """ Returns the state of the BaseDriverEvent subclass instance,
+        serialized to a json-formatted string.
+
+        Returns
+        ----------
+        JSON-formatted string
+        """
         return json.dumps(self.__getstate__())
 
     @staticmethod
@@ -132,6 +139,14 @@ class BaseDriverEvent(HasStrictTraits):
 
     @classmethod
     def loads_json(cls, data):
+        """ Create a BaseDriverEvent subclass object from a json loadable
+        `data` object.
+
+        Parameters
+        ----------
+        data: `str`, `bytes` or `bytearray`
+            An object to be json.loads-ed and passed to class constructor
+        """
         try:
             json_data = json.loads(data)
         except json.JSONDecodeError as e:

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -1,5 +1,6 @@
-import importlib
 from copy import deepcopy
+import importlib
+import json
 
 from traits.api import (
     HasStrictTraits,
@@ -36,6 +37,9 @@ class BaseDriverEvent(HasStrictTraits):
         id = ".".join((self.__class__.__module__, self.__class__.__name__))
         state = {"model_data": state, "id": id}
         return state
+
+    def dumps_json(self):
+        return json.dumps(self.__getstate__())
 
     @staticmethod
     def get_event_class(id_string):
@@ -117,6 +121,10 @@ class BaseDriverEvent(HasStrictTraits):
                 raise DriverEventDeserializationError(error_message)
 
         return event
+
+    @classmethod
+    def loads_json(cls, data):
+        return cls.from_json(json.loads(data))
 
 
 class MCOStartEvent(BaseDriverEvent):

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -107,9 +107,11 @@ class BaseDriverEvent(HasStrictTraits):
         """
         try:
             class_id = json_data["id"]
-        except Exception as e:
+        except KeyError as e:
             raise DriverEventDeserializationError(
-                "Could not parse json data: {}".format(e)
+                f"Could not parse json data. "
+                f"The `json_data` argument should contain the"
+                f"class id key {e}."
             )
         klass = cls.get_event_class(class_id)
         try:

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -13,6 +13,8 @@ class BaseDriverEvent(HasStrictTraits):
         """
         state = pop_dunder_recursive(super().__getstate__())
         state = nested_getstate(state)
+        id = ".".join((self.__class__.__module__, self.__class__.__name__))
+        state = {"model_data": state, "id": id}
         return state
 
 

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -130,7 +130,13 @@ class BaseDriverEvent(HasStrictTraits):
 
     @classmethod
     def loads_json(cls, data):
-        json_data = json.loads(data)
+        try:
+            json_data = json.loads(data)
+        except json.JSONDecodeError as e:
+            raise DriverEventDeserializationError(
+                f"Data object {data} is not compatible "
+                f"with the json.loads method and raises {e}"
+            )
         return cls.from_json(json_data)
 
 

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -108,7 +108,12 @@ class BaseDriverEvent(HasStrictTraits):
             try:
                 event = klass.from_json(json_data["model_data"])
             except Exception:
-                error_message = ""
+                error_message = (
+                    f"Unable to instantiate a {klass} instance "
+                    f"with data {json_data['model_data']}: the "
+                    f"`__init__` and `from_json` methods failed "
+                    f"to create an instance."
+                )
                 raise DriverEventDeserializationError(error_message)
 
         return event

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -105,7 +105,13 @@ class BaseDriverEvent(HasStrictTraits):
             BaseDriverEvent or a subclass of BaseDriverEvent instance
             with attributes values from the `json_data` dict
         """
-        klass = cls.get_event_class(json_data["id"])
+        try:
+            class_id = json_data["id"]
+        except Exception as e:
+            raise DriverEventDeserializationError(
+                "Could not parse json data: {}".format(e)
+            )
+        klass = cls.get_event_class(class_id)
         try:
             event = klass(**json_data["model_data"])
         except TraitError:
@@ -124,7 +130,8 @@ class BaseDriverEvent(HasStrictTraits):
 
     @classmethod
     def loads_json(cls, data):
-        return cls.from_json(json.loads(data))
+        json_data = json.loads(data)
+        return cls.from_json(json_data)
 
 
 class MCOStartEvent(BaseDriverEvent):

--- a/force_bdss/core_driver_events.py
+++ b/force_bdss/core_driver_events.py
@@ -26,6 +26,26 @@ class BaseDriverEvent(HasStrictTraits):
 
     @staticmethod
     def get_event_class(id_string):
+        """Retrieve the class object from the id_string
+
+        Parameters
+        ----------
+        id_string: str
+            The string containing the path to the class definition.
+
+        Returns
+        -------
+        cls: BaseDriverEvent subclass
+
+        Raises
+        ------
+        ImportError
+            If the path from the `id_string` is an incorrect
+             reference
+        DriverEventTypeError
+            If the class from the `id_string` is not a subclass of
+            BaseDriverEvent
+        """
         class_module, class_name = id_string.rsplit(".", 1)
         module = importlib.import_module(class_module)
         try:
@@ -44,9 +64,26 @@ class BaseDriverEvent(HasStrictTraits):
         return cls
 
     @classmethod
-    def from_json(cls, data):
-        klass = cls.get_event_class(data["id"])
-        return klass(**data["model_data"])
+    def from_json(cls, json_data):
+        """ Instantiate a BaseDriverEvent object from a `json_data`
+        dictionary and the generating `factory_registry`.
+        If the `json_data` is an empty dict, the `data_sources`
+        attribute will be an empty list.
+
+        Parameters
+        ----------
+        json_data: dict
+            Dictionary with an execution layer serialized data
+
+        Returns
+        ----------
+        event: BaseDriverEvent
+            BaseDriverEvent or a subclass of BaseDriverEvent instance
+            with attributes values from the `json_data` dict
+        """
+        klass = cls.get_event_class(json_data["id"])
+        event = klass(**json_data["model_data"])
+        return event
 
 
 class MCOStartEvent(BaseDriverEvent):

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -28,31 +28,34 @@ class TestCoreDriverEvents(unittest.TestCase):
         self.assertEqual(
             ev.__getstate__(),
             {
-                "optimal_kpis": [
-                    {
-                        "accuracy": None,
-                        "name": "",
-                        "quality": "AVERAGE",
-                        "type": "",
-                        "value": 10,
-                    }
-                ],
-                "optimal_point": [
-                    {
-                        "accuracy": None,
-                        "name": "",
-                        "quality": "AVERAGE",
-                        "type": "",
-                        "value": 12,
-                    },
-                    {
-                        "accuracy": None,
-                        "name": "",
-                        "quality": "AVERAGE",
-                        "type": "",
-                        "value": 13,
-                    },
-                ],
+                "id": "force_bdss.core_driver_events.MCOProgressEvent",
+                "model_data": {
+                    "optimal_kpis": [
+                        {
+                            "accuracy": None,
+                            "name": "",
+                            "quality": "AVERAGE",
+                            "type": "",
+                            "value": 10,
+                        }
+                    ],
+                    "optimal_point": [
+                        {
+                            "accuracy": None,
+                            "name": "",
+                            "quality": "AVERAGE",
+                            "type": "",
+                            "value": 12,
+                        },
+                        {
+                            "accuracy": None,
+                            "name": "",
+                            "quality": "AVERAGE",
+                            "type": "",
+                            "value": 13,
+                        },
+                    ],
+                },
             },
         )
 
@@ -62,28 +65,49 @@ class TestCoreDriverEvents(unittest.TestCase):
         )
         self.assertDictEqual(
             event.__getstate__(),
-            {"parameter_names": ["p1", "p2"], "kpi_names": ["k1", "k2", "k3"]},
+            {
+                "model_data": {
+                    "parameter_names": ["p1", "p2"],
+                    "kpi_names": ["k1", "k2", "k3"],
+                },
+                "id": "force_bdss.core_driver_events.MCOStartEvent",
+            },
         )
 
     def test_getstate_finish_event(self):
         event = MCOFinishEvent()
-        self.assertFalse(event.__getstate__())
+        self.assertDictEqual(
+            event.__getstate__(),
+            {
+                "model_data": {},
+                "id": "force_bdss.core_driver_events.MCOFinishEvent",
+            },
+        )
 
     def test_getstate_base_event(self):
         event = BaseDriverEvent()
-        self.assertFalse(event.__getstate__())
+        self.assertDictEqual(
+            event.__getstate__(),
+            {
+                "id": "force_bdss.core_driver_events.BaseDriverEvent",
+                "model_data": {},
+            },
+        )
 
         event = DummyEvent(stateful_data=DataValue(value=1))
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "stateless_data": 1,
-                "stateful_data": {
-                    "accuracy": None,
-                    "name": "",
-                    "quality": "AVERAGE",
-                    "type": "",
-                    "value": 1,
+                "id": "force_bdss.tests.test_core_driver_events.DummyEvent",
+                "model_data": {
+                    "stateless_data": 1,
+                    "stateful_data": {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 1,
+                    },
                 },
             },
         )

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -279,3 +279,22 @@ class TestCoreDriverEvents(unittest.TestCase):
         progress_event = BaseDriverEvent.from_json(progress_data)
         self.assertIsInstance(progress_event, MCOProgressEvent)
         self.assertDictEqual(progress_event.__getstate__(), progress_data)
+
+        failed_data = {
+            "id": "force_bdss.core_driver_events.MCOProgressEvent",
+            "model_data": {
+                "optimal_kpis": [{"random_trait": "some data"}],
+                "optimal_point": [],
+            },
+        }
+        with self.assertRaisesRegex(
+            Exception,
+            r"Unable to instantiate a \<class "
+            r"'force_bdss.core_driver_events.MCOProgressEvent'\> "
+            r"instance with data "
+            r"\{'optimal_kpis': \[\{'random_trait': 'some data'\}\],"
+            r" 'optimal_point': \[\]}"
+            r": the `__init__` and `from_json` "
+            r"methods failed to create an instance.",
+        ):
+            BaseDriverEvent.from_json(failed_data)

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -10,6 +10,7 @@ from force_bdss.core_driver_events import (
     WeightedMCOStartEvent,
     MCOFinishEvent,
     BaseDriverEvent,
+    DriverEventTypeError,
 )
 
 
@@ -170,3 +171,49 @@ class TestCoreDriverEvents(unittest.TestCase):
         self.assertEqual(len(event.optimal_kpis), len(event.weights))
         self.assertListEqual(event.weights, [])
         self.assertEqual(event.serialize(), [12, 13])
+
+    def test_get_event_class(self):
+        data = {
+            "id": "force_bdss.core_driver_events.BaseDriverEvent",
+            "model_data": {},
+        }
+        klass = BaseDriverEvent.get_event_class(data["id"])
+        self.assertIs(klass, BaseDriverEvent)
+
+        data = {
+            "id": "force_bdss.core_driver_events.MCOProgressEvent",
+            "model_data": {},
+        }
+        klass = BaseDriverEvent.get_event_class(data["id"])
+        self.assertIs(klass, MCOProgressEvent)
+
+        data = {
+            "id": "force_bdss.core_driver_events.MCOStartEvent",
+            "model_data": {},
+        }
+        klass = BaseDriverEvent.get_event_class(data["id"])
+        self.assertIs(klass, MCOStartEvent)
+
+        data = {
+            "id": "force_bdss.core_driver_events.MCOFinishEvent",
+            "model_data": {},
+        }
+        klass = BaseDriverEvent.get_event_class(data["id"])
+        self.assertIs(klass, MCOFinishEvent)
+
+        data = {"id": "force_bdss.mco.base_mco.BaseMCO", "model_data": {}}
+        error_message = (
+            "Class <class 'force_bdss.mco.base_mco.BaseMCO'> "
+            "must be a subclass of BaseDriverEvent"
+        )
+        with self.assertRaisesRegex(DriverEventTypeError, error_message):
+            BaseDriverEvent.get_event_class(data["id"])
+
+        data = {"id": "force_bdss.mco.base_mco.RandomClass", "model_data": {}}
+        with self.assertRaisesRegex(
+            ImportError,
+            "Unable to locate the class definition RandomClass in module "
+            "<.*> "
+            f"requested by the event with id {data['id']}",
+        ):
+            BaseDriverEvent.get_event_class(data["id"])

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -228,12 +228,12 @@ class TestCoreDriverEvents(unittest.TestCase):
         self.assertDictEqual(event.__getstate__(), data)
 
         start_data = {
-                "model_data": {
-                    "parameter_names": ["p1", "p2"],
-                    "kpi_names": ["k1", "k2", "k3"],
-                },
-                "id": "force_bdss.core_driver_events.MCOStartEvent",
-            }
+            "model_data": {
+                "parameter_names": ["p1", "p2"],
+                "kpi_names": ["k1", "k2", "k3"],
+            },
+            "id": "force_bdss.core_driver_events.MCOStartEvent",
+        }
         start_event = BaseDriverEvent.from_json(start_data)
         self.assertIsInstance(start_event, MCOStartEvent)
         self.assertDictEqual(start_event.__getstate__(), start_data)
@@ -245,3 +245,37 @@ class TestCoreDriverEvents(unittest.TestCase):
         finish_event = BaseDriverEvent.from_json(finish_data)
         self.assertIsInstance(finish_event, MCOFinishEvent)
         self.assertDictEqual(finish_event.__getstate__(), finish_data)
+
+        progress_data = {
+            "id": "force_bdss.core_driver_events.MCOProgressEvent",
+            "model_data": {
+                "optimal_kpis": [
+                    {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 10,
+                    }
+                ],
+                "optimal_point": [
+                    {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 12,
+                    },
+                    {
+                        "accuracy": None,
+                        "name": "",
+                        "quality": "AVERAGE",
+                        "type": "",
+                        "value": 13,
+                    },
+                ],
+            },
+        }
+        progress_event = BaseDriverEvent.from_json(progress_data)
+        self.assertIsInstance(progress_event, MCOProgressEvent)
+        self.assertDictEqual(progress_event.__getstate__(), progress_data)

--- a/force_bdss/tests/test_core_driver_events.py
+++ b/force_bdss/tests/test_core_driver_events.py
@@ -217,3 +217,31 @@ class TestCoreDriverEvents(unittest.TestCase):
             f"requested by the event with id {data['id']}",
         ):
             BaseDriverEvent.get_event_class(data["id"])
+
+    def test_from_json(self):
+        data = {
+            "id": "force_bdss.core_driver_events.BaseDriverEvent",
+            "model_data": {},
+        }
+        event = BaseDriverEvent.from_json(data)
+        self.assertIsInstance(event, BaseDriverEvent)
+        self.assertDictEqual(event.__getstate__(), data)
+
+        start_data = {
+                "model_data": {
+                    "parameter_names": ["p1", "p2"],
+                    "kpi_names": ["k1", "k2", "k3"],
+                },
+                "id": "force_bdss.core_driver_events.MCOStartEvent",
+            }
+        start_event = BaseDriverEvent.from_json(start_data)
+        self.assertIsInstance(start_event, MCOStartEvent)
+        self.assertDictEqual(start_event.__getstate__(), start_data)
+
+        finish_data = {
+            "id": "force_bdss.core_driver_events.MCOFinishEvent",
+            "model_data": {},
+        }
+        finish_event = BaseDriverEvent.from_json(finish_data)
+        self.assertIsInstance(finish_event, MCOFinishEvent)
+        self.assertDictEqual(finish_event.__getstate__(), finish_data)


### PR DESCRIPTION
This PR approaches [#343](https://github.com/force-h2020/force-wfmanager/issues/343) and partially #248 

### Summary

We attempt to implement `BaseDriverEvent` serialization and deserialization methods, such that these can be removed from the WorkflowManager.

### Done

- `BaseDriverEvent.__getstate__` now has similar signature as the `BaseModel.__getstate__`: it contains an `id` and `model_data` fields. 
- Added base class methods `get_event_class`, `from_json`: given a data in an appropriate 
dictionary format, we are able to create basic `BaseDriverEvent` instances with specified class.