### PR TITLE
MAINT: Update to Traits 6.1.0

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -10,7 +10,7 @@ from subprocess import check_call
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
-CORE_DEPS = ["envisage==4.9.2-2",
+CORE_DEPS = ["envisage==4.9.2-3",
              "click==7.0-1"]
 
 DOCS_DEPS = ["sphinx==1.8.5-6"]


### PR DESCRIPTION
## Description

Bumps Envisage version to get Traits 6.1.0
### Summary
Envisage dependency now a `4.9.2-3`

### Future Work
- Exploring new features in traits 6.1.0
## Changes
- Dependency bump: `envisage==4.9.2-3`,  `traits==6.1.0-1`