### PR TITLE
FIX: Included missing Exception types in API

### DIFF
--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -21,7 +21,7 @@ from .data_sources.base_data_source_factory import BaseDataSourceFactory  # noqa
 from .data_sources.i_data_source_factory import IDataSourceFactory  # noqa
 
 from .events.mco_events import *  # noqa
-from .events.base_driver_event import BaseDriverEvent # noqa
+from .events.base_driver_event import BaseDriverEvent, DriverEventDeserializationError, DriverEventTypeError # noqa
 
 from .io.base_csv_writer import BaseCSVWriterFactory, BaseCSVWriterModel, BaseCSVWriter  # noqa
 from .io.workflow_reader import WorkflowReader  # noqa


### PR DESCRIPTION
The `DriverEventDeserializationError` and `DriverEventTypeError` are required to be imported from the `force_bdss.api` module by `force_wfmanager`