### PR TITLE
copyright headers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import click
 import os
 import shutil

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sphinx.environment
 from docutils.utils import get_source_line
 import sys

--- a/force_bdss/__init__.py
+++ b/force_bdss/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/api.py
+++ b/force_bdss/api.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .core.base_factory import BaseFactory  # noqa
 from .core.base_model import BaseModel  # noqa
 from .core.data_value import DataValue  # noqa

--- a/force_bdss/app/__init__.py
+++ b/force_bdss/app/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/app/base_operation.py
+++ b/force_bdss/app/base_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from threading import Event as ThreadingEvent
 import logging
 import sys

--- a/force_bdss/app/bdss_application.py
+++ b/force_bdss/app/bdss_application.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import functools
 import logging
 import sys

--- a/force_bdss/app/evaluate_operation.py
+++ b/force_bdss/app/evaluate_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import provides

--- a/force_bdss/app/i_operation.py
+++ b/force_bdss/app/i_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Instance, Interface
 
 from .workflow_file import WorkflowFile

--- a/force_bdss/app/optimize_operation.py
+++ b/force_bdss/app/optimize_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import provides

--- a/force_bdss/app/tests/__init__.py
+++ b/force_bdss/app/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/app/tests/test_base_operation.py
+++ b/force_bdss/app/tests/test_base_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 import testfixtures

--- a/force_bdss/app/tests/test_bdss_application.py
+++ b/force_bdss/app/tests/test_bdss_application.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import warnings
 

--- a/force_bdss/app/tests/test_evaluate_operation.py
+++ b/force_bdss/app/tests/test_evaluate_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 import testfixtures

--- a/force_bdss/app/tests/test_optimize_operation.py
+++ b/force_bdss/app/tests/test_optimize_operation.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 import testfixtures

--- a/force_bdss/app/tests/test_workflow_file.py
+++ b/force_bdss/app/tests/test_workflow_file.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.core.workflow import Workflow

--- a/force_bdss/app/workflow_file.py
+++ b/force_bdss/app/workflow_file.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import File, HasStrictTraits, Instance, List
 
 from force_bdss.core.workflow import Workflow

--- a/force_bdss/cli/__init__.py
+++ b/force_bdss/cli/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/cli/force_bdss.py
+++ b/force_bdss/cli/force_bdss.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import click
 

--- a/force_bdss/cli/tests/__init__.py
+++ b/force_bdss/cli/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/cli/tests/test_cli_execution.py
+++ b/force_bdss/cli/tests/test_cli_execution.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import subprocess
 import os

--- a/force_bdss/core/__init__.py
+++ b/force_bdss/core/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/core/base_factory.py
+++ b/force_bdss/core/base_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.plugin import Plugin
 from traits.api import Bool, HasStrictTraits, Str
 

--- a/force_bdss/core/base_model.py
+++ b/force_bdss/core/base_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import ABCHasStrictTraits, Instance
 
 from force_bdss.core.base_factory import BaseFactory

--- a/force_bdss/core/data_value.py
+++ b/force_bdss/core/data_value.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Any, String, Enum
 
 from force_bdss.utilities import pop_dunder_recursive

--- a/force_bdss/core/execution_layer.py
+++ b/force_bdss/core/execution_layer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 import logging
 
@@ -7,6 +10,9 @@ from force_bdss.core.data_value import DataValue
 from force_bdss.core.verifier import VerifierError
 from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
 from force_bdss.events.event_notifier_mixin import EventNotifierMixin
+# (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
 from force_bdss.utilities import pop_dunder_recursive, nested_getstate
 
 log = logging.getLogger(__name__)

--- a/force_bdss/core/factory_registry.py
+++ b/force_bdss/core/factory_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Instance, List, provides
 
 from force_bdss.core.i_factory_registry import IFactoryRegistry

--- a/force_bdss/core/i_factory.py
+++ b/force_bdss/core/i_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Interface, Str, Bool
 
 

--- a/force_bdss/core/i_factory_registry.py
+++ b/force_bdss/core/i_factory_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Interface
 
 

--- a/force_bdss/core/input_slot_info.py
+++ b/force_bdss/core/input_slot_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Enum
 
 from force_bdss.local_traits import Identifier

