### PR TITLE
CLN: Interface classes

### DIFF
--- a/force_bdss/core/i_factory.py
+++ b/force_bdss/core/i_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Interface, Str
+from traits.api import Interface, Str, Bool
 
 
 class IFactory(Interface):
@@ -12,6 +12,8 @@ class IFactory(Interface):
     name = Str()
 
     plugin_id = Str(allow_none=False)
+
+    ui_visible = Bool()
 
     def get_name(self):
         """

--- a/force_bdss/data_sources/i_data_source_factory.py
+++ b/force_bdss/data_sources/i_data_source_factory.py
@@ -28,3 +28,11 @@ class IDataSourceFactory(IFactory):
         """
         :return: model class.
         """
+
+    def create_data_source(self):
+        """Returns an instance of subclass BaseDataSource
+        """
+
+    def create_model(self):
+        """Returns an instance of subclass BaseDataSourceModel
+        """

--- a/force_bdss/mco/i_mco_factory.py
+++ b/force_bdss/mco/i_mco_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Type
+from traits.api import Type, List
 
 from force_bdss.core.i_factory import IFactory
 
@@ -25,6 +25,10 @@ class IMCOFactory(IFactory):
         allow_none=False
     )
 
+    parameter_factory_classes = List(Type(
+        "force_bdss.mco.parameters.i_mco_parameter_factory"
+        ".IMCOParameterFactory"))
+
     def get_model_class(self):
         """
         :return: model class.
@@ -40,6 +44,10 @@ class IMCOFactory(IFactory):
         :return: optimizer class
         """
 
+    def get_parameter_factory_classes(self):
+        """Returns a list of classes that provide the
+        IMCOParameterFactory interface"""
+
     def create_optimizer(self):
         """
         :return: optimizer
@@ -53,9 +61,4 @@ class IMCOFactory(IFactory):
     def create_communicator(self):
         """
         :return: communicator
-        """
-
-    def parameter_factories(self):
-        """
-        :return:
         """

--- a/force_bdss/mco/parameters/base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/base_mco_parameter_factory.py
@@ -26,11 +26,6 @@ class BaseMCOParameterFactory(BaseFactory):
         allow_none=False
     )
 
-    def get_model_class(self):
-        raise NotImplementedError(
-            "get_model_class was not implemented in factory {}".format(
-                self.__class__))
-
     def __init__(self, mco_factory, *args, **kwargs):
         super(BaseMCOParameterFactory, self).__init__(
             plugin={'id': mco_factory.plugin_id,
@@ -40,6 +35,11 @@ class BaseMCOParameterFactory(BaseFactory):
             **kwargs)
 
         self.model_class = self.get_model_class()
+
+    def get_model_class(self):
+        raise NotImplementedError(
+            "get_model_class was not implemented in factory {}".format(
+                self.__class__))
 
     def create_model(self, data_values=None):
         """Creates the instance of the model class and returns it.

--- a/force_bdss/mco/parameters/i_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/i_mco_parameter_factory.py
@@ -1,23 +1,19 @@
-from traits.api import Instance, Type, Str
+from traits.api import Instance, Type
 from force_bdss.core.i_factory import IFactory
 
 
 class IMCOParameterFactory(IFactory):
+
     mco_factory = Instance('force_bdss.mco.base_mco_factory.BaseMCOFactory',
                            allow_none=False)
-
-    description = Str()
 
     model_class = Type(
         "force_bdss.mco.parameters.base_mco_parameter.BaseMCOParameter",
         allow_none=False
     )
 
-    def get_description(self):
-        """"""
-
     def get_model_class(self):
-        """"""
+        """Returns type of BaseMCOParameter subclass"""
 
     def create_model(self, data_values=None):
-        """"""
+        """Returns instance of BaseMCOParameter subclass"""

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -210,24 +210,28 @@ class TestRangedVectorMCOParameter(TestCase):
         self.assertEqual(1, len(self.parameter.upper_bound))
         self.assertEqual(1, len(self.parameter.lower_bound))
         self.assertEqual(1, len(self.parameter.initial_value))
+        self.assertListEqual([100.0], self.parameter.upper_bound)
+        self.assertListEqual([0.1], self.parameter.lower_bound)
+        self.assertListEqual([50.05], self.parameter.initial_value)
 
         self.parameter.dimension = 3
         self.assertEqual(3, self.parameter.dimension)
         self.assertEqual(3, len(self.parameter.upper_bound))
         self.assertEqual(3, len(self.parameter.lower_bound))
         self.assertEqual(3, len(self.parameter.initial_value))
-        self.assertListEqual([0.0, 0.0], self.parameter.upper_bound[1:])
-        self.assertListEqual([0.0, 0.0], self.parameter.lower_bound[1:])
-        self.assertListEqual([0.0, 0.0], self.parameter.initial_value[1:])
+        self.assertListEqual([100.0, 0.0, 0.0], self.parameter.upper_bound)
+        self.assertListEqual([0.1, 0.0, 0.0], self.parameter.lower_bound)
+        self.assertListEqual([50.05, 0.0, 0.0], self.parameter.initial_value)
 
+        self.parameter.upper_bound = [100.0, 0.0]
         self.parameter.dimension = 2
         self.assertEqual(2, self.parameter.dimension)
         self.assertEqual(2, len(self.parameter.upper_bound))
         self.assertEqual(2, len(self.parameter.lower_bound))
         self.assertEqual(2, len(self.parameter.initial_value))
-        self.assertListEqual([0.0], self.parameter.upper_bound[1:])
-        self.assertListEqual([0.0], self.parameter.lower_bound[1:])
-        self.assertListEqual([0.0], self.parameter.initial_value[1:])
+        self.assertListEqual([100.0, 0.0], self.parameter.upper_bound)
+        self.assertListEqual([0.1, 0.0], self.parameter.lower_bound)
+        self.assertListEqual([50.05, 0.0], self.parameter.initial_value)
 
     def test_verify(self):
 

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -9,8 +9,6 @@ class INotificationListenerFactory(IFactory):
 
     Refer to the BaseNotificationListenerFactory for documentation.
     """
-    ui_visible = Bool()
-
     listener_class = Type(
         "force_bdss.notification_listeners"
         ".base_notification_listener.BaseNotificationListener",

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -1,4 +1,4 @@
-from traits.api import Type, Bool
+from traits.api import Type
 
 from force_bdss.core.i_factory import IFactory
 

--- a/force_bdss/ui_hooks/i_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/i_ui_hooks_factory.py
@@ -1,5 +1,4 @@
-from traits.api import Instance, Type
-from envisage.plugin import Plugin
+from traits.api import Type
 
 from force_bdss.core.i_factory import IFactory
 
@@ -14,8 +13,6 @@ class IUIHooksFactory(IFactory):
         "force_bdss.ui_hooks.base_ui_hooks_manager.BaseUIHooksManager",
         allow_none=False
     )
-
-    plugin = Instance(Plugin, allow_none=False)
 
     def get_ui_hooks_manager_class(self):
         """


### PR DESCRIPTION
Provides a clean up of `Interface` classes defined in the BDSS.

Generally removes some attributes or methods that are no longer needed by their corresponding base class implementations and includes others that are missing.

Does not change any functionality, only tidies up code base to accompany #311 and provides a minor unit test fix to maintain coverage.