### PR TITLE
Verification message two

### DIFF
--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -139,10 +139,6 @@ class TestOptimizeOperation(TestCase):
                 self.operation._deliver_start_event()
             mock_call.assert_called_once()
 
-    ##############################################
-    # RUN TESTS: POSSIBLY COMMON WITH EVALUATE OPERATION
-    ##############################################
-
     def test_non_valid_file(self):
 
         # Provide a workflow that is invalid
@@ -171,15 +167,22 @@ class TestOptimizeOperation(TestCase):
                     "The MCO has no defined KPIs"
                 ),
                 (
-                    "force_bdss.app.base_operation",
-                    "ERROR",
-                    "The number of input slots is incorrect."
-                ),
+                    'force_bdss.app.base_operation',
+                    'ERROR',
+                    "The number of input slots (1 values) returned by "
+                    "'test_data_source' does "
+                    'not match the number of user-defined names specified '
+                    '(0 values). This is '
+                    'either a plugin error or a file error.'
+                 ),
                 (
-                    "force_bdss.app.base_operation",
-                    "ERROR",
-                    "The number of output slots is incorrect."
-                )
+                    'force_bdss.app.base_operation',
+                    'ERROR',
+                    "The number of output slots (1 values) returned by "
+                    "'test_data_source' does "
+                    'not match the number of user-defined names specified '
+                    '(0 values). This is '
+                    'either a plugin error or a file error.')
             )
 
     def test_run_empty_workflow(self):

--- a/force_bdss/core/tests/test_execution_layer.py
+++ b/force_bdss/core/tests/test_execution_layer.py
@@ -36,8 +36,6 @@ class TestExecutionLayer(TestCase, UnittestTools):
         messages = [error.local_error for error in errors]
 
         self.assertEqual(4, len(messages))
-        self.assertIn("The number of input slots is incorrect.", messages)
-        self.assertIn("The number of output slots is incorrect.", messages)
 
         self.layer.data_sources = []
         errors = self.layer.verify()

--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -105,7 +105,7 @@ class TestVerifier(unittest.TestCase):
 
         errors = verify_workflow(wf)
         self.assertEqual(errors[0].subject, ds_model)
-        self.assertIn("The number of input slots is incorrect.",
+        self.assertIn("The number of input slots",
                       errors[0].local_error)
 
         ds_model.input_slot_info.append(
@@ -114,7 +114,7 @@ class TestVerifier(unittest.TestCase):
 
         errors = verify_workflow(wf)
         self.assertEqual(errors[0].subject, ds_model)
-        self.assertIn("The number of output slots is incorrect.",
+        self.assertIn("The number of output slots ",
                       errors[0].local_error)
 
         ds_model.output_slot_info.append(

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -96,10 +96,18 @@ class BaseDataSourceModel(BaseModel):
 
         errors = []
         if len(input_slots) != len(self.input_slot_info):
+            local_error_txt = (
+                "The number of input slots ({} values) returned"
+                " by '{}' does not match the number"
+                " of user-defined names specified ({} values)."
+                " This is either a plugin error or a file"
+                " error."
+            ).format(len(input_slots), self.factory.name,
+                     len(self.input_slot_info))
             errors.append(
                 VerifierError(
                     subject=self,
-                    local_error="The number of input slots is incorrect.",
+                    local_error=local_error_txt,
                     global_error=(
                         "A data source model has incorrect number "
                         "of input slots."
@@ -110,21 +118,20 @@ class BaseDataSourceModel(BaseModel):
             errors += input_slot.verify()
 
         if len(output_slots) != len(self.output_slot_info):
-            error_txt = (
-                "The number of data values ({} values) returned"
+            local_error_txt = (
+                "The number of output slots ({} values) returned"
                 " by '{}' does not match the number"
                 " of user-defined names specified ({} values)."
                 " This is either a plugin error or a file"
                 " error."
-            ).format(len(res), factory.name, len(model.output_slot_info))
+            ).format(len(output_slots), self.factory.name,
+                     len(self.output_slot_info))
             errors.append(
                 VerifierError(
                     subject=self,
-                    local_error="The number of output slots is incorrect.",
-                    global_error=(
-                        "A data source model has incorrect number "
-                        "of output slots."
-                    ),
+                    local_error=local_error_txt,
+                    global_error="A data source model has incorrect number "
+                                 "of output slots."
                 )
             )
 

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -110,6 +110,13 @@ class BaseDataSourceModel(BaseModel):
             errors += input_slot.verify()
 
         if len(output_slots) != len(self.output_slot_info):
+            error_txt = (
+                "The number of data values ({} values) returned"
+                " by '{}' does not match the number"
+                " of user-defined names specified ({} values)."
+                " This is either a plugin error or a file"
+                " error."
+            ).format(len(res), factory.name, len(model.output_slot_info))
             errors.append(
                 VerifierError(
                     subject=self,


### PR DESCRIPTION
Closes #324. 

Ported output/input slot error messages from ExecutionLayer.execute_layer() to BaseDataSourceModel.verify().

Did not remove tests from execute_layer() - that took me down a unit-test rabbit hole.