--- a/force_bdss/core/kpi_specification.py
+++ b/force_bdss/core/kpi_specification.py
@@ -1,7 +1,13 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Enum, HasStrictTraits, Float, Bool
 
 from force_bdss.local_traits import Identifier
 from force_bdss.utilities import pop_dunder_recursive
+
+# (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
 
 from .verifier import VerifierError
 

--- a/force_bdss/core/output_slot_info.py
+++ b/force_bdss/core/output_slot_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits
 
 from force_bdss.core.verifier import VerifierError

--- a/force_bdss/core/slot.py
+++ b/force_bdss/core/slot.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Str
 
 from force_bdss.local_traits import CUBAType

--- a/force_bdss/core/tests/__init__.py
+++ b/force_bdss/core/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/core/tests/test_base_factory.py
+++ b/force_bdss/core/tests/test_base_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/force_bdss/core/tests/test_base_model.py
+++ b/force_bdss/core/tests/test_base_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_bdss/core/tests/test_data_value.py
+++ b/force_bdss/core/tests/test_data_value.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.core.data_value import DataValue

--- a/force_bdss/core/tests/test_execution_layer.py
+++ b/force_bdss/core/tests/test_execution_layer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 from unittest import TestCase, mock
 

--- a/force_bdss/core/tests/test_factory_registry.py
+++ b/force_bdss/core/tests/test_factory_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.ids import factory_id, mco_parameter_id

--- a/force_bdss/core/tests/test_input_slot_info.py
+++ b/force_bdss/core/tests/test_input_slot_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from traits.api import TraitError
 

--- a/force_bdss/core/tests/test_slot.py
+++ b/force_bdss/core/tests/test_slot.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.core.slot import Slot

--- a/force_bdss/core/tests/test_verifier.py
+++ b/force_bdss/core/tests/test_verifier.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.core.execution_layer import ExecutionLayer

--- a/force_bdss/core/tests/test_workflow.py
+++ b/force_bdss/core/tests/test_workflow.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 import json
 import unittest

--- a/force_bdss/core/verifier.py
+++ b/force_bdss/core/verifier.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import Any, Enum, HasStrictTraits, Str

--- a/force_bdss/core/workflow.py
+++ b/force_bdss/core/workflow.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 import logging
 

