### PR TITLE
FIX: Resolve RangedVectorMCOParameter verify crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ force_bdss/version.py
 .DS_Store
 .idea/
 *.log
+.coverage
+htmlcov/

--- a/force_bdss/mco/parameters/mco_parameters.py
+++ b/force_bdss/mco/parameters/mco_parameters.py
@@ -239,6 +239,7 @@ class RangedVectorMCOParameter(RangedMCOParameter):
         have the expected dimensionality according to dimension attribute"""
         errors = super(RangedMCOParameter, self).verify()
 
+        failed_lengths = []
         for name in ['initial_value', 'upper_bound', 'lower_bound']:
             bound_vector = getattr(self, name)
             if len(bound_vector) != self.dimension:
@@ -246,7 +247,7 @@ class RangedVectorMCOParameter(RangedMCOParameter):
                     f'List attribute {name} must possess same length as '
                     f'determined by dimension attribute: {self.dimension}'
                 )
-                errors.append(
+                failed_lengths.append(
                     VerifierError(
                         subject=self,
                         trait_name=name,
@@ -255,48 +256,51 @@ class RangedVectorMCOParameter(RangedMCOParameter):
                     )
                 )
 
-        failed_init_values = []
-        failed_bounds = []
+        if len(failed_lengths) == 0:
+            failed_init_values = []
+            failed_bounds = []
 
-        for dim in range(self.dimension):
-            initial_value = self.initial_value[dim]
-            upper_bound = self.upper_bound[dim]
-            lower_bound = self.lower_bound[dim]
+            for dim in range(self.dimension):
+                initial_value = self.initial_value[dim]
+                upper_bound = self.upper_bound[dim]
+                lower_bound = self.lower_bound[dim]
 
-            if initial_value > upper_bound or initial_value < lower_bound:
-                failed_init_values.append(dim)
-            if upper_bound < lower_bound:
-                failed_bounds.append(dim)
+                if initial_value > upper_bound or initial_value < lower_bound:
+                    failed_init_values.append(dim)
+                if upper_bound < lower_bound:
+                    failed_bounds.append(dim)
 
-        if failed_init_values:
-            error = (
-                f"Initial values at indices {failed_init_values} of the "
-                "Ranged Vector parameter must be within the lower and "
-                "the upper bounds."
-            )
-            errors.append(
-                VerifierError(
-                    subject=self,
-                    trait_name="initial_value",
-                    local_error=error,
-                    global_error=error,
+            if failed_init_values:
+                error = (
+                    f"Initial values at indices {failed_init_values} of the "
+                    "Ranged Vector parameter must be within the lower and "
+                    "the upper bounds."
                 )
-            )
-
-        if failed_bounds:
-            error = (
-                f"Upper bound values at indices {failed_bounds} of the "
-                "Ranged Vector parameter must greater than the lower "
-                "bound values."
-            )
-            errors.append(
-                VerifierError(
-                    subject=self,
-                    trait_name="upper_bound",
-                    local_error=error,
-                    global_error=error,
+                errors.append(
+                    VerifierError(
+                        subject=self,
+                        trait_name="initial_value",
+                        local_error=error,
+                        global_error=error,
+                    )
                 )
-            )
+
+            if failed_bounds:
+                error = (
+                    f"Upper bound values at indices {failed_bounds} of the "
+                    "Ranged Vector parameter must greater than the lower "
+                    "bound values."
+                )
+                errors.append(
+                    VerifierError(
+                        subject=self,
+                        trait_name="upper_bound",
+                        local_error=error,
+                        global_error=error,
+                    )
+                )
+        else:
+            errors += failed_lengths
 
         return errors
 

--- a/force_bdss/mco/parameters/tests/test_mco_parameters.py
+++ b/force_bdss/mco/parameters/tests/test_mco_parameters.py
@@ -249,18 +249,12 @@ class TestRangedVectorMCOParameter(TestCase):
 
         errors = parameter.verify()
         messages = [error.local_error for error in errors]
-        self.assertEqual(2, len(messages))
+        self.assertEqual(1, len(messages))
 
         expected_message = (
             'List attribute lower_bound must possess same length as '
             'determined by dimension attribute: 1')
         self.assertEqual(expected_message, messages[0])
-
-        expected_message = (
-            "Initial values at indices [0] of the Ranged Vector parameter "
-            "must be within the lower and the upper bounds."
-        )
-        self.assertEqual(expected_message, messages[1])
 
         parameter.lower_bound[:] = parameter.lower_bound[:1]
         parameter.initial_value = [0]


### PR DESCRIPTION
## Description

Bugfix for #360 

### Related Issues
Closes #360

### Summary
Ensures that verification check on vector elements only take place if all vectors have the correct dimensions

## Changes
- Bugfix for `RangegVectorMCOParameter` verify method crashing WfManager UI
