### PR TITLE
ENH: MCO runtime event

### DIFF
--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -1,11 +1,11 @@
-from .base_driver_event import BaseDriverEvent
+from .mco_events import MCORuntimeEvent
 
 
-class DataSourceStartEvent(BaseDriverEvent):
+class DataSourceStartEvent(MCORuntimeEvent):
     """ The Data Source driver should emit this event when the
     DataSource.run method is called."""
 
 
-class DataSourceFinishEvent(BaseDriverEvent):
+class DataSourceFinishEvent(MCORuntimeEvent):
     """ The Data Source driver should emit this event when the
     DataSource.run method finishes."""

--- a/force_bdss/events/mco_events.py
+++ b/force_bdss/events/mco_events.py
@@ -96,6 +96,9 @@ class MCORuntimeEvent(BaseDriverEvent):
      the Workflow or the UI, this event would be an MCORuntimeEvent.
     """
 
+    #: An identification label (name) of the MCORuntimeEvent
+    name = Str(allow_none=False)
+
 
 class WeightedMCOStartEvent(MCOStartEvent):
     """Initializes reporting of weights generated during an MCO by a

--- a/force_bdss/events/mco_events.py
+++ b/force_bdss/events/mco_events.py
@@ -90,6 +90,13 @@ class MCOProgressEvent(BaseDriverEvent, UIEventMixin):
         return cls(**data)
 
 
+class MCORuntimeEvent(BaseDriverEvent):
+    """ The base class for the MCO events fired during the workflow
+     execution. For example, if a DataSource is designed to notify
+     the Workflow or the UI, this event would be an MCORuntimeEvent.
+    """
+
+
 class WeightedMCOStartEvent(MCOStartEvent):
     """Initializes reporting of weights generated during an MCO by a
     WeightedOptimizerEngine"""

--- a/force_bdss/events/mco_events.py
+++ b/force_bdss/events/mco_events.py
@@ -92,12 +92,9 @@ class MCOProgressEvent(BaseDriverEvent, UIEventMixin):
 
 class MCORuntimeEvent(BaseDriverEvent):
     """ The base class for the MCO events fired during the workflow
-     execution. For example, if a DataSource is designed to notify
-     the Workflow or the UI, this event would be an MCORuntimeEvent.
+    execution. This is a supplementary event type that is used to
+    expose data generated on the DataSource or ExecutionLayer level.
     """
-
-    #: An identification label (name) of the MCORuntimeEvent
-    name = Str(allow_none=False)
 
 
 class WeightedMCOStartEvent(MCOStartEvent):

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -4,6 +4,7 @@ from force_bdss.events.data_source_events import (
     DataSourceStartEvent,
     DataSourceFinishEvent,
 )
+from force_bdss.events.mco_events import MCORuntimeEvent
 
 
 class TestDataSourceEvents(TestCase):
@@ -17,6 +18,7 @@ class TestDataSourceEvents(TestCase):
                       "DataSourceStartEvent",
             },
         )
+        self.assertIsInstance(event, MCORuntimeEvent)
 
     def test_getstate_finish_event(self):
         event = DataSourceFinishEvent()
@@ -28,3 +30,5 @@ class TestDataSourceEvents(TestCase):
                       "DataSourceFinishEvent",
             },
         )
+        self.assertIsInstance(event, MCORuntimeEvent)
+

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -9,26 +9,25 @@ from force_bdss.events.mco_events import MCORuntimeEvent
 
 class TestDataSourceEvents(TestCase):
     def test_getstate_start_event(self):
-        event = DataSourceStartEvent()
+        event = DataSourceStartEvent(name="name")
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {},
+                "model_data": {"name": "name"},
                 "id": "force_bdss.events.data_source_events."
-                      "DataSourceStartEvent",
+                "DataSourceStartEvent",
             },
         )
         self.assertIsInstance(event, MCORuntimeEvent)
 
     def test_getstate_finish_event(self):
