### PR TITLE
MAINT: Update ETS deps

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -10,7 +10,7 @@ from subprocess import check_call
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
-CORE_DEPS = ["envisage==4.9.2-3",
+CORE_DEPS = ["envisage==4.9.2-4",
              "click==7.0-1"]
 
 DOCS_DEPS = ["sphinx==1.8.5-6"]


### PR DESCRIPTION
### Description

Updates ETS deps to `envisage==4.9.2-4`

### Related Issues
https://github.com/force-h2020/force-bdss-plugin-nevergrad/issues/26

### Summary
Includes Traits version 6.1.1, which is required for `Union` trait type used in the `force_nevergrad` wrapper

## Changes
- Bumps Envisage to version 4.9.2-4
