### PR TITLE
DEV: Vector MCO parameter

### DIFF
--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -39,8 +39,8 @@ from .mco.i_evaluator import IEvaluator  # noqa
 from .mco.i_mco_factory import IMCOFactory  # noqa
 from .mco.parameters.base_mco_parameter_factory import BaseMCOParameterFactory  # noqa
 from .mco.parameters.base_mco_parameter import BaseMCOParameter  # noqa
-from .mco.parameters.mco_parameters import FixedMCOParameterFactory, RangedMCOParameterFactory, ListedMCOParameterFactory, CategoricalMCOParameterFactory  # noqa
-from .mco.parameters.mco_parameters import FixedMCOParameter, RangedMCOParameter, ListedMCOParameter, CategoricalMCOParameter  # noqa
+from .mco.parameters.mco_parameters import FixedMCOParameterFactory, RangedMCOParameterFactory, ListedMCOParameterFactory, CategoricalMCOParameterFactory, RangedVectorMCOParameterFactory  # noqa
+from .mco.parameters.mco_parameters import FixedMCOParameter, RangedMCOParameter, ListedMCOParameter, CategoricalMCOParameter, RangedVectorMCOParameter  # noqa
 from .mco.optimizer_engines.base_optimizer_engine import BaseOptimizerEngine  # noqa
 from .mco.optimizer_engines.weighted_optimizer_engine import WeightedOptimizerEngine  # noqa
 

--- a/force_bdss/mco/parameters/base_mco_parameter.py
+++ b/force_bdss/mco/parameters/base_mco_parameter.py
@@ -18,10 +18,10 @@ class BaseMCOParameter(BaseModel):
     factory = Instance(BaseMCOParameterFactory, visible=False, transient=True)
 
     #: A user defined name for the parameter
-    name = Identifier(visible=False)
+    name = Identifier(visible=False, verify=True)
 
     #: A CUBA key describing the type of the parameter
