### PR TITLE
added start and finish events

### DIFF
--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from logging import getLogger
 
 from traits.api import (
-    Instance, List, Event, on_trait_change
+    Instance, List, Event, on_trait_change, Type
 )
 
 from force_bdss.core.base_model import BaseModel
@@ -10,6 +10,10 @@ from force_bdss.core.input_slot_info import InputSlotInfo
 from force_bdss.core.output_slot_info import OutputSlotInfo
 from force_bdss.core.verifier import VerifierError
 from force_bdss.data_sources.i_data_source_factory import IDataSourceFactory
+from force_bdss.events.data_source_events import (
+    DataSourceStartEvent,
+    DataSourceFinishEvent
+)
 
 
 logger = getLogger(__name__)
@@ -45,6 +49,14 @@ class BaseDataSourceModel(BaseModel):
     #: option in your model implies a change in the slots. The UI will detect
     #: this and adapt the visual entries.
     changes_slots = Event()
+
+    #: Type of the Data Source Start event
+    _start_event_type = Type(DataSourceStartEvent,
+                             visible=False, transient=True)
+
+    #: Type of the Data Source Finish event
+    _finish_event_type = Type(DataSourceFinishEvent,
+                              visible=False, transient=True)
 
     def verify(self):
         """ Verify the data source model.

--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -14,14 +14,14 @@ class DataSourceStartEvent(MCORuntimeEvent):
     input_names = List(Str())
 
     def serialize(self):
-        """ Provides serialized form of MCOStartEvent for further data storage
+        """ Provides serialized form of DataSourceStartEvent for further data storage
         (e.g. in csv format) or processing.
 
 
         Usage example:
-        For a custom MCOStartEvent subclass, this method can be overloaded.
+        For a custom DataSourceStartEvent subclass, this method can be overloaded.
         An example of a custom `serialize` method would be:
-        >>> class CustomMCOStartEvent(DataSourceStartEvent):
+        >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
         >>>
         >>>     def serialize(self):
         >>>         custom_data = [f"{name} data" for name in self.kpi_names]
@@ -29,7 +29,7 @@ class DataSourceStartEvent(MCORuntimeEvent):
         >>>
 
         Returns:
-            List(Str): event parameters names and kpi names
+            List(Str): input names
         """
         return self.input_names
 
@@ -42,14 +42,14 @@ class DataSourceFinishEvent(MCORuntimeEvent):
     output_names = List(Str())
 
     def serialize(self):
-        """ Provides serialized form of MCOStartEvent for further data storage
+        """ Provides serialized form of DataSourceStartEvent for further data storage
         (e.g. in csv format) or processing.
 
 
         Usage example:
-        For a custom MCOStartEvent subclass, this method can be overloaded.
+        For a custom DataSourceStartEvent subclass, this method can be overloaded.
         An example of a custom `serialize` method would be:
-        >>> class CustomMCOStartEvent(DataSourceStartEvent):
+        >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
         >>>
         >>>     def serialize(self):
         >>>         custom_data = [f"{name} data" for name in self.kpi_names]
@@ -57,6 +57,6 @@ class DataSourceFinishEvent(MCORuntimeEvent):
         >>>
 
         Returns:
-            List(Str): event parameters names and kpi names
+            List(Str): output names
         """
         return self.output_names

--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -1,11 +1,62 @@
 from .mco_events import MCORuntimeEvent
 
+from traits.api import (
+    List,
+    Str
+)
+
 
 class DataSourceStartEvent(MCORuntimeEvent):
     """ The Data Source driver should emit this event when the
     DataSource.run method is called."""
 
+    #: The names assigned to the inputs.
+    input_names = List(Str())
+
+    def serialize(self):
+        """ Provides serialized form of MCOStartEvent for further data storage
+        (e.g. in csv format) or processing.
+
+
+        Usage example:
+        For a custom MCOStartEvent subclass, this method can be overloaded.
+        An example of a custom `serialize` method would be:
+        >>> class CustomMCOStartEvent(DataSourceStartEvent):
+        >>>
+        >>>     def serialize(self):
+        >>>         custom_data = [f"{name} data" for name in self.kpi_names]
+        >>>         return super().serialize() + custom_data
+        >>>
+
+        Returns:
+            List(Str): event parameters names and kpi names
+        """
+        return self.input_names
+
 
 class DataSourceFinishEvent(MCORuntimeEvent):
     """ The Data Source driver should emit this event when the
     DataSource.run method finishes."""
+
+    #: The names assigned to the inputs.
+    output_names = List(Str())
+
+    def serialize(self):
+        """ Provides serialized form of MCOStartEvent for further data storage
+        (e.g. in csv format) or processing.
+
+
+        Usage example:
+        For a custom MCOStartEvent subclass, this method can be overloaded.
+        An example of a custom `serialize` method would be:
+        >>> class CustomMCOStartEvent(DataSourceStartEvent):
+        >>>
+        >>>     def serialize(self):
+        >>>         custom_data = [f"{name} data" for name in self.kpi_names]
+        >>>         return super().serialize() + custom_data
+        >>>
+
+        Returns:
+            List(Str): event parameters names and kpi names
+        """
+        return self.output_names

--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -14,21 +14,9 @@ class DataSourceStartEvent(MCORuntimeEvent):
     input_names = List(Str())
 
     def serialize(self):
-        """ Provides serialized form of DataSourceStartEvent for
-        further data storage
+        """ Provides serialized form of DataSourceStartEvent
+        for further data storage
         (e.g. in csv format) or processing.
-
-
-        Usage example:
-        For a custom DataSourceStartEvent subclass, this method
-        can be overloaded.
-        An example of a custom `serialize` method would be:
-        >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
-        >>>
-        >>>     def serialize(self):
-        >>>         custom_data = [f"{name} data" for name in self.kpi_names]
-        >>>         return super().serialize() + custom_data
-        >>>
 
         Returns:
             List(Str): input names
@@ -47,18 +35,6 @@ class DataSourceFinishEvent(MCORuntimeEvent):
         """ Provides serialized form of DataSourceStartEvent
         for further data storage
         (e.g. in csv format) or processing.
