### PR TITLE
DEV: Suggested Edits for #343

### DIFF
--- a/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
@@ -24,7 +24,7 @@ class AposterioriOptimizerEngine(BaseOptimizerEngine):
 
     #: IOptimizer class that provides library backend for optimizing a
     #: callable
-    optimizer = Instance(IOptimizer)
+    optimizer = Instance(IOptimizer, transient=True)
 
     def optimize(self, *vargs):
         """ Generates optimization results.

--- a/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
@@ -1,7 +1,8 @@
 import logging
-import abc
 
-from traits.api import Str, Property
+from traits.api import Str, Instance
+
+from force_bdss.mco.optimizers.i_optimizer import IOptimizer
 
 from .base_optimizer_engine import BaseOptimizerEngine
 
@@ -21,21 +22,7 @@ class AposterioriOptimizerEngine(BaseOptimizerEngine):
     #: Optimizer name
     name = Str("APosteriori_Optimizer")
 
-    #: Default (initial) guess on input parameter values
-    initial_parameter_value = Property(
-        depends_on="parameters.[initial_value]", visible=False
-    )
-
-    #: Input parameter bounds. Defines the search space.
-    parameter_bounds = Property(
-        depends_on="parameters.[lower_bound, upper_bound]", visible=False
-    )
-
-    def _get_initial_parameter_value(self):
-        return [p.initial_value for p in self.parameters]
-
-    def _get_parameter_bounds(self):
-        return [(p.lower_bound, p.upper_bound) for p in self.parameters]
+    optimizer = Instance(IOptimizer)
 
     def optimize(self, *vargs):
         """ Generates optimization results.
@@ -46,7 +33,7 @@ class AposterioriOptimizerEngine(BaseOptimizerEngine):
             Point of evaluation, objective value
         """
         #:
-        pareto = self.optimize_function(
+        pareto = self.optimizer.optimize_function(
             self._score,
             self.parameters,
             ()
@@ -58,10 +45,3 @@ class AposterioriOptimizerEngine(BaseOptimizerEngine):
     def unpacked_score(self, *unpacked_input):
         packed_input = list(unpacked_input)
         return self._score(packed_input)
-
-    @abc.abstractmethod
-    def optimize_function(self, func, x0, bounds):
-        """ A wrapper for the optimizer. Any subclass of this class
-        can implement this function by also inheriting a mixin class
-        implementing the IOptimizer interface.
-        """

--- a/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
@@ -22,6 +22,8 @@ class AposterioriOptimizerEngine(BaseOptimizerEngine):
     #: Optimizer name
     name = Str("APosteriori_Optimizer")
 
+    #: IOptimizer class that provides library backend for optimizing a
+    #: callable
     optimizer = Instance(IOptimizer)
 
     def optimize(self, *vargs):

--- a/force_bdss/mco/optimizer_engines/base_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/base_optimizer_engine.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 
-from traits.api import ABCHasStrictTraits, List, Instance, Bool
+from traits.api import ABCHasStrictTraits, List, Instance, Bool, Property
 
 from force_bdss.core.kpi_specification import KPISpecification
 from force_bdss.mco.parameters.base_mco_parameter import BaseMCOParameter
@@ -36,9 +36,25 @@ class BaseOptimizerEngine(ABCHasStrictTraits):
         IEvaluator, visible=False, transient=True
     )
 
+    #: Default (initial) guess on input parameter values
+    initial_parameter_value = Property(
+        depends_on="parameters.[initial_value]", visible=False
+    )
+
+    #: Input parameter bounds. Defines the search space.
+    parameter_bounds = Property(
+        depends_on="parameters.[lower_bound, upper_bound]", visible=False
+    )
+
     #: Yield data points on each workflow evaluation, or return filtered
     #: data, e.g. Pareto front only
     verbose_run = Bool(False)
+
+    def _get_initial_parameter_value(self):
+        return [p.initial_value for p in self.parameters]
+
+    def _get_parameter_bounds(self):
+        return [(p.lower_bound, p.upper_bound) for p in self.parameters]
 
     @abc.abstractmethod
     def optimize(self):

--- a/force_bdss/mco/optimizer_engines/tests/test_aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_aposteriori_optimizer_engine.py
@@ -17,11 +17,12 @@ from force_bdss.mco.optimizers.scipy_optimizer import (
 )
 
 
-class AposterioriScipyEngine(ScipyOptimizer, AposterioriOptimizerEngine):
-    """This needs to be a mixin with an a posteriori optimiser, to test
-    the optimize routine.
+class AposterioriScipyEngine(AposterioriOptimizerEngine):
+    """Provide a ScipyOptimizer instance as the default optimizer
+    attribute
     """
-    pass
+    def _optimizer_default(self):
+        return ScipyOptimizer()
 
 
 class DummyOptimizerEngine(MixinDummyOptimizerEngine, AposterioriScipyEngine):
@@ -36,8 +37,6 @@ class TestAposterioriEngine(TestCase):
 
         self.kpis = [KPISpecification(), KPISpecification()]
         self.parameters = [1, 1, 1, 1]
