### PR TITLE
FIX: Correction to #334 to ensure UniformSpaceSampler and DirichletSpaceSampler behave similarly

### DIFF
--- a/force_bdss/mco/optimizer_engines/space_sampling.py
+++ b/force_bdss/mco/optimizer_engines/space_sampling.py
@@ -5,6 +5,22 @@ from traits.api import ABCHasStrictTraits, Bool, ListFloat
 from force_bdss.local_traits import PositiveInt
 
 
+def resolution_to_sample_size(space_dimension, n_points):
+    """ Calculates what is the exact number of space samples (vectors
+    of dimension `space_dimension`) we should pick, in order to have
+    an effective sampling resolution of `nof_points` per dimension.
+    This method unifies the number of samples from stochastic space
+    search models and the number of samples from the uniform-along-each-axis
+    sampling.
+    """
+    samples_total = (
+            np.math.factorial(space_dimension + n_points - 2)
+            / np.math.factorial(space_dimension - 1)
+            / np.math.factorial(n_points - 1)
+    )
+    return int(samples_total)
+
+
 class SpaceSampler(ABCHasStrictTraits):
     """ Base class for search space sampling from various distributions.
 
@@ -85,7 +101,8 @@ class DirichletSpaceSampler(SpaceSampler):
         return self._distribution_function(self.alpha).tolist()
 
     def generate_space_sample(self):
-        for _ in range(self.resolution):
+        n_points = resolution_to_sample_size(self.dimension, self.resolution)
+        for _ in range(n_points):
             yield self._get_sample_point()
 
 

--- a/force_bdss/mco/optimizer_engines/space_sampling.py
+++ b/force_bdss/mco/optimizer_engines/space_sampling.py
@@ -2,6 +2,7 @@ import abc
 import numpy as np
 
 from traits.api import ABCHasStrictTraits, Bool, ListFloat
+
 from force_bdss.local_traits import PositiveInt
 
 
@@ -137,13 +138,21 @@ class UniformSpaceSampler(SpaceSampler):
             Yields all the possible combinations satisfying the requirement
             that the sum of all the weights must always be 1.0
         """
-        n_combinations = self.resolution - 1
+        n_combinations = self.resolution
         if not self.with_zero_values:
             n_combinations += self.dimension
 