-
-
-        Usage example:
-        For a custom DataSourceStartEvent subclass, this method
-        can be overloaded.
-        An example of a custom `serialize` method would be:
-        >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
-        >>>
-        >>>     def serialize(self):
-        >>>         custom_data = [f"{name} data" for name in self.kpi_names]
-        >>>         return super().serialize() + custom_data
-        >>>
 
         Returns:
             List(Str): output names

--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -14,12 +14,14 @@ class DataSourceStartEvent(MCORuntimeEvent):
     input_names = List(Str())
 
     def serialize(self):
-        """ Provides serialized form of DataSourceStartEvent for further data storage
+        """ Provides serialized form of DataSourceStartEvent for
+        further data storage
         (e.g. in csv format) or processing.
 
 
         Usage example:
-        For a custom DataSourceStartEvent subclass, this method can be overloaded.
+        For a custom DataSourceStartEvent subclass, this method
+        can be overloaded.
         An example of a custom `serialize` method would be:
         >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
         >>>
@@ -42,12 +44,14 @@ class DataSourceFinishEvent(MCORuntimeEvent):
     output_names = List(Str())
 
     def serialize(self):
-        """ Provides serialized form of DataSourceStartEvent for further data storage
+        """ Provides serialized form of DataSourceStartEvent
+        for further data storage
         (e.g. in csv format) or processing.
 
 
         Usage example:
-        For a custom DataSourceStartEvent subclass, this method can be overloaded.
+        For a custom DataSourceStartEvent subclass, this method
+        can be overloaded.
         An example of a custom `serialize` method would be:
         >>> class CustomDataSourceStartEvent(DataSourceStartEvent):
         >>>

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -31,3 +31,13 @@ class TestDataSourceEvents(TestCase):
             },
         )
         self.assertIsInstance(event, MCORuntimeEvent)
+
+    def test_serialize_finish_event(self):
+        event = DataSourceFinishEvent()
+
+        self.assertIsNone(event.serialize(), None)
+
+    def test_serialize_start_event(self):
+        event = DataSourceStartEvent()
+
+        self.assertIsNone(event.serialize(), None)

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -35,9 +35,9 @@ class TestDataSourceEvents(TestCase):
     def test_serialize_finish_event(self):
         event = DataSourceFinishEvent()
 
-        self.assertIsNone(event.serialize(), None)
+        self.assertListEqual(event.serialize(), [])
 
     def test_serialize_start_event(self):
         event = DataSourceStartEvent()
 
-        self.assertIsNone(event.serialize(), None)
+        self.assertListEqual(event.serialize(), [])

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -13,7 +13,7 @@ class TestDataSourceEvents(TestCase):
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {},
+                "model_data": {"input_names": []},
                 "id": "force_bdss.events.data_source_events."
                 "DataSourceStartEvent",
             },
@@ -25,7 +25,7 @@ class TestDataSourceEvents(TestCase):
         self.assertDictEqual(
             event.__getstate__(),
             {
-                "model_data": {},
+                "model_data": {"output_names": []},
                 "id": "force_bdss.events.data_source_events."
                 "DataSourceFinishEvent",
             },


### PR DESCRIPTION
Closes #291. Added start and finish events, both with serialize methods, to base data source model. Just copies approach/code for mco model/events.