-    type = String(visible=False)
+    type = String(visible=False, verify=True)
 
     def __init__(self, factory, *args, **kwargs):
         super().__init__(factory=factory, *args, **kwargs)

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -58,13 +58,13 @@ class RangedMCOParameter(BaseMCOParameter):
     lower and upper floating point values."""
 
     #: Lower bound for parameter values range
-    lower_bound = Float(0.1)
+    lower_bound = Float(0.1, verify=True)
 
     #: Upper bound for parameter values range
-    upper_bound = Float(100.0)
+    upper_bound = Float(100.0, verify=True)
 
     #: Initial value. Defines the parameter bias
-    initial_value = Float
+    initial_value = Float(verify=True)
 
     n_samples = Int(5)
 
@@ -168,13 +168,13 @@ class RangedVectorMCOParameter(RangedMCOParameter):
     dimension = PositiveInt(1)
 
     #: Lower vector bound for parameter values range
-    lower_bound = List(Float(), value=[0.1])
+    lower_bound = List(Float(), value=[0.1], verify=True)
 
     #: Upper vector bound for parameter values range
-    upper_bound = List(Float(), value=[100.0])
+    upper_bound = List(Float(), value=[100.0], verify=True)
 
     #: Initial value. Defines the parameter bias
-    initial_value = List(Float())
+    initial_value = List(Float(), verify=True)
 
     def _initial_value_default(self):
         return [

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,7 +1,22 @@
 import numpy as np
 
-from traits.api import List, Str, Property, Float, Any, Int, on_trait_change
-from traitsui.api import ListEditor, Item, View, HGroup
+from traits.api import (
+    List,
+    Str,
+    Property,
+    Float,
+    Any,
+    Int,
+    on_trait_change,
+)
+from traitsui.api import (
+    ListEditor,
+    Item,
+    View,
+    HGroup,
+    RangeEditor,
+    TextEditor,
+)
 
 from force_bdss.local_traits import PositiveInt
 from .base_mco_parameter import BaseMCOParameter
@@ -70,6 +85,32 @@ class RangedMCOParameter(BaseMCOParameter):
     def _get_sample_values(self):
         return list(
             np.linspace(self.lower_bound, self.upper_bound, self.n_samples)
+        )
+
+    def default_traits_view(self):
+        return View(
+            Item(
+                "lower_bound",
+                editor=TextEditor(
+                    auto_set=False, enter_set=True, evaluate=float
+                ),
+            ),
+            Item(
+                "upper_bound",
+                editor=TextEditor(
+                    auto_set=False, enter_set=True, evaluate=float
+                ),
+            ),
+            Item(
+                "initial_value",
+                editor=RangeEditor(
+                    low_name="lower_bound",
+                    high_name="upper_bound",
+                    format="%.3f",
+                    label_width=28,
+                ),
+            ),
+            Item("n_samples"),
         )
 
 

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -73,9 +73,13 @@ class RangedMCOParameter(BaseMCOParameter):
     )
 
     def _initial_value_default(self):
+        """Default initial value lies on midpoint between lower and
+        upper bounds"""
         return 0.5 * (self.lower_bound + self.upper_bound)
 
     def _get_sample_values(self):
+        """Return linearly spaced sample values between lower and
+        upper bounds"""
         return list(
             np.linspace(self.lower_bound, self.upper_bound, self.n_samples)
         )
@@ -107,7 +111,9 @@ class RangedMCOParameter(BaseMCOParameter):
         )
 
     def verify(self):
-        errors = super().verify()
+        """Overloads super method on BaseMCOParameter class to verify that
+        initial_value attribute lies between lower and upper bounds"""
+        errors = super(RangedMCOParameter, self).verify()
 
         if (
             self.initial_value > self.upper_bound
@@ -177,6 +183,8 @@ class RangedVectorMCOParameter(RangedMCOParameter):
     initial_value = List(Float(), verify=True)
 
     def _initial_value_default(self):
+        """Default initial values lie on midpoint between lower and
+        upper bounds for each vector"""
         return [
             0.5 * (lower_bound + upper_bound)
             for lower_bound, upper_bound in zip(
@@ -185,6 +193,8 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         ]
 
     def _get_sample_values(self):
+        """Return linearly spaced sample values between lower and
+        upper bounds for each vector"""
         return [
             list(np.linspace(lower_bound, upper_bound, self.n_samples))
             for lower_bound, upper_bound in zip(
@@ -194,6 +204,8 @@ class RangedVectorMCOParameter(RangedMCOParameter):
 
     @on_trait_change("dimension")
     def _update_bounds(self):
+        """Amends number of dimensions in vector in response to update
+        in UI."""
         for bound_vector in (
             self.lower_bound,
             self.upper_bound,
@@ -218,10 +230,13 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         )
 
     def verify(self):
-        errors = BaseMCOParameter.verify(self)
+        """Overloads super method on BaseMCOParameter class to verify that
+        all initial_value elements lie between lower and upper bounds."""
+        errors = super(RangedMCOParameter, self).verify()
 
         failed_init_values = []
         failed_bounds = []
+
         for dim in range(self.dimension):
             initial_value = self.initial_value[dim]
             upper_bound = self.upper_bound[dim]

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -204,8 +204,8 @@ class RangedVectorMCOParameter(RangedMCOParameter):
 
     @on_trait_change("dimension")
     def _update_bounds(self):
-        """Amends number of dimensions in vector in response to update
-        in UI."""
+        """Amends number of dimensions in each vector property in response
+        to update in UI."""
         for bound_vector in (
             self.lower_bound,
             self.upper_bound,
@@ -213,7 +213,7 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         ):
             if len(bound_vector) < self.dimension:
                 bound_vector.extend(
-                    [0.0 for _ in range(self.dimension - len(bound_vector))]
+                    [0.0] * (self.dimension - len(bound_vector))
                 )
             elif len(bound_vector) > self.dimension:
                 bound_vector[:] = bound_vector[: self.dimension]
@@ -237,8 +237,8 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         errors = super(RangedMCOParameter, self).verify()
 
         for name in ['initial_value', 'upper_bound', 'lower_bound']:
-            vector = getattr(self, name)
-            if len(vector) != self.dimension:
+            bound_vector = getattr(self, name)
+            if len(bound_vector) != self.dimension:
                 error = (
                     f'List attribute {name} must possess same length as '
                     f'determined by dimension attribute: {self.dimension}'

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -114,7 +114,7 @@ class RangedMCOParameter(BaseMCOParameter):
             or self.initial_value < self.lower_bound
         ):
             error = (
-                "Initial value of the Ranged parameter must be withing the "
+                "Initial value of the Ranged parameter must be within the "
                 "lower and the upper bounds."
             )
             errors.append(
@@ -235,7 +235,7 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         if failed_init_values:
             error = (
                 f"Initial values at indices {failed_init_values} of the "
-                "Ranged Vector parameter must be withing the lower and "
+                "Ranged Vector parameter must be within the lower and "
                 "the upper bounds."
             )
             errors.append(

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,8 +1,9 @@
 import numpy as np
 
-from traits.api import List, Str, Property, Float, Any, Int
-from traitsui.api import ListEditor
+from traits.api import List, Str, Property, Float, Any, Int, on_trait_change
+from traitsui.api import ListEditor, Item, View, HGroup
 
+from force_bdss.local_traits import PositiveInt
 from .base_mco_parameter import BaseMCOParameter
 from .base_mco_parameter_factory import BaseMCOParameterFactory
 
@@ -89,6 +90,83 @@ class RangedMCOParameterFactory(BaseMCOParameterFactory):
     #: A long description of the parameter
     def get_description(self):
         return "A parameter with a ranged level in floating point values."
+
+
+class RangedVectorMCOParameter(RangedMCOParameter):
+    """ Vector-value Ranged MCO Parameter"""
+
+    dimension = PositiveInt(1)
+
+    #: Lower vector bound for parameter values range
+    lower_bound = List(Float(), value=[0.1])
+
+    #: Upper vector bound for parameter values range
+    upper_bound = List(Float(), value=[100.0])
+
+    #: Initial value. Defines the parameter bias
+    initial_value = List(Float())
+
+    def _initial_value_default(self):
+        return [
+            0.5 * (lower_bound + upper_bound)
+            for lower_bound, upper_bound in zip(
+                self.lower_bound, self.upper_bound
+            )
+        ]
+
+    def _get_sample_values(self):
+        return [
+            list(np.linspace(lower_bound, upper_bound, self.n_samples))
+            for lower_bound, upper_bound in zip(
+                self.lower_bound, self.upper_bound
+            )
+        ]
+
+    @on_trait_change("dimension")
+    def _update_bounds(self):
+        for bound_vector in (
+            self.lower_bound,
+            self.upper_bound,
+            self.initial_value,
+        ):
+            if len(bound_vector) < self.dimension:
+                bound_vector.extend(
+                    [0.0 for _ in range(self.dimension - len(bound_vector))]
+                )
+            elif len(bound_vector) > self.dimension:
+                bound_vector[:] = bound_vector[: self.dimension]
+
+    def default_traits_view(self):
+        return View(
+            Item("dimension"),
+            HGroup(
+                Item("lower_bound", style="readonly"),
+                Item("upper_bound", style="readonly"),
+                Item("initial_value", style="readonly"),
+            ),
+            Item("n_samples"),
+        )
+
+
+class RangedVectorMCOParameterFactory(BaseMCOParameterFactory):
+    """ Ranged Vector Parameter factory"""
+
+    def get_identifier(self):
+        return "ranged_vector"
+
+    #: A name that will appear in the UI to identify this parameter.
+    def get_name(self):
+        return "Ranged Vector"
+
+    #: Definition of the associated model class.
+    def get_model_class(self):
+        return RangedVectorMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        return (
+            "A vector parameter with a ranged level in floating point values."
+        )
 
 
 class ListedMCOParameter(BaseMCOParameter):

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -231,8 +231,26 @@ class RangedVectorMCOParameter(RangedMCOParameter):
 
     def verify(self):
         """Overloads super method on BaseMCOParameter class to verify that
