### PR TITLE
implement serialise as abstract method

### DIFF
--- a/force_bdss/events/mco_events.py
+++ b/force_bdss/events/mco_events.py
@@ -46,6 +46,9 @@ class MCOStartEvent(BaseDriverEvent, UIEventMixin):
 class MCOFinishEvent(BaseDriverEvent, UIEventMixin):
     """ The MCO driver should emit this event when the evaluation ends."""
 
+    def serialize(self):
+        raise NotImplementedError
+
 
 class MCOProgressEvent(BaseDriverEvent, UIEventMixin):
     """ The MCO driver should emit this event for every new point that is

--- a/force_bdss/ui_hooks/ui_notification_mixins.py
+++ b/force_bdss/ui_hooks/ui_notification_mixins.py
@@ -1,3 +1,5 @@
+import abc
+
 from threading import Event as ThreadingEvent
 
 from traits.api import Instance, HasStrictTraits
@@ -49,4 +51,14 @@ class UIEventMixin:
 
     By default, the MCOStartEvent, MCOProgressEvent and MCOFinishEvent
     classes all inherit from UIEventMixin."""
-    pass
+
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def serialize(self):
+        """ Enforce requirement of serialize method on all subclasses:
+        MCOStartEvent
+        MCOFinishEvent
+        MCOProgressEvent
+        (cf. mco_events.py)
+        """


### PR DESCRIPTION
Solves issue #299. 

UIEventMixin becomes abstract class with serialize method to be implemented by subclasses (MCOStartEvent, MCOFinishEvent, MCOProgressEvent). Added serialize method to MCOFinishEvent, (wasn't present) returning NotImplementedError.