### PR TITLE
FIX: Suggested try-except-finally implementation for EvaluateOperation run

### DIFF
--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -38,22 +38,14 @@ class EvaluateOperation(BaseOperation):
                     mco_factory.plugin_id))
             return False
 
-        mco_data_values = mco_communicator.receive_from_mco(mco_model)
-
         try:
+            mco_data_values = mco_communicator.receive_from_mco(mco_model)
             kpi_results = self.workflow.execute(mco_data_values)
             mco_communicator.send_to_mco(mco_model, kpi_results)
         except Exception:
-            pass
-            """ Including this gives a unit test error that I can't pick apart:
-            log.exception(
-                (
-                    "Method run() of MCO with id '{}' from plugin '{}' "
-                    "raised exception. This might indicate a "
-                    "programming error in the plugin."
-                ).format(mco_factory.id, mco_factory.plugin_id)
-            )
-            """
+            # Simply propagate any error message that is raised, and
+            # ensure that listener and event objects are correctly
+            # teared down afterwards.
             raise
         finally:
             # Tear down listeners


### PR DESCRIPTION
This is a suggestion for #320 of how to implement the `try` statement around any `mco_communicator` functions.

Since it is up to developers to implement both `mco_communicator.recieve_from_mco` and `mco_communicator.send_to_mco`, we include them in a try-except-finally block, to ensure that the threading events and listener instances are correctly finalised in the event of any exception being raised.

At the same time, since there are multiple origins of any exceptions (ie. lines 42, 43 and 44), we can avoid editing the logged traceback, and simply propagate the error message; our main aim is to make sure the code in the `finally` block will always be performed.