### PR TITLE
WIP: FEAT: FileTreeBuilder class ported from force_gromacs

### DIFF
--- a/force_bdss/io/file_tree_builder.py
+++ b/force_bdss/io/file_tree_builder.py
@@ -14,7 +14,7 @@ class FileTreeBuilder(HasStrictTraits):
 
     #: Location to create file tree in. (By default, the
     #: current working directory)
-    directory = Directory()
+    root = Directory()
 
     # --------------------
     #  Private Attributes
@@ -24,9 +24,7 @@ class FileTreeBuilder(HasStrictTraits):
     _file_tree = Dict(Directory, Dict)
 
     def __file_tree_default(self):
-        return collections.OrderedDict({
-            self.directory: {}
-        })
+        return collections.OrderedDict()
 
     # --------------------
     #   Private Methods
@@ -42,7 +40,8 @@ class FileTreeBuilder(HasStrictTraits):
         return each directory that needs to be created in
         an appropriate order."""
         directory_list = [
-            path for path in path_generator(self._file_tree)
+            path for path in path_generator(
+                self._file_tree, self.root)
         ]
         return directory_list
     # --------------------
@@ -54,9 +53,9 @@ class FileTreeBuilder(HasStrictTraits):
         edit an existing paths"""
 
         directories = path.split('/')
-        directory = self._file_tree[directories[0]]
+        directory = self._file_tree
 
-        for folder in directories[1:]:
+        for folder in directories:
             if folder not in directory:
                 directory[folder] = {}
             directory = directory[folder]

--- a/force_bdss/io/file_tree_builder.py
+++ b/force_bdss/io/file_tree_builder.py
@@ -39,7 +39,8 @@ class FileTreeBuilder(HasStrictTraits):
         """Iterate through each branch in file tree and
         return each directory that needs to be created in
         an appropriate order."""
