### PR TITLE
added workflow verification to evaluate operation.

### DIFF
--- a/force_bdss/app/base_operation.py
+++ b/force_bdss/app/base_operation.py
@@ -50,20 +50,20 @@ class BaseOperation(HasStrictTraits):
         self._pause_event = ThreadingEvent()
         self._pause_event.set()
 
-    def run(self, do_verify=False):
-        if do_verify:
-            self.workflow_file.verify()
-            if len(self.workflow_file.errors) != 0:
-                log.error("Unable to execute workflow due to "
-                          "verification errors:")
-                for error in self.workflow_file.errors:
-                    log.error(error.local_error)
-                raise RuntimeError("Workflow file has errors.")
-        """ Evaluate the workflow.
+    def run(self):
+        """ Evaluate the workflow."""
         raise NotImplementedError(
             "{} must implement run".format(
                 self.__class__))
-        """
+
+    def verify_workflow(self):
+        self.workflow_file.verify()
+        if len(self.workflow_file.errors) != 0:
+            log.error("Unable to execute workflow due to "
+                      "verification errors:")
+            for error in self.workflow_file.errors:
+                log.error(error.local_error)
+            raise RuntimeError("Workflow file has errors.")
 
     def _deliver_start_event(self):
         self.workflow.mco_model.notify_start_event()

--- a/force_bdss/app/base_operation.py
+++ b/force_bdss/app/base_operation.py
@@ -50,11 +50,20 @@ class BaseOperation(HasStrictTraits):
         self._pause_event = ThreadingEvent()
         self._pause_event.set()
 
-    def run(self):
-        """ Evaluate the workflow. """
+    def run(self, do_verify=False):
+        if do_verify:
+            self.workflow_file.verify()
+            if len(self.workflow_file.errors) != 0:
+                log.error("Unable to execute workflow due to "
+                          "verification errors:")
+                for error in self.workflow_file.errors:
+                    log.error(error.local_error)
+                raise RuntimeError("Workflow file has errors.")
+        """ Evaluate the workflow.
         raise NotImplementedError(
             "{} must implement run".format(
                 self.__class__))
+        """
 
     def _deliver_start_event(self):
         self.workflow.mco_model.notify_start_event()

--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -13,13 +13,13 @@ class EvaluateOperation(BaseOperation):
     based on the system described by a `Workflow` object.
     """
 
-    def run(self, do_verify=True):
+    def run(self):
 
         """verify the workflow.
         Do not do use this [run(do_verify=False)] on unit tests :
         use OptimizeOperation.run() to test verification.
         """
-        super().run(do_verify=do_verify)
+        self.verify_workflow()
 
         """ Evaluate the workflow. """
         mco_model = self.workflow.mco_model

--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -14,19 +14,14 @@ class EvaluateOperation(BaseOperation):
     """
 
     def run(self):
-
-        """verify the workflow.
-        Do not do use this [run(do_verify=False)] on unit tests :
-        use OptimizeOperation.run() to test verification.
+        """ Evaluate the workflow.
         """
+
+        # Verify the workflow
         self.verify_workflow()
 
-        """ Evaluate the workflow. """
+        # optimizer model and factory
         mco_model = self.workflow.mco_model
-        if mco_model is None:
-            log.info("No MCO defined. Nothing to do. Exiting.")
-            return
-
         mco_factory = mco_model.factory
 
         # Set up listeners

--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -13,7 +13,14 @@ class EvaluateOperation(BaseOperation):
     based on the system described by a `Workflow` object.
     """
 
-    def run(self):
+    def run(self, do_verify=True):
+
+        """verify the workflow.
+        Do not do use this [run(do_verify=False)] on unit tests :
+        use OptimizeOperation.run() to test verification.
+        """
+        super().run(do_verify=do_verify)
+
         """ Evaluate the workflow. """
         mco_model = self.workflow.mco_model
         if mco_model is None:

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -16,7 +16,7 @@ class OptimizeOperation(BaseOperation):
 
     def run(self):
         """ Verify the workflow """
-        super().run(do_verify=True)
+        self.verify_workflow()
 
         """ Create and run the optimizer. """
         mco = self.create_mco()

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -15,10 +15,13 @@ class OptimizeOperation(BaseOperation):
     information during the MCO run."""
 
     def run(self):
-        """ Verify the workflow """
+        """ Create and run the optimizer.
+        """
+
+        # Verify the workflow
         self.verify_workflow()
 
-        """ Create and run the optimizer. """
+        # Create the optimizer
         mco = self.create_mco()
 
         # Set up listeners

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -15,14 +15,10 @@ class OptimizeOperation(BaseOperation):
     information during the MCO run."""
 
     def run(self):
-        """ Create and run the optimizer. """
-        self.workflow_file.verify()
-        if len(self.workflow_file.errors) != 0:
-            log.error("Unable to execute workflow due to verification errors:")
-            for error in self.workflow_file.errors:
-                log.error(error.local_error)
-            raise RuntimeError("Workflow file has errors.")
+        """ Verify the workflow """
+        super().run(do_verify=True)
 
