### PR TITLE
ENH: added explicit dict type case for nested getstate

### DIFF
--- a/force_bdss/tests/test_utilities.py
+++ b/force_bdss/tests/test_utilities.py
@@ -58,14 +58,14 @@ class TestDictUtils(unittest.TestCase):
         class Foo(HasTraits):
             string = Str("abc")
             int_list = List(Int())
-            dictionary = Dict(key_trait=Str(), value_trait=Int())
+            dictionary = Dict(key_trait=Str(), value_trait=List(Int()))
 
-        f = Foo(int_list=[1, 2, 3], dictionary={"a": 1, "b": 2})
+        f = Foo(int_list=[1, 2, 3], dictionary={"a": [1], "b": [2, 3]})
         state = pop_dunder_recursive(f.__getstate__())
         self.assertDictEqual(
             nested_getstate(state),
             {
-                "dictionary": {"a": 1, "b": 2},
+                "dictionary": {"a": [1], "b": [2, 3]},
                 "int_list": [1, 2, 3],
                 "string": "abc",
             },

--- a/force_bdss/tests/test_utilities.py
+++ b/force_bdss/tests/test_utilities.py
@@ -1,6 +1,12 @@
 import unittest
 
-from force_bdss.utilities import pop_dunder_recursive, pop_recursive
+from traits.api import HasTraits, List, Str, Int, Dict
+
+from force_bdss.utilities import (
+    pop_dunder_recursive,
+    pop_recursive,
+    nested_getstate,
+)
 
 
 class TestDictUtils(unittest.TestCase):
@@ -46,4 +52,21 @@ class TestDictUtils(unittest.TestCase):
         missing_key = "another_key"
         self.assertDictEqual(
             pop_recursive(small_dict, missing_key), small_dict
+        )
+
+    def test_nested_getstate(self):
+        class Foo(HasTraits):
+            string = Str("abc")
+            int_list = List(Int())
+            dictionary = Dict(key_trait=Str(), value_trait=Int())
+
+        f = Foo(int_list=[1, 2, 3], dictionary={"a": 1, "b": 2})
+        state = pop_dunder_recursive(f.__getstate__())
+        self.assertDictEqual(
+            nested_getstate(state),
+            {
+                "dictionary": {"a": 1, "b": 2},
+                "int_list": [1, 2, 3],
+                "string": "abc",
+            },
         )

--- a/force_bdss/utilities.py
+++ b/force_bdss/utilities.py
@@ -52,10 +52,7 @@ def nested_getstate(state_dict):
             if isinstance(state_dict[key], (tuple, list)):
                 state_dict[key] = [el.__getstate__() for el in state_dict[key]]
             elif isinstance(state_dict[key], dict):
-                for element in state_dict[key]:
-                    state_dict[key][element] = state_dict[key][
-                        element
-                    ].__getstate__()
+                continue
             else:
                 state_dict[key] = state_dict[key].__getstate__()
         except AttributeError:

--- a/force_bdss/utilities.py
+++ b/force_bdss/utilities.py
@@ -51,6 +51,11 @@ def nested_getstate(state_dict):
         try:
             if isinstance(state_dict[key], (tuple, list)):
                 state_dict[key] = [el.__getstate__() for el in state_dict[key]]
+            elif isinstance(state_dict[key], dict):
+                for element in state_dict[key]:
+                    state_dict[key][element] = state_dict[key][
+                        element
+                    ].__getstate__()
             else:
                 state_dict[key] = state_dict[key].__getstate__()
         except AttributeError:


### PR DESCRIPTION
This PR approaches #283 

### Summary

We add explicit treatment of `dict` type parsing in the `nested_getstate` function. Now, instead of using the built-it Traits `__getstate__` method of `Dict` (which doesn't return the `Dict`'s data but rather the traits representation of that `Dict`), we retain the top-level Traits `__getstate__`.

### Done

- Added extra case to `nested_getstate`:
```
 elif isinstance(state_dict[key], dict):
     continue
```
- Added simple tests to verify that the `Dict` trait is parsed correctly.