-        directory_list = [
+        directory_list = [self.root]
+        directory_list += [
             path for path in path_generator(
                 self._file_tree, self.root)
         ]

--- a/force_bdss/io/file_tree_builder.py
+++ b/force_bdss/io/file_tree_builder.py
@@ -1,0 +1,80 @@
+import logging
+import os
+import collections
+
+from traits.api import HasStrictTraits, Dict, Directory
+
+from force_bdss.utilities import path_generator
+
+log = logging.getLogger(__name__)
+
+
+class FileTreeBuilder(HasStrictTraits):
+    """Class builds nested file trees"""
+
+    #: Location to create file tree in. (By default, the
+    #: current working directory)
+    directory = Directory()
+
+    # --------------------
+    #  Private Attributes
+    # --------------------
+
+    #: Ordered dictionary to hold nested directories
+    _file_tree = Dict(Directory, Dict)
+
+    def __file_tree_default(self):
+        return collections.OrderedDict({
+            self.directory: {}
+        })
+
+    # --------------------
+    #   Private Methods
+    # --------------------
+
+    def _make_directory(self, directory):
+        """Creates new directory if path does not already exist"""
+        if not os.path.exists(directory):
+            os.mkdir(directory)
+
+    def _create_directory_list(self):
+        """Iterate through each branch in file tree and
+        return each directory that needs to be created in
+        an appropriate order."""
+        directory_list = [
+            path for path in path_generator(self._file_tree)
+        ]
+        return directory_list
+    # --------------------
+    #    Public Methods
+    # --------------------
+
+    def add_path(self, path):
+        """Iteratively add a single path to file tree. Do not
+        edit an existing paths"""
+
+        directories = path.split('/')
+        directory = self._file_tree[directories[0]]
+
+        for folder in directories[1:]:
+            if folder not in directory:
+                directory[folder] = {}
+            directory = directory[folder]
+
+        return directory
+
+    def add_folders(self, path, folders):
+        """Add a directory with a list of folders to the
+        file tree. Do not edit an existing folder"""
+
+        directory = self.add_path(path)
+
+        for folder in folders:
+            if folder not in directory:
+                directory[folder] = {}
+
+    def build_file_tree(self):
+        """Builds the file tree"""
+        directory_list = self._create_directory_list()
+        for directory in directory_list:
+            self._make_directory(directory)

--- a/force_bdss/io/tests/test_file_tree_builder.py
+++ b/force_bdss/io/tests/test_file_tree_builder.py
@@ -1,0 +1,147 @@
+from unittest import TestCase, mock
+
+from force_bdss.io.file_tree_builder import (
+    FileTreeBuilder
+)
+
+FILE_TREE_MKPATH = (
+    "force_bdss.io.file_tree_builder.os.mkdir"
+)
+
+
+def mock_empty(value):
+    return None
+
+
+class TestFileTreeBuilder(TestCase):
+
+    def setUp(self):
+
+        self.builder = FileTreeBuilder(
+            directory='test_experiment_1'
+        )
+
+    def test_add_path(self):
+
+        self.assertDictEqual(
+            {'test_experiment_1': {}},
+            self.builder._file_tree
+        )
+
+        self.builder.add_path("test_experiment_1/new_folder")
+
+        self.assertDictEqual(
+            {
+                'test_experiment_1': {
+                    'new_folder': {}
+                }
+            },
+            self.builder._file_tree
+        )
+
+        # Test name nested folder name redundancy
+        self.builder.add_path(
+            "test_experiment_1/another_folder/nested_1/nested_1")
+
+        self.assertDictEqual(
+            {
+                'test_experiment_1': {
+                    'new_folder': {},
+                    'another_folder': {
+                        'nested_1': {
+                            'nested_1': {}
+                        }
+                    }
+                }
+            },
+            self.builder._file_tree
+        )
+
+    def test_add_folders(self):
+
+        self.builder.add_folders(
+            "test_experiment_1/new_folder", ["folder 1", "folder 2"]
+        )
+
+        self.assertDictEqual(
+            {
+                'test_experiment_1': {
+                    'new_folder': {
+                        "folder 1": {},
+                        "folder 2": {}
+                    }
+                }
+            },
+            self.builder._file_tree
+        )
+
+        # Test previously created folders are not overwritten
+        self.builder.add_path(
+            "test_experiment_1/new_folder/folder 2/new_folder")
+        self.builder.add_folders(
+            "test_experiment_1/new_folder",
+            ["folder 2", "folder 3"]
+        )
+        self.assertDictEqual(
+            {
+                'test_experiment_1': {
+                    'new_folder': {
+                        "folder 1": {},
+                        "folder 2": {
+                            "new_folder": {}
+                        },
+                        "folder 3": {}
+                    }
+                }
+            },
+            self.builder._file_tree
+        )
+
+    def test__make_directory(self):
+        with mock.patch(FILE_TREE_MKPATH) as mock_mkdir:
+            mock_mkdir.side_effect = mock_empty
+            self.builder._make_directory('')
+            mock_mkdir.assert_called()
+
+    def test__create_directory_list(self):
+        self.builder._file_tree = {
+            'test_experiment_1': {
+                '1_build': {},
+                '2_minimize': {},
+                '3_production': {},
+            }
+        }
+        directory_list = self.builder._create_directory_list()
+        self.assertListEqual(
+            ['test_experiment_1',
+             'test_experiment_1/1_build',
+             'test_experiment_1/2_minimize',
+             'test_experiment_1/3_production'],
+            directory_list
+        )
+
+        (self.builder._file_tree['test_experiment_1']
+         ['1_build']['1_nested_folder']) = {}
+
+        directory_list = self.builder._create_directory_list()
+        self.assertListEqual(
+            ['test_experiment_1',
+             'test_experiment_1/1_build',
+             'test_experiment_1/1_build/1_nested_folder',
+             'test_experiment_1/2_minimize',
+             'test_experiment_1/3_production'],
+            directory_list
+        )
+
+    def test_build_file_tree(self):
+        self.builder._file_tree = {
+            'test_experiment_1': {
+                '1_build': {},
+                '2_minimize': {},
+                '3_production': {},
+            }
+        }
+        with mock.patch(FILE_TREE_MKPATH) as mock_mkdir:
+            mock_mkdir.side_effect = mock_empty
+            self.builder.build_file_tree()
+            self.assertEqual(4, mock_mkdir.call_count)

--- a/force_bdss/io/tests/test_file_tree_builder.py
+++ b/force_bdss/io/tests/test_file_tree_builder.py
@@ -1,3 +1,4 @@
+from tempfile import NamedTemporaryFile
 from unittest import TestCase, mock
 
 from force_bdss.io.file_tree_builder import (
@@ -94,6 +95,12 @@ class TestFileTreeBuilder(TestCase):
         )
 
     def test__make_directory(self):
+
+        with mock.patch(FILE_TREE_MKPATH) as mock_mkdir:
+            with NamedTemporaryFile() as tmp_file:
+                self.builder._make_directory(tmp_file.name)
+            mock_mkdir.assert_not_called()
+
         with mock.patch(FILE_TREE_MKPATH) as mock_mkdir:
             mock_mkdir.side_effect = mock_empty
             self.builder._make_directory('')

--- a/force_bdss/io/tests/test_file_tree_builder.py
+++ b/force_bdss/io/tests/test_file_tree_builder.py
@@ -18,16 +18,12 @@ class TestFileTreeBuilder(TestCase):
     def setUp(self):
 
         self.builder = FileTreeBuilder(
-            directory='test_experiment_1'
+            root='test_experiment_1'
         )
 
     def test_add_path(self):
 
-        self.assertDictEqual(
-            {'test_experiment_1': {}},
-            self.builder._file_tree
-        )
-
+        self.assertDictEqual({}, self.builder._file_tree)
         self.builder.add_path("test_experiment_1/new_folder")
 
         self.assertDictEqual(
@@ -105,11 +101,9 @@ class TestFileTreeBuilder(TestCase):
 
     def test__create_directory_list(self):
         self.builder._file_tree = {
-            'test_experiment_1': {
-                '1_build': {},
-                '2_minimize': {},
-                '3_production': {},
-            }
+            '1_build': {},
+            '2_minimize': {},
+            '3_production': {}
         }
         directory_list = self.builder._create_directory_list()
         self.assertListEqual(

--- a/force_bdss/io/tests/test_file_tree_builder.py
+++ b/force_bdss/io/tests/test_file_tree_builder.py
@@ -106,6 +106,7 @@ class TestFileTreeBuilder(TestCase):
             '3_production': {}
         }
         directory_list = self.builder._create_directory_list()
+        print(directory_list)
         self.assertListEqual(
             ['test_experiment_1',
              'test_experiment_1/1_build',
@@ -114,8 +115,7 @@ class TestFileTreeBuilder(TestCase):
             directory_list
         )
 
-        (self.builder._file_tree['test_experiment_1']
-         ['1_build']['1_nested_folder']) = {}
+        self.builder._file_tree['1_build']['1_nested_folder'] = {}
 
         directory_list = self.builder._create_directory_list()
         self.assertListEqual(
@@ -129,11 +129,9 @@ class TestFileTreeBuilder(TestCase):
 
     def test_build_file_tree(self):
         self.builder._file_tree = {
-            'test_experiment_1': {
-                '1_build': {},
-                '2_minimize': {},
-                '3_production': {},
-            }
+            '1_build': {},
+            '2_minimize': {},
+            '3_production': {},
         }
         with mock.patch(FILE_TREE_MKPATH) as mock_mkdir:
             mock_mkdir.side_effect = mock_empty

--- a/force_bdss/tests/test_utilities.py
+++ b/force_bdss/tests/test_utilities.py
@@ -14,10 +14,11 @@ class TestDictUtils(unittest.TestCase):
         nested_dict = {
             'first': {
                 'second_1': {
-                    'third_1': {}
+                    'third': {}
                 },
                 'second_2': {
-                    'third_2': {}
+                    'third': {},
+                    'not_a_dict': []
                 }
             }
         }
@@ -27,8 +28,8 @@ class TestDictUtils(unittest.TestCase):
         ]
 
         self.assertListEqual(
-            ['first', 'first/second_1', 'first/second_1/third_1',
-             'first/second_2', 'first/second_2/third_2'],
+            ['first', 'first/second_1', 'first/second_1/third',
+             'first/second_2', 'first/second_2/third'],
             paths
         )
 
@@ -38,8 +39,8 @@ class TestDictUtils(unittest.TestCase):
 
         self.assertListEqual(
             ['root/first', 'root/first/second_1',
-             'root/first/second_1/third_1',
-             'root/first/second_2', 'root/first/second_2/third_2'],
+             'root/first/second_1/third',
+             'root/first/second_2', 'root/first/second_2/third'],
             paths
         )
 

--- a/force_bdss/tests/test_utilities.py
+++ b/force_bdss/tests/test_utilities.py
@@ -1,9 +1,48 @@
 import unittest
 
-from force_bdss.utilities import pop_dunder_recursive, pop_recursive
+from force_bdss.utilities import (
+    pop_dunder_recursive,
+    pop_recursive,
+    path_generator
+)
 
 
 class TestDictUtils(unittest.TestCase):
+
+    def test_path_generator(self):
+
+        nested_dict = {
+            'first': {
+                'second_1': {
+                    'third_1': {}
+                },
+                'second_2': {
+                    'third_2': {}
+                }
+            }
+        }
+
+        paths = [
+            key for key in path_generator(nested_dict)
+        ]
+
+        self.assertListEqual(
+            ['first', 'first/second_1', 'first/second_1/third_1',
+             'first/second_2', 'first/second_2/third_2'],
+            paths
+        )
+
+        paths = [
+            key for key in path_generator(nested_dict, 'root')
+        ]
+
+        self.assertListEqual(
+            ['root/first', 'root/first/second_1',
+             'root/first/second_1/third_1',
+             'root/first/second_2', 'root/first/second_2/third_2'],
+            paths
+        )
+
     def test_dunder_recursive(self):
         test_dict = {
             "__traits_version__": "4.6.0",

--- a/force_bdss/utilities.py
+++ b/force_bdss/utilities.py
@@ -1,3 +1,24 @@
+import os
+
+
+def path_generator(dictionary, path=None):
+    """Recursively iterate over a nested dictionary to
+    yield each key as a path from the top of the branch"""
+
+    if path is None:
+        path = ""
+
+    for key, value in dictionary.items():
+        # Yield current path
+        yield os.path.join(path, key)
+
+        # Continue to iterate down a nested dict
+        if isinstance(value, dict):
+            yield from path_generator(
+                value, os.path.join(path, key)
+            )
+
+
 def pop_recursive(dictionary, remove_key):
     """Recursively remove a named key from dictionary and any contained
     dictionaries."""

--- a/force_bdss/utilities.py
+++ b/force_bdss/utilities.py
@@ -9,11 +9,13 @@ def path_generator(dictionary, path=None):
         path = ""
 
     for key, value in dictionary.items():
-        # Yield current path
-        yield os.path.join(path, key)
-
-        # Continue to iterate down a nested dict
+        # Only continue to iterate down a nested dict
         if isinstance(value, dict):
+
+            # Yield current path
+            yield os.path.join(path, key)
+
+            # Recursively yield all nested dicts
             yield from path_generator(
                 value, os.path.join(path, key)
             )


### PR DESCRIPTION
This PR ports and extends the useful `FileTreeBuilder` class from `force_gromacs` repo.

It can be used to create a nested set of directories in a file system, multiple layers deep. An extra function is included in the `force_bdss.utilities` module to recursively search through a set of nested dictionaries and report back generated file paths.

### Example:

The file tree

```
root
├── folder_1
│   └── folder_1.1
└── folder_2
    ├── folder_2.1
    └── folder_2.2
    |   └── folder_2.2.1
    └── folder_2.3
```

Would be represented by the following `FileTreeBuilder` instance:

``` python
FileTreeBuilder(
       root='root',
       _file_tree={
           'folder_1': {
               'folder_1.1': {}
           },  
           'folder_2': {
              'folder_2.1': {},
              'folder_2.2': {
                  'folder_2.2.1': {}
              },
             'folder_2.3': {},
          }
     }
)
```
In general, the `_file_tree` attribute would not be passed as an argument, but can be constructed using the `FileTreeBuilder.add_path` and `FileTreeBuilder.add_folders` methods.

A possible set of calls to create this `_file_tree` attribute dictionary as shown above could be :

``` python
file_buildler = FileTreeBuilder(root='root')
file_builder.add_path('folder_1/folder_1.1')
file_builder.add_path('folder_2/folder_2.2/folder_2.2.1')
file_builder.add_folders('folder_2', ['folder_2.1', 'folder_2.3'])
```

After constructing the file tree, this can be built in the file system using

```python
file_builder.build_file_tree()
```

This is performed safely - no existing folders or directories will be overwritten