-        all initial_value elements lie between lower and upper bounds."""
+        all initial_value elements lie between lower and upper bounds. Also
+        checks that lower_bound, upper_bound and initial_value vectors
+        have the expected dimensionality according to dimension attribute"""
         errors = super(RangedMCOParameter, self).verify()
+
+        for name in ['initial_value', 'upper_bound', 'lower_bound']:
+            vector = getattr(self, name)
+            if len(vector) != self.dimension:
+                error = (
+                    f'List attribute {name} must possess same length as '
+                    f'determined by dimension attribute: {self.dimension}'
+                )
+                errors.append(
+                    VerifierError(
+                        subject=self,
+                        trait_name=name,
+                        local_error=error,
+                        global_error=error,
+                    )
+                )
 
         failed_init_values = []
         failed_bounds = []

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -100,6 +100,34 @@ class TestRangedMCOParameter(TestCase):
         self.assertEqual(5, parameter.n_samples)
         self.assertEqual(100.0, parameter.initial_value)
 
+    def test_verify(self):
+        parameter = RangedMCOParameter(
+            self.factory,
+            lower_bound=10,
+            upper_bound=20,
+            initial_value=30,
+            name="name",
+            type="type",
+        )
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(1, len(messages))
+        expected_message = (
+            "Initial value of the Ranged parameter must be "
+            "withing the lower and the upper bounds."
+        )
+        self.assertEqual(expected_message, messages[0])
+
+        parameter.lower_bound = 25
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(2, len(messages))
+        expected_message = (
+            "Upper bound value of the Ranged parameter must be greater "
+            "than the lower bound value."
+        )
+        self.assertEqual(expected_message, messages[1])
+
 
 class TestRangedVectorMCOParameter(TestCase):
     def setUp(self):