-        event = DataSourceFinishEvent()
+        event = DataSourceFinishEvent(name="name")
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {},
+                "model_data": {"name": "name"},
                 "id": "force_bdss.events.data_source_events."
-                      "DataSourceFinishEvent",
+                "DataSourceFinishEvent",
             },
         )
         self.assertIsInstance(event, MCORuntimeEvent)
-

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -9,11 +9,11 @@ from force_bdss.events.mco_events import MCORuntimeEvent
 
 class TestDataSourceEvents(TestCase):
     def test_getstate_start_event(self):
-        event = DataSourceStartEvent(name="name")
+        event = DataSourceStartEvent()
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {"name": "name"},
+                "model_data": {},
                 "id": "force_bdss.events.data_source_events."
                 "DataSourceStartEvent",
             },
@@ -21,11 +21,11 @@ class TestDataSourceEvents(TestCase):
         self.assertIsInstance(event, MCORuntimeEvent)
 
     def test_getstate_finish_event(self):
-        event = DataSourceFinishEvent(name="name")
+        event = DataSourceFinishEvent()
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {"name": "name"},
+                "model_data": {},
                 "id": "force_bdss.events.data_source_events."
                 "DataSourceFinishEvent",
             },

--- a/force_bdss/events/tests/test_mco_events.py
+++ b/force_bdss/events/tests/test_mco_events.py
@@ -83,12 +83,12 @@ class TestMCOEvents(unittest.TestCase):
         )
         self.assertIsInstance(event, UIEventMixin)
 
-    def test_getstate_finish_event(self):
-        event = MCORuntimeEvent()
+    def test_getstate_runtime_event(self):
+        event = MCORuntimeEvent(name="name")
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {},
+                "model_data": {"name": "name"},
                 "id": "force_bdss.events.mco_events.MCORuntimeEvent",
             },
         )

--- a/force_bdss/events/tests/test_mco_events.py
+++ b/force_bdss/events/tests/test_mco_events.py
@@ -9,6 +9,7 @@ from force_bdss.events.mco_events import (
     MCOStartEvent,
     WeightedMCOStartEvent,
     MCOFinishEvent,
+    MCORuntimeEvent
 )
 from force_bdss.ui_hooks.ui_notification_mixins import UIEventMixin
 
@@ -81,6 +82,17 @@ class TestMCOEvents(unittest.TestCase):
             },
         )
         self.assertIsInstance(event, UIEventMixin)
+
+    def test_getstate_finish_event(self):
+        event = MCORuntimeEvent()
+        self.assertDictEqual(
+            event.__getstate__(),
+            {
+                "model_data": {},
+                "id": "force_bdss.events.mco_events.MCORuntimeEvent",
+            },
+        )
+        self.assertFalse(isinstance(event, UIEventMixin))
 
     def test_serialize_start_event(self):
         event = MCOStartEvent(

--- a/force_bdss/events/tests/test_mco_events.py
+++ b/force_bdss/events/tests/test_mco_events.py
@@ -84,11 +84,11 @@ class TestMCOEvents(unittest.TestCase):
         self.assertIsInstance(event, UIEventMixin)
 
     def test_getstate_runtime_event(self):
-        event = MCORuntimeEvent(name="name")
+        event = MCORuntimeEvent()
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {"name": "name"},
+                "model_data": {},
                 "id": "force_bdss.events.mco_events.MCORuntimeEvent",
             },
         )


### PR DESCRIPTION
### Summary

This PR attempts to build a foundation for the `BaseDriverEvent`s that are fired during the `Workflow` execution. We introduce a `MCORuntimeEvent` type. The `DataSourceEvent`s are now subclasses of the `MCORuntimeEvent`.

### Done

- Added `MCORuntimeEvent` to the MCO events. 
- `DataSourceStartEvent ` and `DataSourceFinishEvent ` events are now subclasses of `MCORuntimeEvent`
 