### PR TITLE
CLN: Remove Deprecated code

### DIFF
--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -154,6 +154,12 @@ class OptimizeOperation(HasStrictTraits):
                 ).format(listener.factory.id, listener.factory.plugin_id)
             )
 
+    def _set_threading_events(self, listener):
+        """Assign stop and pause threading events to
+        a UIEventNotificationMixin listener"""
+        listener.set_stop_event(self._stop_event)
+        listener.set_pause_event(self._pause_event)
+
     def _initialize_listeners(self):
         listeners = []
 

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -11,7 +11,6 @@ from traits.api import (
     provides,
 )
 
-from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.notification_listeners.base_notification_listener import (
     BaseNotificationListener,
 )

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -179,8 +179,7 @@ class OptimizeOperation(HasStrictTraits):
                 raise
 
             try:
-                listener.set_stop_event(self._stop_event)
-                listener.set_pause_event(self._pause_event)
+                self._set_threading_events(listener)
             except AttributeError:
                 pass
 

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -14,6 +14,10 @@ from traits.api import (
 from force_bdss.notification_listeners.base_notification_listener import (
     BaseNotificationListener,
 )
+from force_bdss.ui_hooks.ui_notification_mixins import (
+    UIEventNotificationMixin
+)
+
 from .i_operation import IOperation
 from .workflow_file import WorkflowFile
 
@@ -178,10 +182,8 @@ class OptimizeOperation(HasStrictTraits):
                 )
                 raise
 
-            try:
+            if isinstance(listener, UIEventNotificationMixin):
                 self._set_threading_events(listener)
-            except AttributeError:
-                pass
 
             try:
                 listener.initialize(nl_model)

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -128,12 +128,11 @@ class TestOptimizeOperation(TestCase):
         factory.raises_on_initialize_listener = False
         factory.return_ui_event_listener = True
 
-        self.operation._initialize_listeners()
-        listener = self.operation.listeners[0]
-        self.assertIs(self.operation._pause_event,
-                      listener._pause_event)
-        self.assertIs(self.operation._stop_event,
-                      listener._stop_event)
+        with mock.patch(
+                'force_bdss.app.optimize_operation.OptimizeOperation'
+                '._set_threading_events') as mock_set_thread:
+            self.operation._initialize_listeners()
+            self.assertEqual(1, mock_set_thread.call_count)
 
     def test__finalize_listeners(self):
 

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -12,6 +12,8 @@ from force_bdss.events.mco_events import (
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.tests import fixtures
 from force_bdss.tests.probe_classes.workflow_file import ProbeWorkflowFile
+from force_bdss.tests.probe_classes.notification_listener import (
+    ProbeUIEventNotificationListener)
 
 
 class TestOptimizeOperation(TestCase):
@@ -67,7 +69,7 @@ class TestOptimizeOperation(TestCase):
 
     def test__set_threading_events(self):
         factory = self.registry.notification_listener_factories[0]
-        factory.return_ui_event_listener = True
+        factory.listener_class = ProbeUIEventNotificationListener
         listener = factory.create_listener()
 
         self.operation._set_threading_events(listener)
@@ -126,11 +128,14 @@ class TestOptimizeOperation(TestCase):
         # Test setting of stop and pause threading events on
         # a UIEventNotificationMixin listener
         factory.raises_on_initialize_listener = False
-        factory.return_ui_event_listener = True
 
         with mock.patch(
                 'force_bdss.app.optimize_operation.OptimizeOperation'
                 '._set_threading_events') as mock_set_thread:
+            self.operation._initialize_listeners()
+            self.assertEqual(0, mock_set_thread.call_count)
+
+            factory.listener_class = ProbeUIEventNotificationListener
             self.operation._initialize_listeners()
             self.assertEqual(1, mock_set_thread.call_count)
 

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -65,6 +65,17 @@ class TestOptimizeOperation(TestCase):
                 ),
             )
 
+    def test__set_threading_events(self):
+        factory = self.registry.notification_listener_factories[0]
+        factory.return_ui_event_listener = True
+        listener = factory.create_listener()
+
+        self.operation._set_threading_events(listener)
+        self.assertIs(self.operation._pause_event,
+                      listener._pause_event)
+        self.assertIs(self.operation._stop_event,
+                      listener._stop_event)
+
     def test__initialize_listeners(self):
 
         # Test normal operation
@@ -111,6 +122,18 @@ class TestOptimizeOperation(TestCase):
                     "The listener will be dropped.",
                 )
             )
+
+        # Test setting of stop and pause threading events on
+        # a UIEventNotificationMixin listener
+        factory.raises_on_initialize_listener = False
+        factory.return_ui_event_listener = True
+
+        self.operation._initialize_listeners()
+        listener = self.operation.listeners[0]
+        self.assertIs(self.operation._pause_event,
+                      listener._pause_event)
+        self.assertIs(self.operation._stop_event,
+                      listener._stop_event)
 
     def test__finalize_listeners(self):
 

--- a/force_bdss/mco/tests/test_base_mco.py
+++ b/force_bdss/mco/tests/test_base_mco.py
@@ -1,39 +1,9 @@
-import testfixtures
 import unittest