@@ -158,6 +186,34 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual([100.0], parameter.upper_bound)
         self.assertEqual(5, parameter.n_samples)
         self.assertEqual([100.0], parameter.initial_value)
+
+    def test_verify(self):
+        parameter = RangedVectorMCOParameter(
+            self.factory,
+            lower_bound=[10],
+            upper_bound=[20],
+            initial_value=[30],
+            name="name",
+            type="type",
+        )
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(1, len(messages))
+        expected_message = (
+            "Initial values at indices [0] of the Ranged Vector parameter "
+            "must be withing the lower and the upper bounds."
+        )
+        self.assertEqual(expected_message, messages[0])
+
+        parameter.upper_bound = [7]
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(2, len(messages))
+        expected_message = (
+            "Upper bound values at indices [0] of the Ranged Vector"
+            " parameter must greater than the lower bound values."
+        )
+        self.assertEqual(expected_message, messages[1])
 
 
 class TestListedMCOParameter(TestCase):

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -10,6 +10,8 @@ from force_bdss.mco.parameters.mco_parameters import (
     ListedMCOParameterFactory,
     CategoricalMCOParameter,
     CategoricalMCOParameterFactory,
+    RangedVectorMCOParameter,
+    RangedVectorMCOParameterFactory,
 )
 
 
@@ -97,6 +99,65 @@ class TestRangedMCOParameter(TestCase):
         self.assertEqual(100.0, parameter.upper_bound)
         self.assertEqual(5, parameter.n_samples)
         self.assertEqual(100.0, parameter.initial_value)