-
-        self.kpis = self.kpis
 
         self.parameters = [
             RangedMCOParameterFactory(self.factory).create_model(
@@ -57,24 +56,14 @@ class TestAposterioriEngine(TestCase):
         self.assertIsInstance(self.optimizer, AposterioriScipyEngine)
         self.assertEqual("APosteriori_Optimizer", self.optimizer.name)
         self.assertIs(self.optimizer.single_point_evaluator, None)
-        self.assertEqual("SLSQP", self.optimizer.algorithms)
-
-        self.assertListEqual(
-            self.optimizer.initial_parameter_value,
-            [0.5] * len(self.parameters),
-        )
-        self.assertListEqual(
-            self.optimizer.parameter_bounds,
-            [(0.0, 1.0)] * len(self.parameters),
-        )
+        self.assertIsInstance(self.optimizer.optimizer, ScipyOptimizer)
+        self.assertEqual("SLSQP", self.optimizer.optimizer.algorithms)
 
     def test___getstate__(self):
         state = self.optimizer.__getstate__()
         self.assertDictEqual(
             {
                 "name": "APosteriori_Optimizer",
-                "algorithms": "SLSQP",
-                "optimizer": None,
                 "verbose_run": False
             },
             state,
@@ -83,3 +72,6 @@ class TestAposterioriEngine(TestCase):
     def test_optimize(self):
         """ To test this we need an a posteriori optimizer installed in bdss.
         """
+        # NOTE: we can use a dummy IOptimize class here to check the
+        # values that should be returned from calling
+        # AposterioriOptimizerEngine.optimize

--- a/force_bdss/mco/optimizer_engines/tests/test_base_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_base_optimizer_engine.py
@@ -17,7 +17,6 @@ class TestBaseOptimizerEngine(TestCase):
         workflow_file.read()
         self.workflow = workflow_file.workflow
 
-        self.kpis = [KPISpecification(), KPISpecification()]
         self.parameters = [1, 1, 1, 1]
         self.optimizer_engine = EmptyOptimizerEngine(
             single_point_evaluator=self.workflow

--- a/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
@@ -24,10 +24,11 @@ from force_bdss.mco.optimizers.scipy_optimizer import ScipyOptimizer
 
 
 class WeightedScipyEngine(WeightedOptimizerEngine):
-
-    def __init__(self, *args, **kwargs):
-        optimizer = ScipyOptimizer()
-        super().__init__(*args, optimizer=optimizer, **kwargs)
+    """Provide a ScipyOptimizer instance as the default optimizer
+    attribute
+    """
+    def _optimizer_default(self):
+        return ScipyOptimizer()
 
 
 class DummyOptimizerEngine(MixinDummyOptimizerEngine, WeightedScipyEngine):
@@ -63,8 +64,6 @@ class TestWeightedOptimizer(TestCase):
         self.kpis = [KPISpecification(), KPISpecification()]
         self.parameters = [1, 1, 1, 1]
 
-        self.kpis = self.kpis
-
         self.parameters = [
             RangedMCOParameterFactory(self.factory).create_model(
                 {"lower_bound": 0.0, "upper_bound": 1.0}
@@ -87,18 +86,8 @@ class TestWeightedOptimizer(TestCase):
         self.assertEqual(7, self.optimizer.num_points)
         self.assertEqual("Uniform", self.optimizer.space_search_mode)
 
-        self.assertListEqual(
-            self.optimizer.initial_parameter_value,
-            [0.5] * len(self.parameters),
-        )
-        self.assertListEqual(
-            self.optimizer.parameter_bounds,
-            [(0.0, 1.0)] * len(self.parameters),
-        )
-
     def test___getstate__(self):
         state = self.optimizer.__getstate__()
-        optimizer = state.pop('optimizer')
         self.assertDictEqual(
             {
                 "name": "Weighted_Optimizer",
@@ -109,7 +98,6 @@ class TestWeightedOptimizer(TestCase):
             },
             state,
         )
-        self.assertIsInstance(optimizer, IOptimizer)
 
     def test__space_search_distribution(self):
         for strategy, klass in (

--- a/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
@@ -19,7 +19,6 @@ from force_bdss.mco.optimizer_engines.space_sampling import (
 from force_bdss.mco.optimizer_engines.weighted_optimizer_engine import (
     WeightedOptimizerEngine
 )
-from force_bdss.mco.optimizers.i_optimizer import IOptimizer
 from force_bdss.mco.optimizers.scipy_optimizer import ScipyOptimizer
 
 

--- a/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
@@ -92,7 +92,7 @@ class WeightedOptimizerEngine(BaseOptimizerEngine):
 
     #: IOptimizer class that provides library backend for optimizing a
     #: callable
-    optimizer = Instance(IOptimizer)
+    optimizer = Instance(IOptimizer, transient=True)
 
     def optimize(self, *vargs):
         """ Generates optimization results.

--- a/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
@@ -90,6 +90,8 @@ class WeightedOptimizerEngine(BaseOptimizerEngine):
     #: Space search distribution for weight points sampling
     space_search_mode = Enum("Uniform", "Dirichlet")
 
+    #: IOptimizer class that provides library backend for optimizing a
+    #: callable
     optimizer = Instance(IOptimizer)
 
     def optimize(self, *vargs):


### PR DESCRIPTION
## Description

### Related Issues
#342 #343 

### Background
Suggested usage of `IOptimizer` classes - although #342 originally planned to have a mixin based system, it may make better sense to use `Interface` classes instead.

### Summary
Rather than using these classes as mixins for `BaseOptimizerEngine` subclasses, we include them as traits. 

This also allows for reallocation of a library backend during runtime.

### Notes:
I am sure there are some confusing naming conventions going on here, happy to hear any alternatives

### Future Work
- Update existing PRs for Nevergrad and ITWM MCO engines
- Expose `IOptimizer` classes in the UI

## Changes
- Moves `initial_parameter_value` and `parameter_bounds` to `BaseOptimizerEngine`
- Includes `optimizer` attribute on `WeightedOptimizerEngine` and `APosterioriEngine` classes, which must fulfil `IOptimizer` interface
- Removes `optimize_function` method from all `BaseOptimizerEngine` subclasses, defers usage to `self.optimizer.optimize_function` instead