--- a/force_bdss/core_plugins/__init__.py
+++ b/force_bdss/core_plugins/__init__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 """
 Here we host the core plugins. They ship with the BDSS and are always
 available. They provide a form of "standard library" of functionality.

--- a/force_bdss/core_plugins/base_extension_plugin.py
+++ b/force_bdss/core_plugins/base_extension_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import traceback
 

--- a/force_bdss/core_plugins/factory_registry_plugin.py
+++ b/force_bdss/core_plugins/factory_registry_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.api import ExtensionPoint, Plugin, ServiceOffer
 from traits.api import List, Instance, provides
 

--- a/force_bdss/core_plugins/service_offer_plugin.py
+++ b/force_bdss/core_plugins/service_offer_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.api import ServiceOffer
 from traits.api import Instance, List, Interface
 

--- a/force_bdss/core_plugins/tests/__init__.py
+++ b/force_bdss/core_plugins/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/core_plugins/tests/test_base_extension_plugin.py
+++ b/force_bdss/core_plugins/tests/test_base_extension_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import testfixtures
 from unittest import mock

--- a/force_bdss/core_plugins/tests/test_factory_registry_plugin.py
+++ b/force_bdss/core_plugins/tests/test_factory_registry_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import warnings
 

--- a/force_bdss/core_plugins/tests/test_service_offer_plugin.py
+++ b/force_bdss/core_plugins/tests/test_service_offer_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 from envisage.api import ServiceOffer

--- a/force_bdss/data_sources/__init__.py
+++ b/force_bdss/data_sources/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/data_sources/base_data_source.py
+++ b/force_bdss/data_sources/base_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 from traits.api import ABCHasStrictTraits, Instance
 

--- a/force_bdss/data_sources/base_data_source_factory.py
+++ b/force_bdss/data_sources/base_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 from traits.api import provides, Type
 

--- a/force_bdss/data_sources/base_data_source_model.py
+++ b/force_bdss/data_sources/base_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 from logging import getLogger
 

--- a/force_bdss/data_sources/i_data_source_factory.py
+++ b/force_bdss/data_sources/i_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Type
 
 from force_bdss.core.i_factory import IFactory

--- a/force_bdss/data_sources/tests/__init__.py
+++ b/force_bdss/data_sources/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/data_sources/tests/test_base_data_source.py
+++ b/force_bdss/data_sources/tests/test_base_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.api import UnittestTools

--- a/force_bdss/data_sources/tests/test_base_data_source_factory.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 import testfixtures

--- a/force_bdss/data_sources/tests/test_base_data_source_model.py
+++ b/force_bdss/data_sources/tests/test_base_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import testfixtures
 

--- a/force_bdss/events/__init__.py
+++ b/force_bdss/events/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/events/base_driver_event.py
+++ b/force_bdss/events/base_driver_event.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import importlib
 import json
 

--- a/force_bdss/events/data_source_events.py
+++ b/force_bdss/events/data_source_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .mco_events import MCORuntimeEvent
 
 from traits.api import (

--- a/force_bdss/events/event_notifier_mixin.py
+++ b/force_bdss/events/event_notifier_mixin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Event
 
 

--- a/force_bdss/events/mco_events.py
+++ b/force_bdss/events/mco_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 
 from traits.api import (

--- a/force_bdss/events/tests/__init__.py
+++ b/force_bdss/events/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/events/tests/test_base_driver_event.py
+++ b/force_bdss/events/tests/test_base_driver_event.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.tests.dummy_classes.notification_listener import DummyEvent

--- a/force_bdss/events/tests/test_data_source_events.py
+++ b/force_bdss/events/tests/test_data_source_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.events.data_source_events import (

--- a/force_bdss/events/tests/test_mco_events.py
+++ b/force_bdss/events/tests/test_mco_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from json import dumps
 import unittest
 

--- a/force_bdss/ids.py
+++ b/force_bdss/ids.py
@@ -1,3 +1,7 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
+
 class ExtensionPointID:
     """The envisage extension points ids for the factories ExtensionPoints.
     These are populated by the envisage plugins.

--- a/force_bdss/io/__init__.py
+++ b/force_bdss/io/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/io/tests/__init__.py
+++ b/force_bdss/io/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/io/tests/test_workflow_reader.py
+++ b/force_bdss/io/tests/test_workflow_reader.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import logging
 

--- a/force_bdss/io/tests/test_workflow_writer.py
+++ b/force_bdss/io/tests/test_workflow_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 import unittest
 import tempfile

--- a/force_bdss/io/workflow_reader.py
+++ b/force_bdss/io/workflow_reader.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 import logging
 

--- a/force_bdss/io/workflow_writer.py
+++ b/force_bdss/io/workflow_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 from traits.api import HasStrictTraits, ReadOnly
 

--- a/force_bdss/local_traits.py
+++ b/force_bdss/local_traits.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Regex, String, BaseInt
 
 #: Used for variable names, but allow also empty string as it's the default

--- a/force_bdss/mco/__init__.py
+++ b/force_bdss/mco/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/base_mco.py
+++ b/force_bdss/mco/base_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 import logging
 

--- a/force_bdss/mco/base_mco_communicator.py
+++ b/force_bdss/mco/base_mco_communicator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 
 from traits.api import ABCHasStrictTraits, Instance

--- a/force_bdss/mco/base_mco_factory.py
+++ b/force_bdss/mco/base_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import provides, Type, List, Instance

--- a/force_bdss/mco/base_mco_model.py
+++ b/force_bdss/mco/base_mco_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from copy import deepcopy
 import logging
 

--- a/force_bdss/mco/i_evaluator.py
+++ b/force_bdss/mco/i_evaluator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import Interface, Instance

--- a/force_bdss/mco/i_mco_factory.py
+++ b/force_bdss/mco/i_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Type, List
 
 from force_bdss.core.i_factory import IFactory