+
+
+class TestRangedVectorMCOParameter(TestCase):
+    def setUp(self):
+        self.mco_factory = mock.Mock(
+            spec=BaseMCOFactory,
+            plugin_id="pid",
+            plugin_name="Plugin",
+            id="mcoid",
+        )
+        self.factory = RangedVectorMCOParameterFactory(self.mco_factory)
+        self.parameter = RangedVectorMCOParameter(self.factory)
+
+    def test_factory(self):
+        self.assertEqual("ranged_vector", self.factory.get_identifier())
+        self.assertEqual("Ranged Vector", self.factory.get_name())
+        self.assertEqual(
+            "A vector parameter with a ranged level in floating point values.",
+            self.factory.get_description(),
+        )
+
+    def test_default(self):
+        self.assertEqual([0.1], self.parameter.lower_bound)
+        self.assertEqual([100.0], self.parameter.upper_bound)
+        self.assertEqual(5, self.parameter.n_samples)
+        self.assertEqual([50.05], self.parameter.initial_value)
+
+    def test_sample_values(self):
+        for expected, actual in zip(
+            [0.1, 25.075, 50.05, 75.025, 100.0],
+            list(self.parameter.sample_values[0]),
+        ):
+            self.assertAlmostEqual(expected, actual)
+        self.parameter.lower_bound[0] = 90.0
+        for expected, actual in zip(
+            [90.0, 92.5, 95.0, 97.5, 100.0],
+            list(self.parameter.sample_values[0]),
+        ):
+            self.assertAlmostEqual(expected, actual)
+        self.parameter.n_samples = 3
+        for expected, actual in zip(
+            [90.0, 95.0, 100.0], list(self.parameter.sample_values[0])
+        ):
+            self.assertAlmostEqual(expected, actual)
+
+    def test_custom_parameter(self):
+        parameter = RangedVectorMCOParameter(self.factory, lower_bound=[10])
+        self.assertListEqual([10], parameter.lower_bound)
+        self.assertListEqual([100.0], parameter.upper_bound)
+        self.assertEqual(5, parameter.n_samples)
+        self.assertEqual([55.0], parameter.initial_value)
+
+        parameter = RangedVectorMCOParameter(
+            self.factory, lower_bound=[10], initial_value=[100]
+        )
+        self.assertEqual([10], parameter.lower_bound)
+        self.assertEqual([100.0], parameter.upper_bound)
+        self.assertEqual(5, parameter.n_samples)
+        self.assertEqual([100.0], parameter.initial_value)
 
 
 class TestListedMCOParameter(TestCase):

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -118,6 +118,20 @@ class TestRangedMCOParameter(TestCase):
         )
         self.assertEqual(expected_message, messages[0])
 
+        parameter.initial_value = 0
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(1, len(messages))
+        expected_message = (
+            "Initial value of the Ranged parameter must be "
+            "withing the lower and the upper bounds."
+        )
+        self.assertEqual(expected_message, messages[0])
+
+        parameter.initial_value = 15
+        errors = parameter.verify()
+        self.assertEqual(0, len(errors))
+
         parameter.lower_bound = 25
         errors = parameter.verify()
         messages = [error.local_error for error in errors]
@@ -228,6 +242,20 @@ class TestRangedVectorMCOParameter(TestCase):
             "must be withing the lower and the upper bounds."
         )
         self.assertEqual(expected_message, messages[0])
+
+        parameter.initial_value = [0]
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(1, len(messages))
+        expected_message = (
+            "Initial values at indices [0] of the Ranged Vector parameter "
+            "must be withing the lower and the upper bounds."
+        )
+        self.assertEqual(expected_message, messages[0])
+
+        parameter.initial_value = [15]
+        errors = parameter.verify()
+        self.assertEqual(0, len(errors))
 
         parameter.upper_bound = [7]
         errors = parameter.verify()

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -1,5 +1,7 @@
 from unittest import TestCase, mock
 