-import warnings
 
-from force_bdss.mco.base_mco import NotifyEventWarning
 from force_bdss.mco.i_mco_factory import IMCOFactory
 from force_bdss.tests.dummy_classes.mco import DummyMCO
 
 from unittest import mock
-
-
-class TestNotifyEventWarning(unittest.TestCase):
-    """NOTE: this class should be removed alongside BaseMCO.event"""
-    def test_warn(self):
-
-        expected_message = (
-            "Use of the BaseMCO.event attribute is now deprecated and will"
-            " be removed in version 0.5.0. Please replace any uses of the "
-            "BaseMCO.notify and BaseMCO.notify_new_point method with the "
-            "equivalent BaseMCOModel.notify and "
-            "BaseMCOModel.notify_progress_event methods respectively")
-
-        expected_log = (
-            "force_bdss.mco.base_mco",
-            "WARNING",
-            expected_message,
-        )
-
-        with testfixtures.LogCapture() as capture, \
-                warnings.catch_warnings(record=True) as errors:
-
-            NotifyEventWarning.warn()
-
-            capture.check(expected_log)
-            self.assertEqual(expected_message, str(errors[0].message))
-
 
 class TestBaseMultiCriteriaOptimizer(unittest.TestCase):
     def test_initialization(self):

--- a/force_bdss/mco/tests/test_base_mco.py
+++ b/force_bdss/mco/tests/test_base_mco.py
@@ -5,6 +5,7 @@ from force_bdss.tests.dummy_classes.mco import DummyMCO
 
 from unittest import mock
 
+
 class TestBaseMultiCriteriaOptimizer(unittest.TestCase):
     def test_initialization(self):
         factory = mock.Mock(spec=IMCOFactory)

--- a/force_bdss/tests/probe_classes/notification_listener.py
+++ b/force_bdss/tests/probe_classes/notification_listener.py
@@ -5,6 +5,9 @@ from force_bdss.api import (
     BaseNotificationListenerModel,
     BaseNotificationListenerFactory,
 )
+from force_bdss.ui_hooks.ui_notification_mixins import (
+    UIEventNotificationMixin
+)
 
 
 def pass_function(*args, **kwargs):
@@ -43,6 +46,11 @@ class ProbeNotificationListener(BaseNotificationListener):
         self.finalize_function()
 
 
+class ProbeUIEventNotificationListener(ProbeNotificationListener,
+                                       UIEventNotificationMixin):
+    pass
+
+
 class ProbeNotificationListenerModel(BaseNotificationListenerModel):
     pass
 
@@ -59,6 +67,8 @@ class ProbeNotificationListenerFactory(BaseNotificationListenerFactory):
     raises_on_finalize_listener = Bool(False)
     raises_on_deliver_listener = Bool(False)
 
+    return_ui_event_listener = Bool(False)
+
     def get_name(self):
         return "test_notification_listener"
 
@@ -66,7 +76,9 @@ class ProbeNotificationListenerFactory(BaseNotificationListenerFactory):
         return "probe_notification_listener"
 
     def get_listener_class(self):
-        return ProbeNotificationListener
+        if self.return_ui_event_listener:
+            return ProbeNotificationListener
+        return ProbeUIEventNotificationListener
 
     def get_model_class(self):
         return ProbeNotificationListenerModel

--- a/force_bdss/tests/probe_classes/notification_listener.py
+++ b/force_bdss/tests/probe_classes/notification_listener.py
@@ -67,8 +67,6 @@ class ProbeNotificationListenerFactory(BaseNotificationListenerFactory):
     raises_on_finalize_listener = Bool(False)
     raises_on_deliver_listener = Bool(False)
 
-    return_ui_event_listener = Bool(False)
-
     def get_name(self):
         return "test_notification_listener"
 
@@ -76,9 +74,7 @@ class ProbeNotificationListenerFactory(BaseNotificationListenerFactory):
         return "probe_notification_listener"
 
     def get_listener_class(self):
-        if self.return_ui_event_listener:
-            return ProbeNotificationListener
-        return ProbeUIEventNotificationListener
+        return ProbeNotificationListener
 
     def get_model_class(self):
         return ProbeNotificationListenerModel


### PR DESCRIPTION
The PR closes #312 

It removes both the `BaseMCO.notify_progress_event` method and the `OptimizeOperation.mco` attribute. Consequently, any existing `BaseMCO` subclasses will need to ensure they are no longer calling `self.notify_progress_event`, and instead replace this with `evaluator.mco_model.notify_progress_event` instead.

Related unit test code is also updated, and an extra test is included to ensure `UIEventNotificationMixin` classes have their pause and stop events set correctly during initialization.

# Change log:
- Removed `BaseMCO.notify` and `BaseMCO.notify_progress_event` methods
- Removed `BaseMCO.event` attribute
- Removed `OptimizeOperation.mco` attribute
- New probe class: `ProbeUIEventNotificationListener`

# Note
~We should probably check that all our existing `BaseMCO` classes in plugins are not still using `self.notify_progress_event` before merging~