### PR TITLE
FIX: Remove KPI target value and bounds verification

### DIFF
--- a/force_bdss/core/kpi_specification.py
+++ b/force_bdss/core/kpi_specification.py
@@ -27,16 +27,18 @@ class KPISpecification(HasStrictTraits):
 
     #: Target value to be used if optimization objective is set to
     #: "TARGET"
-    target_value = Float
+    target_value = Float()
 
     #: Whether or not to use upper or lower boundaries on KPI values;
     #: may be used by some MCO engines
     use_bounds = Bool(False)
 
-    #: Lower threshold of KPI; may be used by some MCO engines
+    #: Lower threshold of KPI; may be used by some MCO engines. Only
+    #: expected to be used when objective == 'MAXIMISE'
     lower_bound = Float(0)
 
-    #: Upper threshold of KPI; may be used by some MCO engines
+    #: Upper threshold of KPI; may be used by some MCO engines. Only
+    #: expected to be used when objective != 'MINIMISE'
     upper_bound = Float(1)
 
     def __getstate__(self):
@@ -47,8 +49,6 @@ class KPISpecification(HasStrictTraits):
 
         Check that the KPI specification:
         - has a name
-        - has correctly assigned upper and lower bounds
-        - has a correctly assigned target value
 
         Returns
         -------
@@ -65,31 +65,5 @@ class KPISpecification(HasStrictTraits):
                     global_error="A KPI is not named",
                 )
             )
-
-        if self.use_bounds:
-            if self.upper_bound < self.lower_bound:
-                error = (
-                    "Upper bound value of the KPI must be greater "
-                    "than the lower bound value."
-                )
-                errors.append(
-                    VerifierError(
-                        subject=self,
-                        trait_name="upper_bound",
-                        local_error=error,
-                        global_error=error,
-                    )
-                )
-
-        if self.objective == "TARGET":
-            if self.target_value == 0:
-                errors.append(
-                    VerifierError(
-                        subject=self,
-                        trait_name='target_value',
-                        local_error="Target value must be non-zero",
-                        global_error="A KPI does not have a target value",
-                    )
-                )
 
         return errors

--- a/force_bdss/core/kpi_specification.py
+++ b/force_bdss/core/kpi_specification.py
@@ -91,22 +91,5 @@ class KPISpecification(HasStrictTraits):
                         global_error="A KPI does not have a target value",
                     )
                 )
-            if self.use_bounds:
-                if (
-                        self.target_value > self.upper_bound
-                        or self.target_value < self.lower_bound
-                ):
-                    error = (
-                        "Target value of the KPI must be within the "
-                        "lower and the upper bounds."
-                    )
-                    errors.append(
-                        VerifierError(
-                            subject=self,
-                            trait_name="target_value",
-                            local_error=error,
-                            global_error=error,
-                        )
-                    )
 
         return errors

--- a/force_bdss/core/tests/test_kpi_specification.py
+++ b/force_bdss/core/tests/test_kpi_specification.py
@@ -45,21 +45,3 @@ class TestKPISpecification(TestCase):
 
         self.kpi.use_bounds = True
         self.assertEqual(0, len(self.kpi.verify()))
-
-        self.kpi.lower_bound = 0.75
-        errors = [error.local_error for error in self.kpi.verify()]
-        self.assertEqual(1, len(errors))
-        self.assertIn(
-            "Target value of the KPI must be within the "
-            "lower and the upper bounds.",
-            errors
-        )
-
-        self.kpi.target_value = 1.25
-        errors = [error.local_error for error in self.kpi.verify()]
-        self.assertEqual(1, len(errors))
-        self.assertIn(
-            "Target value of the KPI must be within the "
-            "lower and the upper bounds.",
-            errors
-        )

--- a/force_bdss/core/tests/test_kpi_specification.py
+++ b/force_bdss/core/tests/test_kpi_specification.py
@@ -18,30 +18,3 @@ class TestKPISpecification(TestCase):
         errors = [error.local_error for error in self.kpi.verify()]
         self.assertEqual(1, len(errors))
         self.assertIn("KPI is not named", errors)
-
-    def test_verify_bounds(self):
-        self.kpi.use_bounds = True
-
-        self.assertEqual(0, len(self.kpi.verify()))
-
-        self.kpi.lower_bound = 2
-        errors = [error.local_error for error in self.kpi.verify()]
-        self.assertEqual(1, len(errors))
-        self.assertIn(
-            "Upper bound value of the KPI must be greater "
-            "than the lower bound value.",
-            errors
-        )
-
-    def test_verify_target(self):
-
-        self.kpi.objective = "TARGET"
-        errors = [error.local_error for error in self.kpi.verify()]
-        self.assertEqual(1, len(errors))
-        self.assertIn("Target value must be non-zero", errors)
-
-        self.kpi.target_value = 0.5
-        self.assertEqual(0, len(self.kpi.verify()))
-
-        self.kpi.use_bounds = True
-        self.assertEqual(0, len(self.kpi.verify()))

--- a/force_bdss/mco/optimizers/tests/test_scipy_optimizer.py
+++ b/force_bdss/mco/optimizers/tests/test_scipy_optimizer.py
@@ -4,6 +4,7 @@
 from unittest import TestCase
 
 from force_bdss.mco.optimizers.scipy_optimizer import (
+    ScipyTypeError,
     ScipyOptimizer
 )
 
@@ -25,6 +26,14 @@ class TestScipyOptimizer(TestCase):
 
     def test_init(self):
         self.assertEqual("SLSQP", self.optimizer.algorithms)
+
+    def test_verify_mco_parameters(self):
+        optimizer = ScipyOptimizer()
+        parameter_factory = self.factory.parameter_factories[0]
+        wrong_parameter = parameter_factory.create_model()
+
+        with self.assertRaises(ScipyTypeError):
+            optimizer.verify_mco_parameters([wrong_parameter])
 
     def test_optimize_function(self):
 


### PR DESCRIPTION
### Description

Removes verification constraints on `KPISpecification` target value and lower / upper bounds. 

### Related Issues
#353 

### Summary
The `KPISepcification.verify` method was expanded in #353 but since the BDSS framework does not have any specific requirements for them, it is up to the MCO implementation how these values should be correctly formatted.

For example, an MCO solver may not need to consider KPI lower bounds if performing a minimisation scheme. Additionally, when using the `"TARGET"` objective, it may not be possible to identify non-symmetric lower and upper bounds around the target value.

At the moment, therefore, we should remove constraints and look to subclass `KPISpecification` in future to implement MCO-dependent features (see #241)

### Notes:
- Also includes an additional unit test for `ScipyOptimizer` class to bump coverage report

## Changes
- Removes target value and bounds error checking in `KPISpecification.verify`