+        """ Create and run the optimizer. """
         mco = self.create_mco()
 
         # Set up listeners

--- a/force_bdss/app/tests/test_bdss_application.py
+++ b/force_bdss/app/tests/test_bdss_application.py
@@ -109,12 +109,12 @@ class TestBDSSApplication(unittest.TestCase):
                 with self.assertRaises(Exception):
                     app._run_workflow()
             capture.check(
-                ('force_bdss.app.optimize_operation',
+                ('force_bdss.app.base_operation',
                  'ERROR',
                  'Unable to execute workflow due to verification errors:'),
-                ('force_bdss.app.optimize_operation',
+                ('force_bdss.app.base_operation',
                  'ERROR', 'Workflow has no MCO'),
-                ('force_bdss.app.optimize_operation',
+                ('force_bdss.app.base_operation',
                  'ERROR',
                  'Workflow has no execution layers'),
                 ('force_bdss.app.bdss_application',

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -89,13 +89,16 @@ class TestEvaluateOperation(TestCase):
         self.operation.workflow.mco_model = factory.create_model()
 
         with testfixtures.LogCapture():
-            with self.assertRaisesRegex(
+            with (self.assertRaisesRegex(
+                    RuntimeError,
+                    "Workflow file has errors.") or
+                  self.assertRaisesRegex(
                     RuntimeError,
                     r"The number of data values returned by the MCO "
                     r"\(1 values\) does not match the number of "
                     r"parameters specified \(0 values\). This is either "
                     "a MCO plugin error or the workflow file is "
-                    "corrupted."):
+                    "corrupted.")):
                 self.operation.run()  # fails
 
     def test_error_for_missing_ds_output_names(self):
@@ -105,11 +108,14 @@ class TestEvaluateOperation(TestCase):
         self.operation.workflow_file.read()
 
         with testfixtures.LogCapture():
-            with self.assertRaisesRegex(
+            with (self.assertRaisesRegex(
+                    RuntimeError,
+                    "Workflow file has errors.") or
+                  self.assertRaisesRegex(
                     RuntimeError,
                     r"The number of data values \(2 values\)"
                     " returned by 'test_data_source' does not match"
-                    " the number of user-defined names"):
+                    " the number of user-defined names")):
                 self.operation.run()   # fails
 
     def test_error_for_incorrect_output_slots(self):

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -124,14 +124,9 @@ class TestEvaluateOperation(TestCase):
         self.operation.workflow_file.read()
 
         with testfixtures.LogCapture():
-            with (self.assertRaisesRegex(
+            with self.assertRaisesRegex(
                     RuntimeError,
-                    "Workflow file has errors.") or
-                  self.assertRaisesRegex(
-                    RuntimeError,
-                    r"The number of data values \(2 values\)"
-                    " returned by 'test_data_source' does not match"
-                    " the number of user-defined names")):
+                    "Workflow file has errors."):
                 self.operation.run()
 
     def test_error_for_incorrect_output_slots(self):

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -68,16 +68,17 @@ class TestEvaluateOperation(TestCase):
         # Test for missing MCO
         self.operation.workflow.mco_model = None
         with testfixtures.LogCapture() as capture:
-            with self.assertRaisesRegex(
+            with (self.assertRaisesRegex(
                     RuntimeError, "Workflow file has errors"
-            ):
+            )):
                 self.operation.run()
             capture.check(
                 ('force_bdss.app.base_operation',
-                  'ERROR',
-                  'Unable to execute workflow due to verification errors:'),
-                 ('force_bdss.app.base_operation', 'ERROR',
-                  'Workflow has no MCO'))
+                 'ERROR',
+                 'Unable to execute workflow due to verification errors:'),
+                ('force_bdss.app.base_operation', 'ERROR',
+                 'Workflow has no MCO'),
+                )
 
     def test_run_broken_mco_communicator(self):
         # Test for broken MCO communicator

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -124,9 +124,14 @@ class TestEvaluateOperation(TestCase):
         self.operation.workflow_file.read()
 
         with testfixtures.LogCapture():
-            with self.assertRaisesRegex(
+            with (self.assertRaisesRegex(
+                      RuntimeError,
+                      "Workflow file has errors.") or
+                  self.assertRaisesRegex(
                     RuntimeError,
-                    "Workflow file has errors."):
+                    r"The number of data values \(2 values\)"
+                    " returned by 'test_data_source' does not match"
+                    " the number of user-defined names")):
                 self.operation.run()
 
     def test_error_for_incorrect_output_slots(self):

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -68,7 +68,7 @@ class TestEvaluateOperation(TestCase):
         # Test for missing MCO
         self.operation.workflow.mco_model = None
         with testfixtures.LogCapture() as capture:
-            self.operation.run()
+            self.operation.run(do_verify=False)
             capture.check(
                 ('force_bdss.app.evaluate_operation',
                  'INFO',
@@ -107,7 +107,7 @@ class TestEvaluateOperation(TestCase):
                     r"parameters specified \(0 values\). This is either "
                     "a MCO plugin error or the workflow file is "
                     "corrupted."):
-                self.operation.run()
+                self.operation.run(do_verify=False)
 
     def test_error_for_incorrect_output_slots(self):
 
@@ -175,7 +175,7 @@ class TestEvaluateOperation(TestCase):
                     r"The number of data values \(2 values\)"
                     " returned by 'test_data_source' does not match"
                     " the number of user-defined names"):
-                self.operation.run()
+                self.operation.run(do_verify=False)
 
     def test_data_source_broken(self):
 
@@ -184,7 +184,7 @@ class TestEvaluateOperation(TestCase):
 
         with testfixtures.LogCapture() as capture:
             with self.assertRaises(Exception):
-                self.operation.run()
+                self.operation.run(do_verify=False)
             capture.check(
                 ('force_bdss.app.evaluate_operation',
                  'INFO',

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -64,6 +64,21 @@ class TestEvaluateOperation(TestCase):
                  'INFO', 'Aggregating KPI data')
             )
 
+    def test_run_missing_mco(self):
+        # Test for missing MCO
+        self.operation.workflow.mco_model = None
+        with testfixtures.LogCapture() as capture:
+            with self.assertRaisesRegex(
+                    RuntimeError, "Workflow file has errors"
+            ):
+                self.operation.run()
+            capture.check(
+                ('force_bdss.app.base_operation',
+                  'ERROR',
+                  'Unable to execute workflow due to verification errors:'),
+                 ('force_bdss.app.base_operation', 'ERROR',
+                  'Workflow has no MCO'))
+
     def test_run_broken_mco_communicator(self):
         # Test for broken MCO communicator
         factory = self.registry.mco_factories[0]

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -99,7 +99,7 @@ class TestEvaluateOperation(TestCase):
                     r"parameters specified \(0 values\). This is either "
                     "a MCO plugin error or the workflow file is "
                     "corrupted.")):
-                self.operation.run()  # fails
+                self.operation.run()
 
     def test_error_for_missing_ds_output_names(self):
 
@@ -116,7 +116,7 @@ class TestEvaluateOperation(TestCase):
                     r"The number of data values \(2 values\)"
                     " returned by 'test_data_source' does not match"
                     " the number of user-defined names")):
