### PR TITLE
FIX: ReadTheDocs page generates auto-api 

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -13,18 +13,13 @@ PYTHON_VERSIONS = ["3.6"]
 CORE_DEPS = ["envisage==4.9.2-4",
              "click==7.0-1"]
 
-DOCS_DEPS = ["sphinx>=1.8.5-6"]
+DOCS_DEPS = ["sphinx>=2.3.1-3"]
 
 DEV_DEPS = ["flake8==3.7.7-1",
             "coverage==4.3.4-1",
             "testfixtures==4.10.0-1"]
 
 PIP_DEPS = ["stevedore==1.32.0"]
-
-# Additional documentation requirements needed by ReadTheDocs
-with open('doc/doc_requirements.txt', 'r') as infile:
-    PIP_DOCS_DEPS = infile.readlines()
-
 
 ADDITIONAL_CORE_DEPS = ["numpy==1.15.4-2",
                         "scipy>=1.2.1"]
@@ -81,7 +76,7 @@ def build_env(python_version):
     if len(PIP_DEPS):
         check_call(
             ["edm", "run", "-e", env_name, "--", "pip", "install"]
-            + PIP_DEPS + PIP_DOCS_DEPS
+            + PIP_DEPS
         )
 
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -13,13 +13,18 @@ PYTHON_VERSIONS = ["3.6"]
 CORE_DEPS = ["envisage==4.9.2-4",
              "click==7.0-1"]
 
-DOCS_DEPS = ["sphinx==1.8.5-6"]
+DOCS_DEPS = ["sphinx>=1.8.5-6"]
 
 DEV_DEPS = ["flake8==3.7.7-1",
             "coverage==4.3.4-1",
             "testfixtures==4.10.0-1"]
 
 PIP_DEPS = ["stevedore==1.32.0"]
+
+# Additional documentation requirements needed by ReadTheDocs
+with open('doc/doc_requirements.txt', 'r') as infile:
+    PIP_DOCS_DEPS = infile.readlines()
+
 
 ADDITIONAL_CORE_DEPS = ["numpy==1.15.4-2",
                         "scipy>=1.2.1"]
@@ -75,7 +80,8 @@ def build_env(python_version):
 
     if len(PIP_DEPS):
         check_call(
-            ["edm", "run", "-e", env_name, "--", "pip", "install"] + PIP_DEPS
+            ["edm", "run", "-e", env_name, "--", "pip", "install"]
+            + PIP_DEPS + PIP_DOCS_DEPS
         )
 
 

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.8.5-6
+sphinx==2.3.1
 docutils==0.16
 sphinxcontrib.apidoc==0.3.0
 sphinxcontrib.bibtex==1.0.0

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -2,3 +2,5 @@ sphinx==2.3.1
 docutils==0.16
 sphinxcontrib.apidoc==0.3.0
 sphinxcontrib.bibtex==1.0.0
+envisage>=4.9.2
+numpy>=1.15.4

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -3,4 +3,4 @@ docutils==0.16
 sphinxcontrib.apidoc==0.3.0
 sphinxcontrib.bibtex==1.0.0
 envisage>=4.9.2
-numpy>=1.15.4
+scipy>=1.2.1

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,0 +1,4 @@
+sphinx==1.8.5-6
+docutils==0.16
+sphinxcontrib.apidoc==0.3.0
+sphinxcontrib.bibtex==1.0.0

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -4,3 +4,5 @@ sphinxcontrib.apidoc==0.3.0
 sphinxcontrib.bibtex==1.0.0
 envisage>=4.9.2
 scipy>=1.2.1
+stevedore==1.32.0
+click>=7.0

--- a/doc/rdt_requirements.txt
+++ b/doc/rdt_requirements.txt
@@ -1,7 +1,5 @@
 sphinx==2.3.1
 docutils==0.16
-sphinxcontrib.apidoc==0.3.0
-sphinxcontrib.bibtex==1.0.0
 envisage>=4.9.2
 scipy>=1.2.1
 stevedore==1.32.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,6 +42,8 @@ def mock_modules():
 mock_modules()
 
 extensions = [
+    'sphinxcontrib.apidoc',
+    'sphinxcontrib.bibtex',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -67,3 +69,7 @@ html_static_path = ['_static']
 html_logo = '_static/force_logo.png'
 htmlhelp_basename = 'FORCEdoc'
 intersphinx_mapping = {'http://docs.python.org/': None}
+apidoc_module_dir = '../../force_bdss'
+apidoc_output_dir = 'api'
+apidoc_excluded_paths = ['*tests*']
+apidoc_separate_modules = False

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,5 +71,5 @@ htmlhelp_basename = 'FORCEdoc'
 intersphinx_mapping = {'http://docs.python.org/': None}
 apidoc_module_dir = '../../force_bdss'
 apidoc_output_dir = 'api'
-apidoc_excluded_paths = ['*tests*']
+apidoc_excluded_paths = ['*tests*', 'api.py']
 apidoc_separate_modules = False

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,8 +42,6 @@ def mock_modules():
 mock_modules()
 
 extensions = [
-    'sphinxcontrib.apidoc',
-    'sphinxcontrib.bibtex',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,6 +25,13 @@ User Manual
 
    Introduction <introduction>
    Installation instructions <installation>
+
+Developer Manual
+================
+
+.. toctree::
+   :maxdepth: 2
+
    Design documentation <design>
    Plugin development <plugin_development>
    Contributing Code <developer_guidelines>


### PR DESCRIPTION
###  Description
Ensures that ReadTheDocs page correctly generates auto API ReST files, Updates `sphinx` version to 2.3.1-3

### Related Issues
Closes #350 

### Background
Includes a `doc/rtd_requirements.txt` file to prompt ReadTheDocs to automatically build api documentation. 

### Notes
- Including the `doc/rtd_requirements.txt` file creates some redundancy in the CI, but there is no neat way around doing so since RDT does not know about `edm` and only installs packages via `pip`

## Changes
- Bump sphinx version to 2.3.1-3