--- a/force_bdss/mco/optimizer_engines/__init__.py
+++ b/force_bdss/mco/optimizer_engines/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/aposteriori_optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import Str, Instance

--- a/force_bdss/mco/optimizer_engines/base_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/base_optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 import logging
 

--- a/force_bdss/mco/optimizer_engines/space_sampling.py
+++ b/force_bdss/mco/optimizer_engines/space_sampling.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 import numpy as np
 

--- a/force_bdss/mco/optimizer_engines/tests/__init__.py
+++ b/force_bdss/mco/optimizer_engines/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/optimizer_engines/tests/test_aposteriori_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_aposteriori_optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.api import RangedMCOParameterFactory

--- a/force_bdss/mco/optimizer_engines/tests/test_base_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_base_optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.api import KPISpecification, RangedMCOParameterFactory

--- a/force_bdss/mco/optimizer_engines/tests/test_space_sampling.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_space_sampling.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest.case import TestCase
 
 import numpy as np

--- a/force_bdss/mco/optimizer_engines/tests/test_utilities.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_utilities.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.mco.optimizer_engines.utilities import convert_by_mask

--- a/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
+++ b/force_bdss/mco/optimizer_engines/tests/test_weighted_optimizer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.api import (

--- a/force_bdss/mco/optimizer_engines/utilities.py
+++ b/force_bdss/mco/optimizer_engines/utilities.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 
 

--- a/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
+++ b/force_bdss/mco/optimizer_engines/weighted_optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 from functools import partial
 

--- a/force_bdss/mco/optimizers/__init__.py
+++ b/force_bdss/mco/optimizers/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/optimizers/i_optimizer.py
+++ b/force_bdss/mco/optimizers/i_optimizer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 import logging
 

--- a/force_bdss/mco/optimizers/scipy_optimizer.py
+++ b/force_bdss/mco/optimizers/scipy_optimizer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 from functools import partial
 from traits.api import (

--- a/force_bdss/mco/optimizers/tests/__init__.py
+++ b/force_bdss/mco/optimizers/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/optimizers/tests/test_scipy_optimizer.py
+++ b/force_bdss/mco/optimizers/tests/test_scipy_optimizer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.mco.optimizers.scipy_optimizer import (

--- a/force_bdss/mco/parameters/__init__.py
+++ b/force_bdss/mco/parameters/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/parameters/base_mco_parameter.py
+++ b/force_bdss/mco/parameters/base_mco_parameter.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import String, Instance
 
 from force_bdss.core.base_model import BaseModel

--- a/force_bdss/mco/parameters/base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/base_mco_parameter_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Type, Instance, provides
 
 from force_bdss.core.base_factory import BaseFactory

--- a/force_bdss/mco/parameters/i_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/i_mco_parameter_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Instance, Type
 from force_bdss.core.i_factory import IFactory
 

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 
 from traits.api import List, Str, Property, Float, Any, Int, on_trait_change

--- a/force_bdss/mco/parameters/tests/__init__.py
+++ b/force_bdss/mco/parameters/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/parameters/tests/test_base_mco_parameter.py
+++ b/force_bdss/mco/parameters/tests/test_base_mco_parameter.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.mco.parameters.base_mco_parameter import BaseMCOParameter

--- a/force_bdss/mco/parameters/tests/test_base_mco_parameter_factory.py
+++ b/force_bdss/mco/parameters/tests/test_base_mco_parameter_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock, TestCase
 
 from traits.trait_errors import TraitError

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 from traitsui.api import View

--- a/force_bdss/mco/tests/__init__.py
+++ b/force_bdss/mco/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/mco/tests/test_base_mco.py
+++ b/force_bdss/mco/tests/test_base_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.mco.i_mco_factory import IMCOFactory

--- a/force_bdss/mco/tests/test_base_mco_communicator.py
+++ b/force_bdss/mco/tests/test_base_mco_communicator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.mco.i_mco_factory import IMCOFactory

--- a/force_bdss/mco/tests/test_base_mco_factory.py
+++ b/force_bdss/mco/tests/test_base_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.trait_errors import TraitError

--- a/force_bdss/mco/tests/test_base_mco_model.py
+++ b/force_bdss/mco/tests/test_base_mco_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.api import UnittestTools

--- a/force_bdss/notification_listeners/__init__.py
+++ b/force_bdss/notification_listeners/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/notification_listeners/base_csv_writer.py
+++ b/force_bdss/notification_listeners/base_csv_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import csv
 
 from traits.api import Str, Instance, List, Dict, File

--- a/force_bdss/notification_listeners/base_notification_listener.py
+++ b/force_bdss/notification_listeners/base_notification_listener.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 
 from traits.api import ABCHasStrictTraits, Instance

--- a/force_bdss/notification_listeners/base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/base_notification_listener_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 from traits.api import (
     provides, Type

--- a/force_bdss/notification_listeners/base_notification_listener_model.py
+++ b/force_bdss/notification_listeners/base_notification_listener_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Instance
 
 from force_bdss.core.base_model import BaseModel

--- a/force_bdss/notification_listeners/i_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/i_notification_listener_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Type
 
 from force_bdss.core.i_factory import IFactory

--- a/force_bdss/notification_listeners/tests/__init__.py
+++ b/force_bdss/notification_listeners/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/notification_listeners/tests/test_base_csv_writer.py
+++ b/force_bdss/notification_listeners/tests/test_base_csv_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_bdss/notification_listeners/tests/test_base_notification_listener_factory.py
+++ b/force_bdss/notification_listeners/tests/test_base_notification_listener_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.trait_errors import TraitError

--- a/force_bdss/tests/__init__.py
+++ b/force_bdss/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/tests/dummy_classes/__init__.py
+++ b/force_bdss/tests/dummy_classes/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/tests/dummy_classes/data_source.py
+++ b/force_bdss/tests/dummy_classes/data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.core.slot import Slot
 from force_bdss.data_sources.base_data_source import BaseDataSource
 from force_bdss.data_sources.base_data_source_factory import \

--- a/force_bdss/tests/dummy_classes/extension_plugin.py
+++ b/force_bdss/tests/dummy_classes/extension_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasTraits, Interface
 
 from force_bdss.core_plugins.base_extension_plugin import \

--- a/force_bdss/tests/dummy_classes/factory_registry.py
+++ b/force_bdss/tests/dummy_classes/factory_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Any
 
 from force_bdss.core.factory_registry import FactoryRegistry

--- a/force_bdss/tests/dummy_classes/mco.py
+++ b/force_bdss/tests/dummy_classes/mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Int
 from force_bdss.mco.base_mco import BaseMCO
 from force_bdss.mco.base_mco_communicator import BaseMCOCommunicator

--- a/force_bdss/tests/dummy_classes/notification_listener.py
+++ b/force_bdss/tests/dummy_classes/notification_listener.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.core.data_value import DataValue
 from force_bdss.events.base_driver_event import BaseDriverEvent
 from force_bdss.notification_listeners.base_notification_listener import \

--- a/force_bdss/tests/dummy_classes/optimizer_engine.py
+++ b/force_bdss/tests/dummy_classes/optimizer_engine.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 
 from traits.api import Array, HasStrictTraits

--- a/force_bdss/tests/dummy_classes/ui_hooks.py
+++ b/force_bdss/tests/dummy_classes/ui_hooks.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.ui_hooks.base_ui_hooks_manager import BaseUIHooksManager
 
 

--- a/force_bdss/tests/fixtures/__init__.py
+++ b/force_bdss/tests/fixtures/__init__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from os.path import join, dirname, abspath
 
 

--- a/force_bdss/tests/probe_classes/__init__.py
+++ b/force_bdss/tests/probe_classes/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/tests/probe_classes/data_source.py
+++ b/force_bdss/tests/probe_classes/data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Bool, Function, Int, on_trait_change
 
 from force_bdss.core.data_value import DataValue

--- a/force_bdss/tests/probe_classes/evaluator.py
+++ b/force_bdss/tests/probe_classes/evaluator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     provides,
     Instance

--- a/force_bdss/tests/probe_classes/factory_registry.py
+++ b/force_bdss/tests/probe_classes/factory_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Any
 
 from force_bdss.core.factory_registry import FactoryRegistry

--- a/force_bdss/tests/probe_classes/mco.py
+++ b/force_bdss/tests/probe_classes/mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Bool, Int, Function, Any
 
 from force_bdss.core.data_value import DataValue

--- a/force_bdss/tests/probe_classes/notification_listener.py
+++ b/force_bdss/tests/probe_classes/notification_listener.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Bool, Function, Any
 
 from force_bdss.api import (

--- a/force_bdss/tests/probe_classes/optimizer.py
+++ b/force_bdss/tests/probe_classes/optimizer.py
@@ -1,4 +1,7 @@
 
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasStrictTraits,
     provides

--- a/force_bdss/tests/probe_classes/probe_extension_plugin.py
+++ b/force_bdss/tests/probe_classes/probe_extension_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.core_plugins.base_extension_plugin import BaseExtensionPlugin
 from force_bdss.ids import plugin_id
 from force_bdss.tests.probe_classes.data_source import ProbeDataSourceFactory

--- a/force_bdss/tests/probe_classes/ui_hooks.py
+++ b/force_bdss/tests/probe_classes/ui_hooks.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Bool
 from force_bdss.api import BaseUIHooksFactory, BaseUIHooksManager
 

--- a/force_bdss/tests/probe_classes/workflow_file.py
+++ b/force_bdss/tests/probe_classes/workflow_file.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.app.workflow_file import WorkflowFile
 from force_bdss.io.workflow_reader import WorkflowReader
 from force_bdss.io.workflow_writer import WorkflowWriter

--- a/force_bdss/tests/test_ids.py
+++ b/force_bdss/tests/test_ids.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.ids import factory_id, plugin_id

--- a/force_bdss/tests/test_local_traits.py
+++ b/force_bdss/tests/test_local_traits.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from traits.api import HasStrictTraits, TraitError
 

--- a/force_bdss/tests/test_utilities.py
+++ b/force_bdss/tests/test_utilities.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.api import HasTraits, List, Str, Int, Dict

--- a/force_bdss/tests/utils.py
+++ b/force_bdss/tests/utils.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sys
 from contextlib import contextmanager
 from io import StringIO

--- a/force_bdss/ui_hooks/__init__.py
+++ b/force_bdss/ui_hooks/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/ui_hooks/base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/base_ui_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 from traits.api import provides, Type
 

--- a/force_bdss/ui_hooks/base_ui_hooks_manager.py
+++ b/force_bdss/ui_hooks/base_ui_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import HasStrictTraits, Instance
 
 from .i_ui_hooks_factory import IUIHooksFactory

--- a/force_bdss/ui_hooks/i_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/i_ui_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Type
 
 from force_bdss.core.i_factory import IFactory

--- a/force_bdss/ui_hooks/tests/__init__.py
+++ b/force_bdss/ui_hooks/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_bdss/ui_hooks/tests/test_base_ui_hooks_factory.py
+++ b/force_bdss/ui_hooks/tests/test_base_ui_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.trait_errors import TraitError

--- a/force_bdss/ui_hooks/tests/test_base_ui_hooks_manager.py
+++ b/force_bdss/ui_hooks/tests/test_base_ui_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.tests.dummy_classes.ui_hooks import DummyUIHooksManager

--- a/force_bdss/ui_hooks/tests/test_ui_notification_mixins.py
+++ b/force_bdss/ui_hooks/tests/test_ui_notification_mixins.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 from threading import Event
 

--- a/force_bdss/ui_hooks/ui_notification_mixins.py
+++ b/force_bdss/ui_hooks/ui_notification_mixins.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import abc
 
 from threading import Event as ThreadingEvent

--- a/force_bdss/utilities.py
+++ b/force_bdss/utilities.py
@@ -1,3 +1,7 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
+
 def pop_recursive(dictionary, remove_key):
     """Recursively remove a named key from dictionary and any contained
     dictionaries."""

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import os
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
## Description
Add Enthought open source copyright header to every file.

### Notes
The headers were inserted automatically using PyCharm's Copyright Profile functionality. The only problem is that it ends up creating two blank lines at the end of blank  _init_.py module files, which then don't pass flake8, so the extra line has to be removed manually.

## Changes
Just the header on each file