-                self.operation.run()   # fails
+                self.operation.run()
 
     def test_error_for_incorrect_output_slots(self):
 

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -117,23 +117,6 @@ class TestEvaluateOperation(TestCase):
                     "corrupted.")):
                 self.operation.run()
 
-    def test_error_for_missing_ds_output_names(self):
-
-        factory = self.registry.data_source_factories[0]
-        factory.output_slots_size = 2
-        self.operation.workflow_file.read()
-
-        with testfixtures.LogCapture():
-            with (self.assertRaisesRegex(
-                      RuntimeError,
-                      "Workflow file has errors.") or
-                  self.assertRaisesRegex(
-                    RuntimeError,
-                    r"The number of data values \(2 values\)"
-                    " returned by 'test_data_source' does not match"
-                    " the number of user-defined names")):
-                self.operation.run()
-
     def test_error_for_incorrect_output_slots(self):
 
         def probe_run(self, *args, **kwargs):

--- a/force_bdss/cli/tests/test_cli_execution.py
+++ b/force_bdss/cli/tests/test_cli_execution.py
@@ -35,7 +35,7 @@ class TestCLIExecution(unittest.TestCase):
                 stderr=devnull)
             proc.communicate(b"1")
             retcode = proc.wait()
-            self.assertEqual(retcode, 0)
+            self.assertEqual(retcode, 1)
 
     def test_unsupported_file_input(self):
         with cd(fixtures.dirpath()):

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -8,7 +8,6 @@ from force_bdss.io.workflow_reader import WorkflowReader
 from force_bdss.tests.dummy_classes.factory_registry import (
     DummyFactoryRegistry,
 )
-
 from force_bdss.io.workflow_writer import (
     WorkflowWriter,
 )

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -63,6 +63,14 @@ class TestBaseMCOModel(unittest.TestCase, UnittestTools):
                 "kpis": [],
             },
         )
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "The number of data values returned by"
+                r" the MCO \(0 values\) does not match the"
+                r" number of parameters specified \(1 values\)."
+                " This is either a MCO plugin error or the workflow"
+                " file is corrupted."):
+            mco_model.bind_parameters([])
 
     def test_notify_events(self):
         workflow_file = ProbeWorkflowFile(path=fixtures.get("test_probe.json"))


### PR DESCRIPTION
Closes #317. This is not the best solution. 

The problem is, is that `capture.check` (in the unit test) has to match every log in A.foo(), no matter whether it comes from A.foo or BaseOfA.foo(). Therefore you cannot just separate out part of Evaluate/OptimizeOperation.run() into a base class and then test that part separately in base unit test.

What I have done is port the workflow verification part of Evaluate/OptimizeOperation.run() into the base class, but only run that part during testing of OptimizeOperation.run(), by using a do_verify=False switch during testing of EvaluateOperation.run().