### PR TITLE
DEV: Bumped to version to 0.5.0dev0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 FORCE BDSS Changelog
 ====================
 
+Release 0.5.0
+-------------
+
 Release 0.4.0
 -------------
 
-Released:
+Released: 24 Feb 2020
 
 Release notes
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.4.0"
+VERSION = "0.5.0.dev0"
 
 
 # Read description


### PR DESCRIPTION
This PR bumps the `master` branch version of Force BDSS to 0.5.0dev0