+from traitsui.api import View
+
 from force_bdss.mco.base_mco_factory import BaseMCOFactory
 from force_bdss.mco.parameters.mco_parameters import (
     FixedMCOParameter,
@@ -59,6 +61,7 @@ class TestRangedMCOParameter(TestCase):
         self.assertEqual(100.0, self.parameter.upper_bound)
         self.assertEqual(5, self.parameter.n_samples)
         self.assertEqual(50.05, self.parameter.initial_value)
+        self.assertIsInstance(self.parameter.default_traits_view(), View)
 
     def test_sample_values(self):
         for expected, actual in zip(
@@ -167,6 +170,7 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual([100.0], self.parameter.upper_bound)
         self.assertEqual(5, self.parameter.n_samples)
         self.assertEqual([50.05], self.parameter.initial_value)
+        self.assertIsInstance(self.parameter.default_traits_view(), View)
 
     def test_sample_values(self):
         for expected, actual in zip(
@@ -224,6 +228,15 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertListEqual([0.0], self.parameter.upper_bound[1:])
         self.assertListEqual([0.0], self.parameter.lower_bound[1:])
         self.assertListEqual([0.0], self.parameter.initial_value[1:])
+
+        # Test individual list changes
+        self.parameter.upper_bound[:] = self.parameter.upper_bound[:-1]
+        self.parameter.dimension = 3
+        self.assertEqual(3, len(self.parameter.upper_bound))
+
+        self.parameter.lower_bound.append(1.0)
+        self.parameter.dimension = 1
+        self.assertEqual(1, len(self.parameter.lower_bound))
 
     def test_verify(self):
 

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -187,6 +187,30 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual(5, parameter.n_samples)
         self.assertEqual([100.0], parameter.initial_value)
 
+    def test_dimension_change(self):
+        self.assertEqual(1, self.parameter.dimension)
+        self.assertEqual(1, len(self.parameter.upper_bound))
+        self.assertEqual(1, len(self.parameter.lower_bound))
+        self.assertEqual(1, len(self.parameter.initial_value))
+
+        self.parameter.dimension = 3
+        self.assertEqual(3, self.parameter.dimension)
+        self.assertEqual(3, len(self.parameter.upper_bound))
+        self.assertEqual(3, len(self.parameter.lower_bound))
+        self.assertEqual(3, len(self.parameter.initial_value))
+        self.assertListEqual([0.0, 0.0], self.parameter.upper_bound[1:])
+        self.assertListEqual([0.0, 0.0], self.parameter.lower_bound[1:])
+        self.assertListEqual([0.0, 0.0], self.parameter.initial_value[1:])
+
+        self.parameter.dimension = 2
+        self.assertEqual(2, self.parameter.dimension)
+        self.assertEqual(2, len(self.parameter.upper_bound))
+        self.assertEqual(2, len(self.parameter.lower_bound))
+        self.assertEqual(2, len(self.parameter.initial_value))
+        self.assertListEqual([0.0], self.parameter.upper_bound[1:])
+        self.assertListEqual([0.0], self.parameter.lower_bound[1:])
+        self.assertListEqual([0.0], self.parameter.initial_value[1:])
+
     def test_verify(self):
         parameter = RangedVectorMCOParameter(
             self.factory,

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -114,7 +114,7 @@ class TestRangedMCOParameter(TestCase):
         self.assertEqual(1, len(messages))
         expected_message = (
             "Initial value of the Ranged parameter must be "
-            "withing the lower and the upper bounds."
+            "within the lower and the upper bounds."
         )
         self.assertEqual(expected_message, messages[0])
 
@@ -124,7 +124,7 @@ class TestRangedMCOParameter(TestCase):
         self.assertEqual(1, len(messages))
         expected_message = (
             "Initial value of the Ranged parameter must be "
-            "withing the lower and the upper bounds."
+            "within the lower and the upper bounds."
         )
         self.assertEqual(expected_message, messages[0])
 
@@ -239,7 +239,7 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual(1, len(messages))
         expected_message = (
             "Initial values at indices [0] of the Ranged Vector parameter "
-            "must be withing the lower and the upper bounds."
+            "must be within the lower and the upper bounds."
         )
         self.assertEqual(expected_message, messages[0])
 
@@ -249,7 +249,7 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual(1, len(messages))
         expected_message = (
             "Initial values at indices [0] of the Ranged Vector parameter "
-            "must be withing the lower and the upper bounds."
+            "must be within the lower and the upper bounds."
         )
         self.assertEqual(expected_message, messages[0])
 

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -229,53 +229,35 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertListEqual([0.0], self.parameter.lower_bound[1:])
         self.assertListEqual([0.0], self.parameter.initial_value[1:])
 
-        # Test individual list changes
-        self.parameter.upper_bound[:] = self.parameter.upper_bound[:-1]
-        self.parameter.dimension = 3
-        self.assertEqual(3, len(self.parameter.upper_bound))
-
-        self.parameter.lower_bound.append(1.0)
-        self.parameter.dimension = 1
-        self.assertEqual(1, len(self.parameter.lower_bound))
-
     def test_verify(self):
 
         parameter = RangedVectorMCOParameter(
             self.factory,
             lower_bound=[10, 20],
             upper_bound=[20],
-            initial_value=[15],
-            name="name",
-            type="type",
-        )
-
-        errors = parameter.verify()
-        messages = [error.local_error for error in errors]
-        self.assertEqual(1, len(messages))
-        expected_message = (
-            'List attribute lower_bound must possess same length as '
-            'determined by dimension attribute: 1')
-
-        self.assertEqual(expected_message, messages[0])
-
-        parameter = RangedVectorMCOParameter(
-            self.factory,
-            lower_bound=[10],
-            upper_bound=[20],
             initial_value=[30],
             name="name",
             type="type",
         )
+
         errors = parameter.verify()
         messages = [error.local_error for error in errors]
-        self.assertEqual(1, len(messages))
+        self.assertEqual(2, len(messages))
+
+        expected_message = (
+            'List attribute lower_bound must possess same length as '
+            'determined by dimension attribute: 1')
+        self.assertEqual(expected_message, messages[0])
+
         expected_message = (
             "Initial values at indices [0] of the Ranged Vector parameter "
             "must be within the lower and the upper bounds."
         )
-        self.assertEqual(expected_message, messages[0])
+        self.assertEqual(expected_message, messages[1])
 
+        parameter.lower_bound[:] = parameter.lower_bound[:1]
         parameter.initial_value = [0]
+
         errors = parameter.verify()
         messages = [error.local_error for error in errors]
         self.assertEqual(1, len(messages))

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -226,6 +226,25 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertListEqual([0.0], self.parameter.initial_value[1:])
 
     def test_verify(self):
+
+        parameter = RangedVectorMCOParameter(
+            self.factory,
+            lower_bound=[10, 20],
+            upper_bound=[20],
+            initial_value=[15],
+            name="name",
+            type="type",
+        )
+
+        errors = parameter.verify()
+        messages = [error.local_error for error in errors]
+        self.assertEqual(1, len(messages))
+        expected_message = (
+            'List attribute lower_bound must possess same length as '
+            'determined by dimension attribute: 1')
+
+        self.assertEqual(expected_message, messages[0])
+
         parameter = RangedVectorMCOParameter(
             self.factory,
             lower_bound=[10],

--- a/force_bdss/tests/dummy_classes/optimizer_engine.py
+++ b/force_bdss/tests/dummy_classes/optimizer_engine.py
@@ -22,4 +22,5 @@ class MixinDummyOptimizerEngine(HasStrictTraits):
         self.scaling_values = np.array([1./0.17**2] * self.dimension)
 
     def _score(self, input_point):
-        return (input_point[0] - 0.33) ** 2, (input_point[1] - 0.67) ** 2
+        score = (input_point[0] - 0.33) ** 2, (input_point[1] - 0.67) ** 2
+        return score

--- a/force_bdss/tests/probe_classes/data_source.py
+++ b/force_bdss/tests/probe_classes/data_source.py
@@ -3,11 +3,9 @@ from traits.api import Bool, Function, Int, on_trait_change
 from force_bdss.core.data_value import DataValue
 from force_bdss.core.slot import Slot
 from force_bdss.data_sources.base_data_source import BaseDataSource
-from force_bdss.data_sources.base_data_source_model import (
-    BaseDataSourceModel
-)
+from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
 from force_bdss.data_sources.base_data_source_factory import (
-    BaseDataSourceFactory
+    BaseDataSourceFactory,
 )
 from force_bdss.local_traits import CUBAType
 
@@ -54,6 +52,8 @@ class ProbeDataSourceModel(BaseDataSourceModel):
 
     input_slots_size = Int(1)
     output_slots_size = Int(1)
+
+    test_trait = Int(13, desc="Test trait", verify=True, transient=True)
 
     @on_trait_change(
         "input_slots_type,output_slots_type,"

--- a/force_bdss/tests/probe_classes/mco.py
+++ b/force_bdss/tests/probe_classes/mco.py
@@ -2,9 +2,12 @@ from traits.api import Bool, Int, Function, Any
 
 from force_bdss.core.data_value import DataValue
 from force_bdss.api import (
-    BaseMCOModel, BaseMCO, BaseMCOFactory,
-    BaseMCOParameter, BaseMCOParameterFactory,
-    BaseMCOCommunicator
+    BaseMCOModel,
+    BaseMCO,
+    BaseMCOFactory,
+    BaseMCOParameter,
+    BaseMCOParameterFactory,
+    BaseMCOCommunicator,
 )
 
 
@@ -31,7 +34,8 @@ class ProbeMCO(BaseMCO):
 
 
 class ProbeParameter(BaseMCOParameter):
-    pass
+
+    test_trait = Int(13, desc="Test trait", verify=True, transient=True)
 
 
 class ProbeParameterFactory(BaseMCOParameterFactory):
@@ -98,8 +102,8 @@ class ProbeMCOFactory(BaseMCOFactory):
             raise Exception("ProbeMCOFactory.create_communicator")
 
         return self.communicator_class(
-            self,
-            nb_output_data_values=self.nb_output_data_values)
+            self, nb_output_data_values=self.nb_output_data_values
+        )
 
     def create_model(self, model_data=None):
         if self.raises_on_create_model:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.4.0"
+VERSION = "0.5.0dev"
 
 
 # Read description


### PR DESCRIPTION
This PR approaches [#11](https://github.com/force-h2020/force-bdss-plugin-nevergrad/issues/11)

### Summary

We introduce a `RangedVectorMCOParameter` which is an extension to the existing `RangedMCOParameter`, but implements vector-valued bounds and values.

### Done

- Refactored the `View` of the `RangedMCOParameter` to add `RangeEditor` view to the `initial_value`.
- Implemented the `RangedVectorMCOParameter`. The dimensions of the vector-valued attributes are defined by the `dimension` attribute. The `lower_bound, upper_bound, initial_value` lists add / remove elements if the lengths are different from the `dimension` value. The bounds view is a standard `ListEditor` enhanced with a `style="readonly"` option.
- Implemented `verify` methods for the `RangedMCOParameter`s: we test whether the upper bound is above the lower bound, and if the initial value is within these bounds. 
- Also includes check to ensure each vector property has the expected dimensionality, since this could be incorrectly assigned in a workflow JSON.
- Added `verify=True` to the `name`, `type` traits of the `BaseMCOParameter`
- Added `verify=True` to the bounds and the initial value of the `RangedMCOParameter`s.