-        scaling = 1.0 / n_combinations
-        for int_w in self._int_weights():
-            yield [scaling * val for val in int_w]
+        # If we are only returning one weight combination, it must
+        # equal 1.0 since the weights are all normalised. No zero
+        # values will be allowed in this case.
+        try:
+            scaling = 1.0 / (n_combinations - 1)
+        except ZeroDivisionError:
+            yield [1.0]
+
+        else:
+            for int_w in self._int_weights():
+                yield [scaling * val for val in int_w]
 
     def _int_weights(self, resolution=None, dimension=None):
         """Helper routine for the `_get_sample_point`. Generates integer values

--- a/force_bdss/mco/optimizer_engines/tests/test_space_sampling.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_space_sampling.py
@@ -4,20 +4,56 @@ import numpy as np
 
 from force_bdss.mco.optimizer_engines.space_sampling import (
     UniformSpaceSampler, DirichletSpaceSampler,
-    SpaceSampler)
+    SpaceSampler, resolution_to_sample_size)
+
+
+class TestSpaceSampling(TestCase):
+
+    def test_resolution_to_sample_size(self):
+
+        self.assertEqual(1, resolution_to_sample_size(1, 1))
+        self.assertEqual(1, resolution_to_sample_size(1, 10))
+        self.assertEqual(1, resolution_to_sample_size(3, 1))
+        self.assertEqual(6, resolution_to_sample_size(3, 3))
+        self.assertEqual(715, resolution_to_sample_size(5, 10))
 
 
 class BaseTestSampler(TestCase):
+
     distribution = SpaceSampler
+
+    def setUp(self):
+        self.dimensions = [1, 3, 5]
+        self.resolutions = [1, 3, 10]
+
+    def assertArrayAlmostEqual(self, array_like1, array_like2):
+        return self.assertTrue(
+            np.allclose(array_like1, array_like2))
 
     def generate_values(self, *args, **kwargs):
         return self.distribution(*args, **kwargs).generate_space_sample(
             **kwargs
         )
 
-    def assertArrayAlmostEqual(self, array_like1, array_like2):
-        return self.assertTrue(
-            np.allclose(array_like1, array_like2))
+    def generate_samplers(self, **kwargs):
+        for dimension in self.dimensions:
+            for resolutions in self.resolutions:
+                yield self.distribution(
+                    dimension, resolutions, **kwargs
+                )
+
+    def generate_space_samples(self, **kwargs):
+        for sampler in self.generate_samplers(**kwargs):
+            space_sample = list(sampler.generate_space_sample())
+            self.assertEqual(
+                len(space_sample),
+                resolution_to_sample_size(
+                    sampler.dimension, sampler.resolution
+                ),
+            )
+
+            for sample in space_sample:
+                self.assertAlmostEqual(1.0, sum(sample))
 
 
 class TestUniformSpaceSampler(BaseTestSampler):
@@ -27,6 +63,15 @@ class TestUniformSpaceSampler(BaseTestSampler):
         return self.distribution(*args, **kwargs)._int_weights()
 
     def test__int_weights(self):
+
+        self.assertListEqual(
+            [[1]],
+            list(self.generate_weights(1, 1))
+        )
+        self.assertListEqual(
+            [[0]],
+            list(self.generate_weights(1, 1, with_zero_values=True))
+        )
 
         self.assertListEqual(
             [[1, 1]],
@@ -46,16 +91,7 @@ class TestUniformSpaceSampler(BaseTestSampler):
             list(self.generate_weights(2, 3, with_zero_values=True))
         )
 
-    def test_space_sample(self):
-
-        self.assertEqual(
-            [[1.0]],
-            list(self.generate_values(1, 5))
-        )
-        self.assertEqual(
-            [[1.0]],
-            list(self.generate_values(1, 5, with_zero_values=True))
-        )
+    def test_space_sample_values(self):
 
         self.assertArrayAlmostEqual(
             [[5/6, 1/6], [2/3, 1/3], [0.5, 0.5], [1/3, 2/3], [1/6, 5/6]],
@@ -66,41 +102,26 @@ class TestUniformSpaceSampler(BaseTestSampler):
             list(self.generate_values(2, 5, with_zero_values=True)),
         )
 
-        # Assert all weights are normalised to 1
-        for weights in self.generate_values(3, 10):
-            self.assertAlmostEqual(1.0, sum(weights))
-        for weights in self.generate_values(3, 10, with_zero_values=True):
-            self.assertAlmostEqual(1.0, sum(weights))
+    def test_generate_space_sample(self):
+        for with_zero_values in [False, True]:
+            self.generate_space_samples(
+                with_zero_values=with_zero_values)
 
 
 class TestDirichletSpaceSampler(BaseTestSampler):
+
     distribution = DirichletSpaceSampler
 
     def setUp(self):
-        self.dimensions = [3, 1, 5]
+        super().setUp()
         self.alphas = [1, 0.5, 10]
-        self.n_points = [3, 10, 6]
-
-    def generate_samplers(self):
-        for dimension in self.dimensions:
-            for n_points in self.n_points:
-                for alpha in self.alphas:
-                    yield DirichletSpaceSampler(
-                        dimension, n_points, alpha=alpha
-                    )
 
     def test__get_sample_point(self):
-        for sampler in self.generate_samplers():
-            self.assertAlmostEqual(1.0, sum(sampler._get_sample_point()))
+        for alpha in self.alphas:
+            for sampler in self.generate_samplers(alpha=alpha):
+                self.assertAlmostEqual(
+                    1.0, sum(sampler._get_sample_point()))
 
     def test_generate_space_sample(self):
-        for sampler in self.generate_samplers():
-
-            space_sample = list(sampler.generate_space_sample())
-            self.assertEqual(
-                len(space_sample),
-                sampler.resolution
-            )
-
-            for sample in space_sample:
-                self.assertAlmostEqual(1.0, sum(sample))
+        for alpha in self.alphas:
+            self.generate_space_samples(alpha=alpha)


### PR DESCRIPTION
This PR corrects some mistakes introduced in #334.

 It reintroduces the `resolution_to_sample_size` function in order to ensure that the `UniformSpaceSampler` and `DirichletSpaceSampler` sample the same number of points for a given pair of `dimension` and `resolution` attributes. 

Additionally, some extra logic is introduced into the `UniformSpaceSampler` to handle edge cases when only one weight will be returned. This is always set to `1.0` due to our normalisation constraints.

