### PR TITLE
TST/FIX: Suggested fixes to TestBaseDataSourceModel class

### DIFF
--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -186,5 +186,5 @@ class TestEvaluateOperation(TestCase):
                   "'force.bdss.enthought.plugin.test.v0.factory."
                   "probe_data_source', plugin "
                   "'force.bdss.enthought.plugin.test.v0'. "
-                  "This might indicate a  programming "
+                  "This might indicate a programming "
                   'error'))

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -76,7 +76,7 @@ class BaseDataSourceModel(BaseModel):
         except Exception:
             logger.exception(
                 "Unable to create data source from factory '%s', plugin "
-                "'%s'. This might indicate a  programming error",
+                "'%s'. This might indicate a programming error",
                 self.factory.id,
                 self.factory.plugin_id,
             )

--- a/force_bdss/data_sources/tests/test_base_data_source_model.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_model.py
@@ -1,4 +1,5 @@
 import unittest
+import testfixtures
 
 from traits.api import Int
 from traits.testing.api import UnittestTools
@@ -88,18 +89,27 @@ class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
 
         self.mock_factory.create_data_source = create_data_source
         model = DummyDataSourceModel(self.mock_factory)
-        with self.assertRaisesRegex(
-                Exception, "Bad data source factory"):
-            model.verify()
+        with testfixtures.LogCapture() as capture:
+            with self.assertRaisesRegex(
+                    Exception, "Bad data source factory"):
+                model.verify()
+            capture.check(
+                ("force_bdss.data_sources.base_data_source_model",
+                 "ERROR",
+                 "Unable to create data source from factory "
+                 "'id', plugin 'dummy_id'. This "
+                 "might indicate a programming error")
+            )
 
     def test_bad_slots(self):
         self.mock_factory.create_data_source = mock.MagicMock(
             return_value=BadDataSource(self.mock_factory)
         )
         model = DummyDataSourceModel(self.mock_factory)
-        with self.assertRaisesRegex(
-                Exception, "bad slots"):
-            model.verify()
+        with testfixtures.LogCapture():
+            with self.assertRaisesRegex(
+                    Exception, "bad slots"):
+                model.verify()
 
     def test_from_json(self):
         registry = DummyFactoryRegistry()

--- a/force_bdss/data_sources/tests/test_base_data_source_model.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_model.py
@@ -33,7 +33,8 @@ class BadDataSource(DummyDataSource):
 
 class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
     def setUp(self):
-        self.mock_factory = mock.Mock(spec=BaseDataSourceFactory)
+        self.mock_factory = mock.Mock(
+            spec=BaseDataSourceFactory, plugin_id='dummy_id')
         self.mock_factory.id = "id"
 
     def test_getstate(self):
@@ -82,12 +83,13 @@ class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
             model.c = 5
 
     def test_bad_factory(self):
-        def create_data_source(self):
+        def create_data_source():
             raise Exception("Bad data source factory")
 
         self.mock_factory.create_data_source = create_data_source
         model = DummyDataSourceModel(self.mock_factory)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(
+                Exception, "Bad data source factory"):
             model.verify()
 
     def test_bad_slots(self):
@@ -95,7 +97,8 @@ class TestBaseDataSourceModel(unittest.TestCase, UnittestTools):
             return_value=BadDataSource(self.mock_factory)
         )
         model = DummyDataSourceModel(self.mock_factory)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(
+                Exception, "bad slots"):
             model.verify()
 
     def test_from_json(self):


### PR DESCRIPTION
Includes fixes to mocked objects that ensure both `TestBaseDataSourceModel.test_bad_factory` and `TestBaseDataSourceModel.test_bad_slots` are asserting that the correct `Exceptions` have been raised.

Previously, an error was being generated in the invocation of `self.mock_factory.create_data_source`, related to a missing `plugin_id` attribute on the mocked `BaseDataSourceFactory` class. This then prevented any further code from being tested.

This has now been resolved, with `testfixtures.LogCapture` used to check the logs and tidy up the unit test traceback.

## Note:
I couldn't get the `capture.check` call to work in `test_bad_slots` (string formatting I expect), so I left it out. The `LogCapture` context manager is still used, since it prevents the log statements from cluttering up the unit test output.